### PR TITLE
chore: use biomejs instead of eslint + prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-yarn lint-staged

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/biome.json
+++ b/biome.json
@@ -1,30 +1,32 @@
 {
 	"$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
-	"vcs": {
-		"enabled": false,
-		"clientKind": "git",
-		"useIgnoreFile": false
-	},
-	"files": {
-		"ignoreUnknown": false,
-		"ignore": []
-	},
+	"vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
+	"files": { "ignoreUnknown": false, "ignore": [] },
 	"formatter": {
 		"enabled": true,
-		"indentStyle": "tab"
+		"useEditorconfig": true,
+		"formatWithErrors": false,
+		"indentStyle": "space",
+		"indentWidth": 2,
+		"lineEnding": "lf",
+		"lineWidth": 80,
+		"attributePosition": "auto",
+		"bracketSpacing": true,
+		"ignore": [".github/*"]
 	},
-	"organizeImports": {
-		"enabled": true
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
+	"organizeImports": { "enabled": true },
+	"linter": { "enabled": true, "rules": { "recommended": true } },
 	"javascript": {
 		"formatter": {
-			"quoteStyle": "double"
+			"jsxQuoteStyle": "double",
+			"quoteProperties": "asNeeded",
+			"trailingCommas": "es5",
+			"semicolons": "asNeeded",
+			"arrowParentheses": "always",
+			"bracketSameLine": false,
+			"quoteStyle": "double",
+			"attributePosition": "auto",
+			"bracketSpacing": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.3",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@rollup/plugin-json": "^6.1.0",

--- a/src/components/Asset/AssetComboIcon.tsx
+++ b/src/components/Asset/AssetComboIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { BaseTokenInfo } from "../../types/base"
+import type { BaseTokenInfo } from "../../types/base"
 
 export const AssetComboIcon = ({
   icon,

--- a/src/components/Asset/AssetList.tsx
+++ b/src/components/Asset/AssetList.tsx
@@ -1,10 +1,10 @@
-import React, { ReactNode } from "react"
 import { Text } from "@radix-ui/themes"
 import clsx from "clsx"
+import React, { type ReactNode } from "react"
 
-import { BaseTokenInfo } from "../../types/base"
+import type { BaseTokenInfo } from "../../types/base"
 import { balanceToCurrency, balanceToDecimal } from "../../utils/balanceTo"
-import { TokenListWithNotSelectableToken } from "../Modal/ModalSelectAssets"
+import type { TokenListWithNotSelectableToken } from "../Modal/ModalSelectAssets"
 
 import { AssetComboIcon } from "./AssetComboIcon"
 

--- a/src/components/Asset/AssetList.tsx
+++ b/src/components/Asset/AssetList.tsx
@@ -79,12 +79,14 @@ export const AssetList = ({
           i
         ) => (
           <button
-            key={i}
+            key={rest.defuseAssetId}
+            type={"button"}
             className={clsx(
               "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",
               isNotSelectable && "opacity-50 pointer-events-none"
             )}
-            onClick={() => handleSelectToken && handleSelectToken(assets[i]!)}
+            // biome-ignore lint/style/noNonNullAssertion: i is always within bounds
+            onClick={() => handleSelectToken?.(assets[i]!)}
           >
             <AssetComboIcon
               name={name as string}

--- a/src/components/Block/BlockEvaluatePrice.tsx
+++ b/src/components/Block/BlockEvaluatePrice.tsx
@@ -1,10 +1,13 @@
-import React from "react"
 import { InfoCircledIcon } from "@radix-ui/react-icons"
 import { Tooltip } from "@radix-ui/themes"
 import clsx from "clsx"
+import React from "react"
 
-import { EvaluateResultEnum, SwapEstimateProviderResponse } from "../../types"
-import { BaseTokenInfo } from "../../types/base"
+import {
+  EvaluateResultEnum,
+  type SwapEstimateProviderResponse,
+} from "../../types"
+import type { BaseTokenInfo } from "../../types/base"
 import { tokenBalanceToFormatUnits } from "../../utils"
 
 const BEST_PRICE = "best price"

--- a/src/components/Block/BlockEvaluatePrice.tsx
+++ b/src/components/Block/BlockEvaluatePrice.tsx
@@ -44,7 +44,7 @@ export const BlockEvaluatePrice = ({
                           Rate{" "}
                           {tokenBalanceToFormatUnits({
                             balance: result.amount_out,
-                            decimals: tokenOut.decimals!,
+                            decimals: tokenOut.decimals,
                           })}{" "}
                           from {result.solver_id}
                         </span>

--- a/src/components/Block/BlockMultiBalances.tsx
+++ b/src/components/Block/BlockMultiBalances.tsx
@@ -38,6 +38,7 @@ export const BlockMultiBalances = ({
           height={16}
         />
       )}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: sorry keyboard users */}
       <span
         onClick={handleClick}
         className={clsx(

--- a/src/components/Block/BlockMultiBalances.tsx
+++ b/src/components/Block/BlockMultiBalances.tsx
@@ -1,8 +1,8 @@
-import React from "react"
-import { Checkbox, Text, Tooltip } from "@radix-ui/themes"
-import { CheckedState } from "@radix-ui/react-checkbox"
+import type { CheckedState } from "@radix-ui/react-checkbox"
 import { InfoCircledIcon } from "@radix-ui/react-icons"
+import { Checkbox, Text, Tooltip } from "@radix-ui/themes"
 import clsx from "clsx"
+import React from "react"
 
 import { smallBalanceToFormat } from "../../utils"
 

--- a/src/components/Button/ButtonCustom.tsx
+++ b/src/components/Button/ButtonCustom.tsx
@@ -1,7 +1,13 @@
-import React, { ReactNode, ButtonHTMLAttributes } from "react"
-import { FieldValues } from "react-hook-form"
+import {
+  Button,
+  type ButtonProps,
+  Spinner,
+  Text,
+  type TextProps,
+} from "@radix-ui/themes"
 import clsx from "clsx"
-import { Button, Text, ButtonProps, TextProps, Spinner } from "@radix-ui/themes"
+import React, { type ReactNode, type ButtonHTMLAttributes } from "react"
+import type { FieldValues } from "react-hook-form"
 
 interface Props<T extends FieldValues>
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color"> {

--- a/src/components/Button/ButtonIcon.tsx
+++ b/src/components/Button/ButtonIcon.tsx
@@ -19,6 +19,7 @@ export const ButtonIcon = ({
 }: Props) => {
   return (
     <button
+      type={"button"}
       className={clsx(
         "flex justify-center items-center w-[40px] h-[40px] rounded-md overflow-hidden bg-white dark:bg-black",
         className && className

--- a/src/components/Button/ButtonIcon.tsx
+++ b/src/components/Button/ButtonIcon.tsx
@@ -1,5 +1,5 @@
-import React, { MouseEvent, PropsWithChildren } from "react"
 import clsx from "clsx"
+import React, { type MouseEvent, type PropsWithChildren } from "react"
 
 interface Props extends PropsWithChildren {
   onClick?: (e: MouseEvent<HTMLButtonElement>) => void

--- a/src/components/Button/ButtonSwitch.tsx
+++ b/src/components/Button/ButtonSwitch.tsx
@@ -1,6 +1,6 @@
-import React from "react"
-import clsx from "clsx"
 import { ArrowDownIcon } from "@radix-ui/react-icons"
+import clsx from "clsx"
+import type React from "react"
 
 import { ButtonIcon } from "./ButtonIcon"
 

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -126,7 +126,7 @@ export const FieldComboInput = <T extends FieldValues>({
           disabled && "text-black-200 pointer-events-none placeholder-black-200"
         )}
       />
-      {errors && errors[fieldName] ? (
+      {errors?.[fieldName] ? (
         <span className="absolute bottom-4 left-5 text-sm font-medium text-red-400">
           {(errors[fieldName] as FieldError).message}
         </span>

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -1,17 +1,17 @@
-import React from "react"
-import {
-  Path,
-  FieldValues,
-  FieldErrors,
+import clsx from "clsx"
+import type React from "react"
+import type {
   FieldError,
+  FieldErrors,
+  FieldValues,
+  Path,
   UseFormRegister,
 } from "react-hook-form"
-import clsx from "clsx"
 
-import { BaseTokenInfo } from "../../types/base"
+import type { BaseTokenInfo } from "../../types/base"
 import {
   BlockMultiBalances,
-  BlockMultiBalancesProps,
+  type BlockMultiBalancesProps,
 } from "../Block/BlockMultiBalances"
 import { SelectAssets } from "../SelectAssets"
 
@@ -133,7 +133,7 @@ export const FieldComboInput = <T extends FieldValues>({
       ) : null}
       {price && price !== "0" && errors && !errors[fieldName] ? (
         <span className="absolute flex flex-nowrap items-center gap-2 bottom-4 left-5 text-sm font-medium text-secondary">
-          ~${parseFloat(price).toFixed(2)}
+          ~${Number.parseFloat(price).toFixed(2)}
           {label && label}
         </span>
       ) : null}

--- a/src/components/Form/FieldTextInput.tsx
+++ b/src/components/Form/FieldTextInput.tsx
@@ -1,6 +1,6 @@
-import React from "react"
 import clsx from "clsx"
-import { FieldValues, Path, UseFormRegister } from "react-hook-form"
+import React from "react"
+import type { FieldValues, Path, UseFormRegister } from "react-hook-form"
 
 interface Props<T extends FieldValues> {
   fieldName: Path<T>

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -37,8 +37,7 @@ export const Form = <T extends FieldValues>({
 
   const childrenWithProps = Children.map(children, (child) => {
     if (isValidElement(child)) {
-      // Avoid an error TS2339
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // biome-ignore lint/suspicious/noExplicitAny: avoid an error TS2339
       const childType = child.type as any
       const childName =
         childType.displayName || childType.name || childType?.type?.name
@@ -52,6 +51,6 @@ export const Form = <T extends FieldValues>({
     return child
   })
 
-  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  // biome-ignore lint/suspicious/noExplicitAny: <reason>
   return <form onSubmit={handleSubmit as any}>{childrenWithProps}</form>
 }

--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -1,15 +1,15 @@
 import React, {
-  PropsWithChildren,
+  type PropsWithChildren,
   Children,
   cloneElement,
   isValidElement,
-  ReactElement,
-  FormEventHandler,
+  type ReactElement,
+  type FormEventHandler,
 } from "react"
-import {
-  UseFormRegister,
+import type {
   FieldValues,
   UseFormHandleSubmit,
+  UseFormRegister,
 } from "react-hook-form"
 
 import { FieldComboInputRegistryName } from "./FieldComboInput"

--- a/src/components/Modal/ModalDialog.tsx
+++ b/src/components/Modal/ModalDialog.tsx
@@ -1,14 +1,14 @@
+import { Dialog } from "@radix-ui/themes"
 import React, {
-  PropsWithChildren,
+  type PropsWithChildren,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react"
-import { Dialog } from "@radix-ui/themes"
 
-import { useModalStore } from "../../providers/ModalStoreProvider"
 import { useResize } from "../../hooks/useResize"
+import { useModalStore } from "../../providers/ModalStoreProvider"
 
 const ModalDialog = ({ children }: PropsWithChildren) => {
   const { onCloseModal } = useModalStore((state) => state)

--- a/src/components/Modal/ModalDialog.tsx
+++ b/src/components/Modal/ModalDialog.tsx
@@ -27,8 +27,11 @@ const ModalDialog = ({ children }: PropsWithChildren) => {
     handleCloseModal()
   }, [handleCloseModal])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `divRef.current` will be fixed soon
   useEffect(() => {
-    setContainerWidth(divRef.current!.offsetWidth || 0)
+    if (divRef.current) {
+      setContainerWidth(divRef.current.offsetWidth || 0)
+    }
     return () => {
       setContainerWidth(0)
     }

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -36,11 +36,11 @@ export const ModalSelectAssets = () => {
   const handleSearchClear = () => setSearchValue("")
 
   const filterPattern = (asset: BaseTokenInfo) =>
-    asset
-      .name!.toLocaleUpperCase()
+    asset.name
+      .toLocaleUpperCase()
       .includes(deferredQuery.toLocaleUpperCase()) ||
-    asset
-      .chainName!.toLocaleUpperCase()
+    asset.chainName
+      .toLocaleUpperCase()
       .includes(deferredQuery.toLocaleUpperCase())
 
   const handleSelectToken = (token: BaseTokenInfo) => {
@@ -51,6 +51,7 @@ export const ModalSelectAssets = () => {
     })
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `payload` for some reason is not in the dependencies, need to investigate
   useEffect(() => {
     if (!data.size && !isLoading) {
       return
@@ -62,7 +63,7 @@ export const ModalSelectAssets = () => {
 
     const getAssetList: TokenListWithNotSelectableToken[] = []
     const getAssetListWithBalances: TokenListWithNotSelectableToken[] = []
-    data.forEach((value) => {
+    for (const value of data.values()) {
       let isNotSelectable = false
       // We do not filter "tokenIn" as give full access to tokens in first step
       // Filtration by routes should happen only at "tokenOut"
@@ -84,7 +85,7 @@ export const ModalSelectAssets = () => {
         })
       }
       getAssetList.push({ ...value, isNotSelectable })
-    })
+    }
     setAssetList(getAssetList)
     setAssetListWithBalances(getAssetListWithBalances)
   }, [data, isLoading])
@@ -118,6 +119,7 @@ export const ModalSelectAssets = () => {
           {deferredQuery && (
             <div className="flex justify-center items-center">
               <button
+                type={"button"}
                 onClick={handleSearchClear}
                 className="mb-2.5 px-3 py-1.5 bg-red-100 rounded-full"
               >

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useDeferredValue, useEffect } from "react"
 import { Text } from "@radix-ui/themes"
+import React, { useState, useDeferredValue, useEffect } from "react"
 
-import { BaseTokenInfo } from "../../types/base"
-import { SearchBar } from "../SearchBar"
-import { AssetList } from "../Asset/AssetList"
 import { useModalStore } from "../../providers/ModalStoreProvider"
 import { useTokensStore } from "../../providers/TokensStoreProvider"
-import { ModalType } from "../../stores/modalStore"
-import { NetworkTokenWithSwapRoute } from "../../types"
+import type { ModalType } from "../../stores/modalStore"
+import type { NetworkTokenWithSwapRoute } from "../../types"
+import type { BaseTokenInfo } from "../../types/base"
+import { AssetList } from "../Asset/AssetList"
+import { SearchBar } from "../SearchBar"
 
 import ModalDialog from "./ModalDialog"
 

--- a/src/components/Network/AssetList.tsx
+++ b/src/components/Network/AssetList.tsx
@@ -73,7 +73,8 @@ const AssetList = ({
           i
         ) => (
           <button
-            key={i}
+            key={rest.defuseAssetId}
+            type={"button"}
             className={clsx(
               "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",
               isNotSelectable && "opacity-50 pointer-events-none"

--- a/src/components/Network/AssetList.tsx
+++ b/src/components/Network/AssetList.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode } from "react"
 import { Text } from "@radix-ui/themes"
 import clsx from "clsx"
+import React, { type ReactNode } from "react"
 
-import { BaseTokenInfo } from "../../types/base"
+import type { BaseTokenInfo } from "../../types/base"
 import { balanceToCurrency, balanceToDecimal } from "../../utils/balanceTo"
-import { TokenListWithNotSelectableToken } from "../Modal/ModalSelectAssets"
 import { AssetComboIcon } from "../Asset/AssetComboIcon"
+import type { TokenListWithNotSelectableToken } from "../Modal/ModalSelectAssets"
 
 type Props = {
   title?: string

--- a/src/components/Network/Network.tsx
+++ b/src/components/Network/Network.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@radix-ui/themes"
-import React from "react"
 import clsx from "clsx"
+import React from "react"
 
 import { NetworkIcon } from "./NetworkIcon"
 

--- a/src/components/Network/NetworkIcon.tsx
+++ b/src/components/Network/NetworkIcon.tsx
@@ -1,5 +1,5 @@
-import React from "react"
 import clsx from "clsx"
+import React from "react"
 
 export const NetworkIcon = ({
   chainIcon,

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
+import { Cross1Icon, MagnifyingGlassIcon } from "@radix-ui/react-icons"
 import React from "react"
-import { MagnifyingGlassIcon, Cross1Icon } from "@radix-ui/react-icons"
 
 type Props = {
   query: string

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -24,6 +24,7 @@ export const SearchBar = ({
         onChange={(e) => setQuery(e.target.value)}
       />
       <button
+        type={"button"}
         onClick={() => {
           handleOverrideCancel ? handleOverrideCancel() : setQuery("")
         }}

--- a/src/components/SelectAssets.tsx
+++ b/src/components/SelectAssets.tsx
@@ -1,7 +1,7 @@
-import React from "react"
 import { CaretDownIcon } from "@radix-ui/react-icons"
+import type React from "react"
 
-import { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo } from "../types/base"
 
 import { AssetComboIcon } from "./Asset/AssetComboIcon"
 

--- a/src/components/SelectAssets.tsx
+++ b/src/components/SelectAssets.tsx
@@ -12,17 +12,18 @@ type Props = {
 
 const EmptyIcon = () => {
   return (
-    <span className="relative min-w-[36px] min-h-[36px] bg-gray-200 rounded-full"></span>
+    <span className="relative min-w-[36px] min-h-[36px] bg-gray-200 rounded-full" />
   )
 }
 
 export const SelectAssets = ({ selected, handleSelect }: Props) => {
   const handleAssetsSelect = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
-    handleSelect && handleSelect()
+    handleSelect?.()
   }
   return (
     <button
+      type={"button"}
       onClick={handleAssetsSelect}
       className="max-w-[148px] md:max-w-[210px] bg-white shadow-select-token rounded-full flex justify-between items-center p-1 gap-2.5 dark:bg-black-800 dark:shadow-select-token-dark"
     >

--- a/src/components/WarnBox/index.tsx
+++ b/src/components/WarnBox/index.tsx
@@ -38,6 +38,7 @@ export const WarnBox = ({
         {generateWarningBalanceMessage()}
       </Text>
       {allowableNearAmount !== "0" && (
+        /* biome-ignore lint/a11y/useKeyWithClickEvents: sorry keyboard users */
         <span
           onClick={() => {
             const value = balanceToDecimal(allowableNearAmount ?? "0", decimals)

--- a/src/components/WarnBox/index.tsx
+++ b/src/components/WarnBox/index.tsx
@@ -1,5 +1,5 @@
-import React from "react"
 import { Text } from "@radix-ui/themes"
+import React from "react"
 
 import { smallBalanceToFormat } from "../../utils"
 import { balanceToDecimal } from "../../utils/balanceTo"

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,4 +1,4 @@
-import { Settings } from "../types"
+import type { Settings } from "../types"
 
 let settings: Settings = {
   providerIds: [],

--- a/src/constants/swap.ts
+++ b/src/constants/swap.ts
@@ -5,4 +5,4 @@ export const CONNECTOR_BTC_MAINNET = "__d_btc_mainnet_connector"
 
 export const CREATE_INTENT_EXPIRATION_BLOCK_BOOST = 350
 export const CREATE_INTENT_ROLLBACK_DELAY = 90
-export const MAX_GAS_TRANSACTION = "300" + "0".repeat(12)
+export const MAX_GAS_TRANSACTION = `300${"0".repeat(12)}`

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1,5 +1,5 @@
 import { INDEXER } from "../types"
-import { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo } from "../types/base"
 
 export const LIST_NETWORKS_TOKENS: BaseTokenInfo[] = [
   {

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -1,6 +1,6 @@
+import { quoteMachine } from "@defuse-protocol/swap-facade"
 import { useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
-import { quoteMachine } from "@defuse-protocol/swap-facade"
 import { createActor } from "xstate"
 
 import { ButtonCustom, ButtonSwitch } from "../../../components/Button"
@@ -8,7 +8,7 @@ import { Form } from "../../../components/Form"
 import { FieldComboInput } from "../../../components/Form/FieldComboInput"
 import { WarnBox } from "../../../components/WarnBox"
 import { NEAR_TOKEN_META } from "../../../constants"
-import { BaseTokenInfo } from "../../../types/base"
+import type { BaseTokenInfo } from "../../../types/base"
 
 type SwapFormValues = {
   amountIn: string // tokenIn

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -61,6 +61,7 @@ export const SwapForm = ({
     input: {},
   }).start()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `quoteActor.send` for some reason is not in the dependencies, need to investigate
   useEffect(() => {
     const subscription = watch((value, { name }) => {
       if (name === "amountIn") {

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -20,10 +20,15 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
   const handleSelect = (fieldName: string, selectToken: BaseTokenInfo) => {
     setModalType(ModalType.MODAL_SELECT_ASSETS, { fieldName, selectToken })
   }
+
+  assert(tokenList.length > 2, "Token list must have at least 2 tokens")
+
   return (
     <SwapWidgetProvider>
       <SwapForm
+        // biome-ignore lint/style/noNonNullAssertion: tokenList is asserted to have at least 2 tokens
         selectTokenIn={tokenList[0]!}
+        // biome-ignore lint/style/noNonNullAssertion: tokenList is asserted to have at least 2 tokens
         selectTokenOut={tokenList[1]!}
         onSubmit={handleSubmit}
         onSelect={handleSelect}
@@ -31,4 +36,10 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
       />
     </SwapWidgetProvider>
   )
+}
+
+function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg)
+  }
 }

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -3,10 +3,10 @@ import React from "react"
 import { SwapWidgetProvider } from "../../../providers"
 import { useModalStore } from "../../../providers/ModalStoreProvider"
 import { ModalType } from "../../../stores/modalStore"
-import { BaseTokenInfo } from "../../../types/base"
-import { SwapWidgetProps } from "../../../types"
+import type { SwapWidgetProps } from "../../../types"
+import type { BaseTokenInfo } from "../../../types/base"
 
-import { OnSubmitValues, SwapForm } from "./SwapForm"
+import { type OnSubmitValues, SwapForm } from "./SwapForm"
 
 export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
   const { setModalType, payload, onCloseModal } = useModalStore(

--- a/src/hooks/useCalculateTokenToUsd.ts
+++ b/src/hooks/useCalculateTokenToUsd.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-import { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo } from "../types/base"
 
 export const useCalculateTokenToUsd = () => {
   const [priceToUsd, setPriceToUsd] = useState("0")
@@ -9,7 +9,7 @@ export const useCalculateTokenToUsd = () => {
     amount: string,
     selectToken: BaseTokenInfo | undefined
   ) => {
-    if (!selectToken || !parseFloat(amount)) {
+    if (!selectToken || !Number.parseFloat(amount)) {
       setPriceToUsd("0")
       return
     }

--- a/src/hooks/useModalSearchParams.ts
+++ b/src/hooks/useModalSearchParams.ts
@@ -16,5 +16,5 @@ export const useModalSearchParams = () => {
     ) {
       setModalType(modalType as ModalType)
     }
-  }, [])
+  }, [setModalType])
 }

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, MutableRefObject } from "react"
+import { type MutableRefObject, useCallback, useEffect, useState } from "react"
 
 export const useResize = (ref: MutableRefObject<HTMLElement | null>) => {
   const getDimensions = useCallback(

--- a/src/providers/ModalStoreProvider.tsx
+++ b/src/providers/ModalStoreProvider.tsx
@@ -32,7 +32,7 @@ export const useModalStore = <T,>(selector: (store: ModalStore) => T): T => {
   const modalStoreContext = useContext(ModalStoreContext)
 
   if (!modalStoreContext) {
-    throw new Error(`useModalStore must be use within ModalStoreProvider`)
+    throw new Error("useModalStore must be use within ModalStoreProvider")
   }
 
   return useStore(modalStoreContext, selector)

--- a/src/providers/SwapWidgetProvider.tsx
+++ b/src/providers/SwapWidgetProvider.tsx
@@ -1,4 +1,5 @@
-import React, { PropsWithChildren } from "react"
+import type React from "react"
+import type { PropsWithChildren } from "react"
 
 import { Modal } from "../components/Modal"
 

--- a/src/providers/TokensStoreProvider.tsx
+++ b/src/providers/TokensStoreProvider.tsx
@@ -2,9 +2,9 @@ import React, { type ReactNode, createContext, useRef, useContext } from "react"
 import { type StoreApi, useStore } from "zustand"
 
 import {
+  type TokensStore,
   createTokensStore,
   initTokensStore,
-  TokensStore,
 } from "../stores/tokensStore"
 
 export const TokensStoreContext = createContext<StoreApi<TokensStore> | null>(

--- a/src/providers/TokensStoreProvider.tsx
+++ b/src/providers/TokensStoreProvider.tsx
@@ -32,7 +32,7 @@ export const useTokensStore = <T,>(selector: (store: TokensStore) => T): T => {
   const tokensStoreContext = useContext(TokensStoreContext)
 
   if (!tokensStoreContext) {
-    throw new Error(`useTokensStore must be use within TokensStoreProvider`)
+    throw new Error("useTokensStore must be use within TokensStoreProvider")
   }
 
   return useStore(tokensStoreContext, selector)

--- a/src/stores/tokensStore.ts
+++ b/src/stores/tokensStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand/vanilla"
 
-import { NetworkTokenWithSwapRoute } from "../types"
+import type { NetworkTokenWithSwapRoute } from "../types"
 
 export type TokensState = {
   data: Map<string, NetworkTokenWithSwapRoute>

--- a/src/stores/tokensStore.ts
+++ b/src/stores/tokensStore.ts
@@ -38,7 +38,9 @@ export const createTokensStore = (
     updateTokens: (data: NetworkTokenWithSwapRoute[]) =>
       set((state) => {
         const updatedData = new Map(state.data)
-        data.forEach((item) => updatedData.set(item.defuseAssetId, item))
+        for (const item of data) {
+          updatedData.set(item.defuseAssetId, item)
+        }
         return { data: updatedData, isFetched: true, isLoading: false }
       }),
   }))

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,6 +1,6 @@
 import type { AccountView } from "near-api-js/lib/providers/provider"
 
-import { Result } from "./solver"
+import type { Result } from "./solver"
 
 export type DefuseBaseIds = {
   defuse_asset_id: string
@@ -38,11 +38,11 @@ export interface NetworkToken extends TokenInfo, DefuseBaseIds {
 }
 
 export enum QueueTransactions {
-  "DEPOSIT" = "deposit",
-  "WITHDRAW" = "withdraw",
-  "STORAGE_DEPOSIT_TOKEN_IN" = "storageDepositTokenIn",
-  "STORAGE_DEPOSIT_TOKEN_OUT" = "storageDepositTokenOut",
-  "CREATE_INTENT" = "createIntent",
+  DEPOSIT = "deposit",
+  WITHDRAW = "withdraw",
+  STORAGE_DEPOSIT_TOKEN_IN = "storageDepositTokenIn",
+  STORAGE_DEPOSIT_TOKEN_OUT = "storageDepositTokenOut",
+  CREATE_INTENT = "createIntent",
 }
 
 export interface NearTXTransaction {

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -1,4 +1,4 @@
-import { BaseTokenInfo } from "./base"
+import type { BaseTokenInfo } from "./base"
 
 // TODO: Must be moved to @defuse/swap-facade
 export type SwapMessageParams = {
@@ -23,11 +23,11 @@ export type SwapWidgetProps = {
 }
 
 export enum QueueTransactionsEnum {
-  "DEPOSIT" = "deposit",
-  "WITHDRAW" = "withdraw",
-  "STORAGE_DEPOSIT_TOKEN_IN" = "storageDepositTokenIn",
-  "STORAGE_DEPOSIT_TOKEN_OUT" = "storageDepositTokenOut",
-  "CREATE_INTENT" = "createIntent",
+  DEPOSIT = "deposit",
+  WITHDRAW = "withdraw",
+  STORAGE_DEPOSIT_TOKEN_IN = "storageDepositTokenIn",
+  STORAGE_DEPOSIT_TOKEN_OUT = "storageDepositTokenOut",
+  CREATE_INTENT = "createIntent",
 }
 
 export type SelectToken = BaseTokenInfo | undefined
@@ -70,8 +70,8 @@ export type CallRequestIntentProps = {
 }
 
 export enum EvaluateResultEnum {
-  BEST,
-  LOW,
+  BEST = 0,
+  LOW = 1,
 }
 
 type WithAccounts = {
@@ -84,6 +84,6 @@ export interface ModalConfirmSwapPayload
     WithAccounts {}
 
 export enum INDEXER {
-  INTENT_0,
-  INTENT_1,
+  INTENT_0 = 0,
+  INTENT_1 = 1,
 }

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -5,7 +5,7 @@ export function debounce<T extends (...args: any[]) => void>(
 ): (...args: Parameters<T>) => void {
   let timeout: ReturnType<typeof setTimeout>
 
-  return function (...args: Parameters<T>) {
+  return (...args: Parameters<T>) => {
     clearTimeout(timeout)
     timeout = setTimeout(() => {
       func(...args)

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function debounce<T extends (...args: any[]) => void>(
+export function debounce<T extends (...args: unknown[]) => void>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {

--- a/src/utils/debouncePromise.ts
+++ b/src/utils/debouncePromise.ts
@@ -3,9 +3,9 @@ interface FunctionWithArguments {
   (...args: any): any
 }
 
-interface DebouncedFunction<F extends FunctionWithArguments> {
-  (...args: Parameters<F>): Promise<ReturnType<F>>
-}
+type DebouncedFunction<F extends FunctionWithArguments> = (
+  ...args: Parameters<F>
+) => Promise<ReturnType<F>>
 
 type DebounceReturn<F extends FunctionWithArguments> = (
   ...args: Parameters<F>

--- a/src/utils/debouncePromise.ts
+++ b/src/utils/debouncePromise.ts
@@ -1,7 +1,5 @@
-interface FunctionWithArguments {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (...args: any): any
-}
+// biome-ignore lint/suspicious/noExplicitAny: <reason>
+type FunctionWithArguments = (...args: any) => any
 
 type DebouncedFunction<F extends FunctionWithArguments> = (
   ...args: Parameters<F>

--- a/src/utils/isSameToken.ts
+++ b/src/utils/isSameToken.ts
@@ -1,4 +1,4 @@
-import { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo } from "../types/base"
 
 export const isSameToken = (
   token: BaseTokenInfo,

--- a/src/utils/near.ts
+++ b/src/utils/near.ts
@@ -1,8 +1,8 @@
+import { getNearProvider, setNearProvider } from "@near-eth/client"
 import { providers } from "near-api-js"
-import { CodeResult } from "near-api-js/lib/providers/provider"
-import { setNearProvider, getNearProvider } from "@near-eth/client"
+import type { CodeResult } from "near-api-js/lib/providers/provider"
 
-import { NearViewAccount } from "../types"
+import type { NearViewAccount } from "../types"
 
 // Accessing ENV in the browser is not recommended.
 // Instead, it is better to explicitly pass values to functions.

--- a/src/utils/near.ts
+++ b/src/utils/near.ts
@@ -13,7 +13,8 @@ const NEAR_NODE_URL = /*@__PURE__*/ (() =>
 export const storageBalance = async (contractId: string, accountId: string) => {
   try {
     setNearProvider(
-      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any // eslint-disable-line
+      // biome-ignore lint/suspicious/noExplicitAny: <reason>
+      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any
     )
 
     const nearProvider = getNearProvider()
@@ -40,7 +41,8 @@ export const nearAccount = async (
 ): Promise<NearViewAccount | null> => {
   try {
     setNearProvider(
-      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any // eslint-disable-line
+      // biome-ignore lint/suspicious/noExplicitAny: <reason>
+      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any
     )
 
     const nearProvider = getNearProvider()
@@ -63,7 +65,8 @@ export const nep141Balance = async (
 ): Promise<string | null> => {
   try {
     setNearProvider(
-      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any // eslint-disable-line
+      // biome-ignore lint/suspicious/noExplicitAny: <reason>
+      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any
     )
     const nearProvider = getNearProvider()
     const storageBalance = await nearProvider.query<CodeResult>({
@@ -91,7 +94,8 @@ export const intentStatus = async (
 ): Promise<string | null> => {
   try {
     setNearProvider(
-      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any // eslint-disable-line
+      // biome-ignore lint/suspicious/noExplicitAny: <reason>
+      new providers.JsonRpcProvider({ url: NEAR_NODE_URL }) as any
     )
 
     const nearProvider = getNearProvider()

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,14 +1,14 @@
 import { formatUnits } from "viem"
 
 export const smallBalanceToFormat = (balance: string, toFixed = 14): string => {
-  if (!parseFloat(balance)) {
+  if (!Number.parseFloat(balance)) {
     return balance
   }
-  const isSmallBalance = parseFloat(balance) < 0.00001
+  const isSmallBalance = Number.parseFloat(balance) < 0.00001
   if (isSmallBalance) {
     return "~0.00001"
   }
-  return parseFloat(balance.substring(0, toFixed)).toString()
+  return Number.parseFloat(balance.substring(0, toFixed)).toString()
 }
 
 export const tokenBalanceToFormatUnits = ({
@@ -18,7 +18,7 @@ export const tokenBalanceToFormatUnits = ({
   balance: string | undefined
   decimals: number
 }): string => {
-  if (!parseFloat(balance?.toString() ?? "0")) {
+  if (!Number.parseFloat(balance?.toString() ?? "0")) {
     return "0"
   }
   const balanceToUnits = formatUnits(

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -18,11 +18,11 @@ export const tokenBalanceToFormatUnits = ({
   balance: string | undefined
   decimals: number
 }): string => {
-  if (!Number.parseFloat(balance?.toString() ?? "0")) {
+  if (balance == null || !Number.parseFloat(balance?.toString() ?? "0")) {
     return "0"
   }
   const balanceToUnits = formatUnits(
-    BigInt(balance!.toString()),
+    BigInt(balance.toString()),
     decimals
   ).toString()
 

--- a/src/utils/tokenList.ts
+++ b/src/utils/tokenList.ts
@@ -1,5 +1,5 @@
 import { NEAR_TOKEN_META, W_NEAR_TOKEN_META } from "../constants"
-import { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo } from "../types/base"
 
 /**
  * Wrap Near has to be applied to Native Near and goes in conjunction on Swap.

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,60 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@biomejs/biome@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-1.9.3.tgz#5362fc390ac00c82e3698824490e3801d012c1b0"
+  integrity sha512-POjAPz0APAmX33WOQFGQrwLvlu7WLV4CFJMlB12b6ZSg+2q6fYu9kZwLCOA+x83zXfcPd1RpuWOKJW0GbBwLIQ==
+  optionalDependencies:
+    "@biomejs/cli-darwin-arm64" "1.9.3"
+    "@biomejs/cli-darwin-x64" "1.9.3"
+    "@biomejs/cli-linux-arm64" "1.9.3"
+    "@biomejs/cli-linux-arm64-musl" "1.9.3"
+    "@biomejs/cli-linux-x64" "1.9.3"
+    "@biomejs/cli-linux-x64-musl" "1.9.3"
+    "@biomejs/cli-win32-arm64" "1.9.3"
+    "@biomejs/cli-win32-x64" "1.9.3"
+
+"@biomejs/cli-darwin-arm64@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.3.tgz#3a981835a7a891589b356bbdb4e50157e494aa7d"
+  integrity sha512-QZzD2XrjJDUyIZK+aR2i5DDxCJfdwiYbUKu9GzkCUJpL78uSelAHAPy7m0GuPMVtF/Uo+OKv97W3P9nuWZangQ==
+
+"@biomejs/cli-darwin-x64@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.3.tgz#0e33284e5def9cbc17705b6a9acbc22b161accb1"
+  integrity sha512-vSCoIBJE0BN3SWDFuAY/tRavpUtNoqiceJ5PrU3xDfsLcm/U6N93JSM0M9OAiC/X7mPPfejtr6Yc9vSgWlEgVw==
+
+"@biomejs/cli-linux-arm64-musl@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.3.tgz#b68e2fe56381cbf71770b6c785215448c47595fd"
+  integrity sha512-VBzyhaqqqwP3bAkkBrhVq50i3Uj9+RWuj+pYmXrMDgjS5+SKYGE56BwNw4l8hR3SmYbLSbEo15GcV043CDSk+Q==
+
+"@biomejs/cli-linux-arm64@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.3.tgz#bb8186f000bd7366c3a1822a4a505e374905c462"
+  integrity sha512-vJkAimD2+sVviNTbaWOGqEBy31cW0ZB52KtpVIbkuma7PlfII3tsLhFa+cwbRAcRBkobBBhqZ06hXoZAN8NODQ==
+
+"@biomejs/cli-linux-x64-musl@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.3.tgz#01ccee0db2ca2ec9fb51fa69b2fc9e96434b5b32"
+  integrity sha512-TJmnOG2+NOGM72mlczEsNki9UT+XAsMFAOo8J0me/N47EJ/vkLXxf481evfHLlxMejTY6IN8SdRSiPVLv6AHlA==
+
+"@biomejs/cli-linux-x64@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.3.tgz#82d6fb824dd2c76142ab8625e202eb63a34e14f1"
+  integrity sha512-x220V4c+romd26Mu1ptU+EudMXVS4xmzKxPVb9mgnfYlN4Yx9vD5NZraSx/onJnd3Gh/y8iPUdU5CDZJKg9COA==
+
+"@biomejs/cli-win32-arm64@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.3.tgz#7fac607ade8e204eecae09e127713f000da0ccf2"
+  integrity sha512-lg/yZis2HdQGsycUvHWSzo9kOvnGgvtrYRgoCEwPBwwAL8/6crOp3+f47tPwI/LI1dZrhSji7PNsGKGHbwyAhw==
+
+"@biomejs/cli-win32-x64@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.3.tgz#1cbc269dcd5f29b034cb7f5982353c1cc3629318"
+  integrity sha512-cQMy2zanBkVLpmmxXdK6YePzmZx0s5Z7KEnwmrW54rcXK3myCNbQa09SwGZ8i/8sLw0H9F3X7K4rxVNGU8/D4Q==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"


### PR DESCRIPTION
PR includes:
- Biomejs installation with default configuration
- Fixes of existing files with found errors
- Disabling pre-commit hook

I decided to go with default linting configuration that Biomejs provides. I find it comprehensive, as it covers common JS, TS and React cases.
On other hand I imported format rules from prettier, because biomejs has quite different format rules and I didn't want to change code drastically. Overall format rules is a matter of taste.

Follow-up PR will include removal of prettier and eslint tools.