### PR TITLE
refactor: Use swap UI machine

### DIFF
--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -116,11 +116,13 @@ export const FieldComboInput = <T extends FieldValues>({
       )}
     >
       <input
+        type={"text"}
         {...register(fieldName, option)}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
         placeholder={placeholder}
         disabled={disabled}
+        autoComplete={"off"}
         className={clsx(
           "grow flex-1 bg-gray-50 max-w-[140px] md:max-w-[none] md:min-w-[calc(100%-210px)] text-3xl font-medium placeholder-black border-transparent focus:border-transparent focus:ring-0 dark:bg-black-900 dark:placeholder-white",
           disabled && "text-black-200 pointer-events-none placeholder-black-200"

--- a/src/features/machines/swapUIMachine.test.ts
+++ b/src/features/machines/swapUIMachine.test.ts
@@ -14,8 +14,8 @@ describe("swapUIMachine", () => {
     formValidation: vi.fn(async (): Promise<boolean> => {
       return true
     }),
-    queryQuote: vi.fn(async (): Promise<QuoteTmp> => {
-      return {}
+    queryQuote: vi.fn(async (): Promise<QuoteTmp[]> => {
+      return []
     }),
     swap: async (): Promise<Output> => {
       return {}
@@ -28,10 +28,11 @@ describe("swapUIMachine", () => {
     swap: fromPromise(defaultActorImpls.swap),
   }
 
-  const defaultActions = {}
+  const defaultActions = {
+    updateUIAmountOut: vi.fn(),
+  }
 
   const defaultGuards = {
-    isFormValid: vi.fn(),
     isQuoteRelevant: vi.fn(),
   }
 
@@ -97,7 +98,7 @@ describe("swapUIMachine", () => {
     const err = new Error("Something went wrong")
     defaultActorImpls.queryQuote
       .mockRejectedValueOnce(err)
-      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce([])
     const service = interpret().start()
 
     // act

--- a/src/features/machines/swapUIMachine.test.ts
+++ b/src/features/machines/swapUIMachine.test.ts
@@ -11,6 +11,9 @@ import { type QuoteTmp, swapUIMachine } from "./swapUIMachine"
 
 describe("swapUIMachine", () => {
   const defaultActorImpls = {
+    formValidation: vi.fn(async (): Promise<boolean> => {
+      return true
+    }),
     queryQuote: vi.fn(async (): Promise<QuoteTmp> => {
       return {}
     }),
@@ -20,6 +23,7 @@ describe("swapUIMachine", () => {
   }
 
   const defaultActors = {
+    formValidation: fromPromise(defaultActorImpls.formValidation),
     queryQuote: fromPromise(defaultActorImpls.queryQuote),
     swap: fromPromise(defaultActorImpls.swap),
   }
@@ -61,9 +65,8 @@ describe("swapUIMachine", () => {
   const F = () => false
 
   it.each`
-    initialState      | expectedState        | event      | guards                | context
-    ${"editing.idle"} | ${"editing.idle"}    | ${"input"} | ${{ isFormValid: F }} | ${null}
-    ${"editing.idle"} | ${"editing.quoting"} | ${"input"} | ${{ isFormValid: T }} | ${null}
+    initialState      | expectedState           | event      | guards  | context
+    ${"editing.idle"} | ${"editing.validating"} | ${"input"} | ${null} | ${null}
   `(
     'should reach "$expectedState" given "$initialState" when the "$event" event occurs',
     ({ initialState, expectedState, event, guards, context }) => {
@@ -91,7 +94,6 @@ describe("swapUIMachine", () => {
 
   it("should set and reset the quote querying error", async () => {
     // arrange
-    guards.isFormValid.mockReturnValueOnce(true)
     const err = new Error("Something went wrong")
     defaultActorImpls.queryQuote
       .mockRejectedValueOnce(err)

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -16,6 +16,9 @@ export const swapUIMachine = setup({
     },
   },
   actors: {
+    formValidation: fromPromise(async (): Promise<boolean> => {
+      throw new Error("not implemented")
+    }),
     queryQuote: fromPromise(async (): Promise<QuoteTmp> => {
       throw new Error("not implemented")
     }),
@@ -32,15 +35,12 @@ export const swapUIMachine = setup({
     quotePollingInterval: 500,
   },
   guards: {
-    isFormValid: () => {
-      throw new Error("not implemented")
-    },
     isQuoteRelevant: () => {
       throw new Error("not implemented")
     },
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaArgSwDpI8AXPAOygGJYcAjAW1IG0AGAXUVAwHtZS8PclxAAPRAEYJADgIB2AKwA2JdIkBmVqyUKFAJgA0IAJ6S9e+UoCcc6bfV7pe1noC+ro6ky5CxMpSoKDBwSNk4kEF5+MiERcQQsPQ0CVl1pKx1pFRdDE0REuQIdABY7BTslYpctNw8QL2x8IggBAKCQ5glw7j4BWIj4rAVtAgybCWsJPSUpOSNTBIUCCTkVCYU5c3T1HfdPdEbfFv8oAjwIABswKlFYEjQSMAI0ADNHgCcACgBHHB5HgAKPAuFwoUAAkuQPgA3NAXACUNAOPmarVO5yuYREUT6wgG+SULgI0gUO1Jq3SVisuQWE2Ky1UKyk0m0TiU6j29WRTT8YIIv3+YKoECETwo0J4AGsngLHgBFHBgd54JVYiI4mJ40CDdTJaTFKR6KwOBTFTSreaIPRyVgpazFcrFTZ6BRTJSchoo3mUfl-E5UJXvHjvAgYC4PF7Bhi+-5gBVKlXvNU9aKCLVifJTelVbZKRTFKypPOWhDW23aKwO-XO121fbeJq0Rikf0i8hi8gS6UET2N+hMEgnBDingAYweabCycivU1cUQuisRRUjipw1KMxLElYEgIpvKrAy6krxWKHu5hFHPAYYbAjxo93eJAA8tDVRxsbO0-OEKal7o5ELQC0isEkS3MQpWQPBQqQcHcJHcOpyB4CA4BEXs8E-VN+m1fInCWFRAMAlQqWKHQS0SIlNArdR1xJItzwbI40Sw3EfywOROOXIiMmsStyLyBIpHpGxOP1axtGmRxGMOVETjOS4wFYud8QSTYl0ImxeNIgTaSUCwyQLJ0Vk2TYzzqDC5L5WUwWU79VMSSo9y0Q8dnwyttC3J1LBkaRjxsHQMgUGSUSbAcTjsnCMwQdRFAIPQDSycxaKsfRihLY1ljI0opjkBxNA5CyLwIK8byuR5IvTeI5AkekZBUB0DQNPMaUkGR4tddQnHUUpSXtRDXCAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaArgSwDpI8AXPAOygGJYcAjAW1IG0AGAXUVAwHtZS8PclxAAPRAEYJADgIB2AKwA2JdIkBmVqyUKFAJgA0IAJ6S9e+UoCcc6bfV7pe1noC+ro6ky5CxMpSoKDBwSNk4kEF5+MiERcQQsfSsCABZWdQUJOQl06WkU6SNTBIVZVgkFFIqUhXtWFPV3T3RsfCIIAUoCAEccHhJIKlFYEjQBgjQAMwGAJwAKXv6wAAUeABs1iigASXJZgDc0NYBKGhafds6oHr6BiDCRKIFYiPjEhVYCaSVylKsUv5ZIqSb4EVTlVhWZQ-CpKRoeEBeVq+Dr+a6LNFUCBCMAECj7HgAa1xGLAAEUcGAZngqQ8Ik8YsJXogsOoNF8qhI9FYHJVNHIlMCEHo5J9tP9Sik5OZMnolE1Eec2n4tjd+lsqFSZjwZgQMGsxpMdQw1QMKVSaTM6dw+M8maA3lyUqlWNIeUpFH9WMo5EKRWLrDV8tK9LKFUiLrRGKRMdjyLj8UTcRG2lGmCQ0QhEwBjMaCchha2RW2MuKIXTJFRKRxWKH1b4SIU5CQESqlSFw-4A8NKwjZngMfVgAY0UYzEgAeX2tI4jxL+bLCEqyV0cisrDXujd0gUfpFBG0O+k3trDnKEh73mVqNVh02EDzATjCfIBOJBBTKKuBDveAfmZzPMhELWd6XnF4HRZEUlAIcwrBUdJnGcDIhUUVJVHUJwnH0PJ8kvZFLjRH8jj-R9qGfPFXyTD9e0I28SP-LYsyo3NGULCRwhtaIF2ZEo1FbRw9E0PIXD0KRUIUdD8nqUN1ClTJ5QVcgeAgOARE-OduIgsQWWPT5nChGQjyUDRfRMKCHDBEy5WlN0t3SfCLhVShNLtRcsEUCwDMyPJShM9QzOKLAJBqAh1EwuTTPUQNzEc69vz-NYwFc0teI8+pYMhHzjNM1D1DBDJRRkKUpDUFI4q-IiMS2FKeMghI5WdD4tB5TDQ3+bQmylSwjPUWsBQUeCFAqj96HTNFau0+IAskvQqm+cwMihOahR5AgQqUAouTkBxNHhZorz7AchwGSb7R0hBsmdGQVBqKoqg9QxzIQUrYMyNq5J3aL-hG5zrl-RiXLArTzreITkhu+DHByOTrEKZ7EgsD07A0c8MjsaRfpvLpSQgM73MySSTKyeCrA0Bw7D9Jx1oChwJBsTa0mkeF3CAA */
   id: "swap-ui",
 
   context: {
@@ -56,40 +56,29 @@ export const swapUIMachine = setup({
           target: "submitting",
           guard: "isQuoteRelevant",
         },
-        input: [
-          {
-            target: ".quoting",
-            actions: ["clearQuote", "clearError"],
-            guard: "isFormValid",
-          },
-          {
-            target: ".idle",
-            actions: ["clearQuote", "clearError"],
-          },
-        ],
+        input: {
+          target: ".validating",
+          actions: ["clearQuote", "clearError"],
+        },
       },
 
       states: {
-        idle: {
-          after: {
-            quotePollingInterval: {
-              target: "quoting",
-              guard: "isFormValid",
-            },
-          },
-        },
+        idle: {},
+
         quoting: {
           invoke: {
             id: "quoteQuerier",
             src: "queryQuote",
 
             onDone: {
-              target: "idle",
+              target: "quoted",
               actions: assign({ quote: ({ event }) => event.output }),
+              reenter: true,
             },
 
             onError: {
-              target: "idle",
+              target: "quoted",
+
               actions: assign({
                 error: ({ event }) => {
                   if (event.error instanceof Error) {
@@ -98,6 +87,31 @@ export const swapUIMachine = setup({
                   return new Error("unknown error")
                 },
               }),
+
+              reenter: true,
+            },
+          },
+        },
+
+        validating: {
+          invoke: {
+            src: "formValidation",
+
+            onDone: [
+              {
+                target: "quoting",
+                guard: ({ event }) => event.output,
+              },
+              "idle",
+            ],
+          },
+        },
+
+        quoted: {
+          after: {
+            quotePollingInterval: {
+              target: "quoting",
+              reenter: true,
             },
           },
         },

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -2,7 +2,9 @@ import { assign, fromPromise, setup } from "xstate"
 import type { Output } from "./swapIntentMachine"
 
 // biome-ignore lint/complexity/noBannedTypes: It is temporary type, will be replaced with real quote interface
-export type QuoteTmp = {}
+export type QuoteTmp = {
+  amount_out: string
+}
 
 export const swapUIMachine = setup({
   types: {
@@ -11,7 +13,7 @@ export const swapUIMachine = setup({
     },
     context: {} as {
       error: Error | null
-      quote: QuoteTmp | null
+      quotes: QuoteTmp[] | null
       outcome: Output | null
     },
   },
@@ -19,7 +21,7 @@ export const swapUIMachine = setup({
     formValidation: fromPromise(async (): Promise<boolean> => {
       throw new Error("not implemented")
     }),
-    queryQuote: fromPromise(async (): Promise<QuoteTmp> => {
+    queryQuote: fromPromise(async (): Promise<QuoteTmp[]> => {
       throw new Error("not implemented")
     }),
     swap: fromPromise(async (): Promise<Output> => {
@@ -27,7 +29,10 @@ export const swapUIMachine = setup({
     }),
   },
   actions: {
-    clearQuote: assign({ quote: null }),
+    updateUIAmountOut: () => {
+      throw new Error("not implemented")
+    },
+    clearQuote: assign({ quotes: null }),
     clearError: assign({ error: null }),
     clearOutcome: assign({ outcome: null }),
   },
@@ -40,12 +45,12 @@ export const swapUIMachine = setup({
     },
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaArgSwDpI8AXPAOygGJYcAjAW1IG0AGAXUVAwHtZS8PclxAAPRAEYJADgIB2AKwA2JdIkBmVqyUKFAJgA0IAJ6S9e+UoCcc6bfV7pe1noC+ro6ky5CxMpSoKDBwSNk4kEF5+MiERcQQsfSsCABZWdQUJOQl06WkU6SNTBIVZVgkFFIqUhXtWFPV3T3RsfCIIAUoCAEccHhJIKlFYEjQBgjQAMwGAJwAKXv6wAAUeABs1iigASXJZgDc0NYBKGhafds6oHr6BiDCRKIFYiPjEhVYCaSVylKsUv5ZIqSb4EVTlVhWZQ-CpKRoeEBeVq+Dr+a6LNFUCBCMAECj7HgAa1xGLAAEUcGAZngqQ8Ik8YsJXogsOoNF8qhI9FYHJVNHIlMCEHo5J9tP9Sik5OZMnolE1Eec2n4tjd+lsqFSZjwZgQMGsxpMdQw1QMKVSaTM6dw+M8maA3lyUqlWNIeUpFH9WMo5EKRWLrDV8tK9LKFUiLrRGKRMdjyLj8UTcRG2lGmCQ0QhEwBjMaCchha2RW2MuKIXTJFRKRxWKH1b4SIU5CQESqlSFw-4A8NKwjZngMfVgAY0UYzEgAeX2tI4jxL+bLCEqyV0cisrDXujd0gUfpFBG0O+k3trDnKEh73mVqNVh02EDzATjCfIBOJBBTKKuBDveAfmZzPMhELWd6XnF4HRZEUlAIcwrBUdJnGcDIhUUVJVHUJwnH0PJ8kvZFLjRH8jj-R9qGfPFXyTD9e0I28SP-LYsyo3NGULCRwhtaIF2ZEo1FbRw9E0PIXD0KRUIUdD8nqUN1ClTJ5QVcgeAgOARE-OduIgsQWWPT5nChGQjyUDRfRMKCHDBEy5WlN0t3SfCLhVShNLtRcsEUCwDMyPJShM9QzOKLAJBqAh1EwuTTPUQNzEc69vz-NYwFc0teI8+pYMhHzjNM1D1DBDJRRkKUpDUFI4q-IiMS2FKeMghI5WdD4tB5TDQ3+bQmylSwjPUWsBQUeCFAqj96HTNFau0+IAskvQqm+cwMihOahR5AgQqUAouTkBxNHhZorz7AchwGSb7R0hBsmdGQVBqKoqg9QxzIQUrYMyNq5J3aL-hG5zrl-RiXLArTzreITkhu+DHByOTrEKZ7EgsD07A0c8MjsaRfpvLpSQgM73MySSTKyeCrA0Bw7D9Jx1oChwJBsTa0mkeF3CAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaArgSwDpI8AXPAOygGJYcAjAW1IG0AGAXUVAwHtZS8PclxAAPRAEYJADgIB2AKwA2JdIkBmVqyUKFAJgA0IAJ6S9e+UoCcc6bfV7pe1noC+ro6ky5CxMpSoKDBwSNk4kEF5+MiERcQQsABZrAiV1CXt1dSUJBQlEo1ME6SsCLIyFbKsJJT0FVgl3T3RsfCIIAUoCAEccHn9qCCEwAgoANx4AaxHe-rAARRwwACc8FbCRKIFYiPisdPUCaUSpPSsHBUTNOSVCxD05VgJtK0SFY7lzPL0lJpAvVq+DoDHp9AZUFbLHjLAgYAA2aBIADNoQxQXNFis1ssNhEtjFhLtEFgJHpEgREqwStlFIkrKxlHI7ggHk8Xm8Pl9SX8AT52p0oAQxmg4XgIIiKINhqNyBNpgReW0-JKhSKxRLKAhxjwAMYSoRhXHcPjbQmgPYPJQEcxWFSsBwue0KZmKCmqdROJz6aQ+xI8lp85VdYWi8XgobkEba+WKoEC1WhjVQLWy3X68iGiThY3RQRmsTEpQNa0lY7SdS6Wr25n6eRXWzSepnCT0twef4BpXAlWzEiQKiiWAkREjNBIvvLAAUvbAAAUeHDRZQAJLkCchgCUNE7cZBM4gRsiJoJcWJuie0iL+VedIyzJkVtUDVYVmUV+U6n93jatEYpHD0rRiMsYKvQTAkAMKYTHqBKGhwmzHnmp4ILopQqLUJSvqwiSXhI97Fpc7wvmkN5+u2IE6jwDDwmAfY0MOywkAA8mM6zwXiiE7OaiCXKUuhyPSAm6KWzomPcDzPKoREKFY5zOFI7jtuQPAQHAIixghuZcQWxRaNaL55D67w5OoTJiQkPyHDYNzaBI2EtlSZHNN+u6SppprIVgigWM4r4yI2uGmcyJI3KklxKAJJQCawAmfuRO78iCYpwmA7knkSCSPOSvmGQFJlmUUciHGkCiPDIiRyFIahOR2LmJT2YJuRxWn5haSjkvUWjnB6dSvNo94VZY-nqLJNwyToX6AvVwZqmGTU5h5GVYHoI1lJ8zilZemE+sFchyEcAlybYK1qFkk2Bt2XT7mlSFLcosiOPo9KVDoL3Mj8+3hToDIVi+ijnT+YH-vNR4tchpkKNaJyXuYFavmSzLnAQ+TtWoDwOJocXOVNlHUSlfY3dp8SVeSD7tZc+Q1J894yNaeQ9eoOEva8imuEAA */
   id: "swap-ui",
 
   context: {
     error: null,
-    quote: null,
+    quotes: null,
     outcome: null,
   },
 
@@ -72,7 +77,7 @@ export const swapUIMachine = setup({
 
             onDone: {
               target: "quoted",
-              actions: assign({ quote: ({ event }) => event.output }),
+              actions: assign({ quotes: ({ event }) => event.output }),
               reenter: true,
             },
 
@@ -102,7 +107,10 @@ export const swapUIMachine = setup({
                 target: "quoting",
                 guard: ({ event }) => event.output,
               },
-              "idle",
+              {
+                target: "idle",
+                actions: "updateUIAmountOut",
+              },
             ],
           },
         },
@@ -114,6 +122,8 @@ export const swapUIMachine = setup({
               reenter: true,
             },
           },
+
+          entry: "updateUIAmountOut",
         },
       },
 

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -1,7 +1,7 @@
 import { quoteMachine } from "@defuse-protocol/swap-facade"
 import { useActor, useSelector } from "@xstate/react"
 import { useEffect, useRef, useState } from "react"
-import { useForm } from "react-hook-form"
+import { useFormContext } from "react-hook-form"
 
 import { ButtonCustom, ButtonSwitch } from "../../../components/Button"
 import { Form } from "../../../components/Form"
@@ -10,7 +10,7 @@ import { WarnBox } from "../../../components/WarnBox"
 import { NEAR_TOKEN_META } from "../../../constants"
 import type { BaseTokenInfo } from "../../../types/base"
 
-type SwapFormValues = {
+export type SwapFormValues = {
   amountIn: string // tokenIn
   amountOut: string // tokenOut
 }
@@ -51,7 +51,7 @@ export const SwapForm = ({
     setValue,
     watch,
     formState: { errors },
-  } = useForm<SwapFormValues>({ reValidateMode: "onSubmit" })
+  } = useFormContext<SwapFormValues>()
 
   const allowableNearAmountRef = useRef<null | string>(null)
 

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -1,5 +1,3 @@
-import { quoteMachine } from "@defuse-protocol/swap-facade"
-import { useActor, useSelector } from "@xstate/react"
 import { useEffect, useRef, useState } from "react"
 import { useFormContext } from "react-hook-form"
 
@@ -50,7 +48,6 @@ export const SwapForm = ({
     handleSubmit,
     register,
     setValue,
-    watch,
     formState: { errors },
   } = useFormContext<SwapFormValues>()
 
@@ -61,13 +58,6 @@ export const SwapForm = ({
   const [errorSelectTokenIn, setErrorSelectTokenIn] = useState("")
   const [errorSelectTokenOut, setErrorSelectTokenOut] = useState("")
   const [errorMsg, setErrorMsg] = useState<ErrorEnum>()
-
-  const [state, send, actorRef] = useActor(quoteMachine, {
-    input: {
-      assetIn: selectTokenIn?.defuseAssetId,
-      assetOut: selectTokenOut?.defuseAssetId,
-    },
-  })
 
   const handleSwitch = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
@@ -81,36 +71,6 @@ export const SwapForm = ({
       console.log(state.value, state.context)
     })
   }, [swapUIActorRef])
-
-  useEffect(() => {
-    const subscription = watch((value, { name }) => {
-      if (name === "amountIn" && selectTokenIn && selectTokenOut) {
-        send({
-          type: "SET_PARAMS",
-          data: {
-            assetIn: selectTokenIn.defuseAssetId,
-            assetOut: selectTokenOut.defuseAssetId,
-            amountIn: String(value.amountIn),
-          },
-        })
-      }
-    })
-    return () => subscription.unsubscribe()
-  }, [watch, selectTokenIn, selectTokenOut, send])
-
-  const quotes = useSelector(actorRef, (state) => state.context.quotes)
-
-  useEffect(() => {
-    if (quotes) {
-      // TODO: amountOut - Find the best quote with the highest estimatedOut value
-      if (quotes.length > 0 && quotes[0]) {
-        setValue(
-          "amountOut",
-          (quotes[0] as unknown as { amountOut: string }).amountOut
-        )
-      }
-    }
-  }, [quotes, setValue])
 
   return (
     <div className="md:max-w-[472px] rounded-[1rem] p-5 shadow-paper bg-white dark:shadow-paper-dark dark:bg-black-800">

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -9,6 +9,7 @@ import { FieldComboInput } from "../../../components/Form/FieldComboInput"
 import { WarnBox } from "../../../components/WarnBox"
 import { NEAR_TOKEN_META } from "../../../constants"
 import type { BaseTokenInfo } from "../../../types/base"
+import { SwapUIMachineContext } from "./SwapUIMachineProvider"
 
 export type SwapFormValues = {
   amountIn: string // tokenIn
@@ -53,6 +54,8 @@ export const SwapForm = ({
     formState: { errors },
   } = useFormContext<SwapFormValues>()
 
+  const swapUIActorRef = SwapUIMachineContext.useActorRef()
+
   const allowableNearAmountRef = useRef<null | string>(null)
 
   const [errorSelectTokenIn, setErrorSelectTokenIn] = useState("")
@@ -65,7 +68,6 @@ export const SwapForm = ({
       assetOut: selectTokenOut?.defuseAssetId,
     },
   })
-  console.log("LOG: quoteMachine - state", state)
 
   const handleSwitch = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
@@ -73,6 +75,12 @@ export const SwapForm = ({
     setValue("amountOut", "")
     setValue("amountIn", "")
   }
+
+  useEffect(() => {
+    swapUIActorRef.subscribe((state) => {
+      console.log(state.value, state.context)
+    })
+  }, [swapUIActorRef])
 
   useEffect(() => {
     const subscription = watch((value, { name }) => {

--- a/src/features/swap/components/SwapFormProvider.tsx
+++ b/src/features/swap/components/SwapFormProvider.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren } from "react"
+import { FormProvider, useForm } from "react-hook-form"
+import type { SwapFormValues } from "./SwapForm"
+
+type SwapFormProps = PropsWithChildren
+
+export function SwapFormProvider({ children }: SwapFormProps) {
+  const methods = useForm<SwapFormValues>({
+    defaultValues: {
+      amountIn: "",
+      amountOut: "",
+    },
+  })
+
+  return <FormProvider {...methods}>{children}</FormProvider>
+}

--- a/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
@@ -1,0 +1,24 @@
+import { type PropsWithChildren, useEffect } from "react"
+import { useFormContext } from "react-hook-form"
+import type { SwapFormValues } from "./SwapForm"
+import { SwapUIMachineContext } from "./SwapUIMachineProvider"
+
+export function SwapUIMachineFormSyncProvider({ children }: PropsWithChildren) {
+  const { watch } = useFormContext<SwapFormValues>()
+  const actorRef = SwapUIMachineContext.useActorRef()
+
+  useEffect(() => {
+    // When values are set externally, they trigger "watch" callback too.
+    // In order to avoid, unnecessary state updates need to check if the form is changed by user
+    const sub = watch(async (_, { type, name }) => {
+      if (type === "change" && name != null) {
+        actorRef.send({ type: "input" })
+      }
+    })
+    return () => {
+      sub.unsubscribe()
+    }
+  }, [watch, actorRef])
+
+  return <>{children}</>
+}

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -1,15 +1,28 @@
 import { createActorContext } from "@xstate/react"
+import { parseUnits } from "ethers"
 import type { PropsWithChildren } from "react"
 import { useFormContext } from "react-hook-form"
+import { formatUnits } from "viem"
 import { fromPromise } from "xstate"
+import type { BaseTokenInfo } from "../../../types/base"
 import { swapIntentMachine } from "../../machines/swapIntentMachine"
 import { type QuoteTmp, swapUIMachine } from "../../machines/swapUIMachine"
 import type { SwapFormValues } from "./SwapForm"
 
 export const SwapUIMachineContext = createActorContext(swapUIMachine)
 
-export function SwapUIMachineProvider({ children }: PropsWithChildren) {
-  const { trigger } = useFormContext<SwapFormValues>()
+interface SwapUIMachineProviderProps extends PropsWithChildren {
+  assetIn: BaseTokenInfo
+  assetOut: BaseTokenInfo
+}
+
+export function SwapUIMachineProvider({
+  children,
+  assetIn,
+  assetOut,
+}: SwapUIMachineProviderProps) {
+  const { trigger, getValues, setValue, resetField } =
+    useFormContext<SwapFormValues>()
 
   return (
     <SwapUIMachineContext.Provider
@@ -17,15 +30,34 @@ export function SwapUIMachineProvider({ children }: PropsWithChildren) {
         delays: {
           quotePollingInterval: 5000, // temporary increase to 5 sec during development in order to reduce polluting the logs
         },
+        actions: {
+          updateUIAmountOut: ({ context }) => {
+            const quote = context.quotes?.[0]
+            if (quote) {
+              const amountOut = quote.amount_out
+              const amountOutFormatted = formatUnits(
+                BigInt(amountOut),
+                assetOut.decimals
+              )
+              setValue("amountOut", amountOutFormatted)
+            } else {
+              setValue("amountOut", "")
+            }
+          },
+        },
         actors: {
           formValidation: fromPromise(async () => {
             // We validate only `amountIn` and not entire form, because currently `amountOut` is also part of the form
             return trigger("amountIn")
           }),
-          queryQuote: fromPromise(async (): Promise<QuoteTmp> => {
-            console.log("queryQuote...")
-            await new Promise((resolve) => setTimeout(resolve, 1500))
-            throw new Error("not implemented")
+          queryQuote: fromPromise(async (): Promise<QuoteTmp[]> => {
+            const { amountIn } = getValues()
+
+            // todo: may throw if too many decimals, need to write safe parser
+            const amountInParsed = parseUnits(amountIn, assetIn.decimals)
+
+            // todo: replace with real quote
+            return [{ amount_out: ((amountInParsed * 3n) / 2n).toString() }]
           }),
           // @ts-expect-error For some reason `swapIntentMachine` does not satisfy `swap` actor type
           swap: swapIntentMachine,

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -1,0 +1,38 @@
+import { createActorContext } from "@xstate/react"
+import type { PropsWithChildren } from "react"
+import { useFormContext } from "react-hook-form"
+import { fromPromise } from "xstate"
+import { swapIntentMachine } from "../../machines/swapIntentMachine"
+import { type QuoteTmp, swapUIMachine } from "../../machines/swapUIMachine"
+import type { SwapFormValues } from "./SwapForm"
+
+export const SwapUIMachineContext = createActorContext(swapUIMachine)
+
+export function SwapUIMachineProvider({ children }: PropsWithChildren) {
+  const { trigger } = useFormContext<SwapFormValues>()
+
+  return (
+    <SwapUIMachineContext.Provider
+      logic={swapUIMachine.provide({
+        delays: {
+          quotePollingInterval: 5000, // temporary increase to 5 sec during development in order to reduce polluting the logs
+        },
+        actors: {
+          formValidation: fromPromise(async () => {
+            // We validate only `amountIn` and not entire form, because currently `amountOut` is also part of the form
+            return trigger("amountIn")
+          }),
+          queryQuote: fromPromise(async (): Promise<QuoteTmp> => {
+            console.log("queryQuote...")
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+            throw new Error("not implemented")
+          }),
+          // @ts-expect-error For some reason `swapIntentMachine` does not satisfy `swap` actor type
+          swap: swapIntentMachine,
+        },
+      })}
+    >
+      {children}
+    </SwapUIMachineContext.Provider>
+  )
+}

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -10,6 +10,8 @@ import type { ModalSelectAssetsPayload } from "src/components/Modal/ModalSelectA
 import { useTokensStore } from "../../../providers/TokensStoreProvider"
 import { type OnSubmitValues, SwapForm } from "./SwapForm"
 import { SwapFormProvider } from "./SwapFormProvider"
+import { SwapUIMachineFormSyncProvider } from "./SwapUIMachineFormSyncProvider"
+import { SwapUIMachineProvider } from "./SwapUIMachineProvider"
 
 export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
   const { updateTokens } = useTokensStore((state) => state)
@@ -81,14 +83,18 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
   return (
     <SwapWidgetProvider>
       <SwapFormProvider>
-        <SwapForm
-          selectTokenIn={selectTokenIn ?? tokenList[0]}
-          selectTokenOut={selectTokenOut ?? tokenList[1]}
-          onSwitch={handleSwitch}
-          onSubmit={handleSubmit}
-          onSelect={handleSelect}
-          isFetching={false}
-        />
+        <SwapUIMachineProvider>
+          <SwapUIMachineFormSyncProvider>
+            <SwapForm
+              selectTokenIn={selectTokenIn ?? tokenList[0]}
+              selectTokenOut={selectTokenOut ?? tokenList[1]}
+              onSwitch={handleSwitch}
+              onSubmit={handleSubmit}
+              onSelect={handleSelect}
+              isFetching={false}
+            />
+          </SwapUIMachineFormSyncProvider>
+        </SwapUIMachineProvider>
       </SwapFormProvider>
     </SwapWidgetProvider>
   )

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -1,4 +1,3 @@
-import type React from "react"
 import { useEffect, useState } from "react"
 
 import { SwapWidgetProvider } from "../../../providers"
@@ -10,6 +9,7 @@ import type { BaseTokenInfo } from "../../../types/base"
 import type { ModalSelectAssetsPayload } from "src/components/Modal/ModalSelectAssets"
 import { useTokensStore } from "../../../providers/TokensStoreProvider"
 import { type OnSubmitValues, SwapForm } from "./SwapForm"
+import { SwapFormProvider } from "./SwapFormProvider"
 
 export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
   const { updateTokens } = useTokensStore((state) => state)
@@ -80,14 +80,16 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
 
   return (
     <SwapWidgetProvider>
-      <SwapForm
-        selectTokenIn={selectTokenIn ?? tokenList[0]}
-        selectTokenOut={selectTokenOut ?? tokenList[1]}
-        onSwitch={handleSwitch}
-        onSubmit={handleSubmit}
-        onSelect={handleSelect}
-        isFetching={false}
-      />
+      <SwapFormProvider>
+        <SwapForm
+          selectTokenIn={selectTokenIn ?? tokenList[0]}
+          selectTokenOut={selectTokenOut ?? tokenList[1]}
+          onSwitch={handleSwitch}
+          onSubmit={handleSubmit}
+          onSelect={handleSelect}
+          isFetching={false}
+        />
+      </SwapFormProvider>
     </SwapWidgetProvider>
   )
 }

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -18,12 +18,14 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
 
   assert(tokenList.length > 2, "Token list must have at least 2 tokens")
 
-  const [selectTokenIn, setSelectTokenIn] = useState<BaseTokenInfo | undefined>(
-    tokenList[0]
+  const [selectTokenIn, setSelectTokenIn] = useState<BaseTokenInfo>(
+    // biome-ignore lint/style/noNonNullAssertion: tokenList[0] is guaranteed to be defined
+    tokenList[0]!
   )
-  const [selectTokenOut, setSelectTokenOut] = useState<
-    BaseTokenInfo | undefined
-  >(tokenList[1])
+  const [selectTokenOut, setSelectTokenOut] = useState<BaseTokenInfo>(
+    // biome-ignore lint/style/noNonNullAssertion: tokenList[1] is guaranteed to be defined
+    tokenList[1]!
+  )
 
   const { setModalType, payload, onCloseModal } = useModalStore(
     (state) => state
@@ -86,8 +88,8 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
         <SwapUIMachineProvider>
           <SwapUIMachineFormSyncProvider>
             <SwapForm
-              selectTokenIn={selectTokenIn ?? tokenList[0]}
-              selectTokenOut={selectTokenOut ?? tokenList[1]}
+              selectTokenIn={selectTokenIn}
+              selectTokenOut={selectTokenOut}
               onSwitch={handleSwitch}
               onSubmit={handleSubmit}
               onSelect={handleSelect}

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -85,7 +85,10 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
   return (
     <SwapWidgetProvider>
       <SwapFormProvider>
-        <SwapUIMachineProvider>
+        <SwapUIMachineProvider
+          assetIn={selectTokenIn}
+          assetOut={selectTokenOut}
+        >
           <SwapUIMachineFormSyncProvider>
             <SwapForm
               selectTokenIn={selectTokenIn}


### PR DESCRIPTION
# Summary
The main point of PR is integrate the swap UI machine into the form.

# Changes
PR:
- enables widget to use swap UI machine
- replaces previous quoting mechanism
- does small refactoring

Currently we have multiple sources of truth: `amountIn` in form, selected assets in `useState` and duplicated data in state machines. All these data live in different places (files, components); they synchronize via observing variables and executing useEffects in cascade. New providers try to address this issue of synchornization and streamline the flow of data. 