### PR TITLE
chore: add script that generates defuse-contract-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 
 # Local build
 *.tgz
+
+# Generated types
+src/types/defuse-contracts-types.d.ts

--- a/artifacts/defuse_contract_abi.json
+++ b/artifacts/defuse_contract_abi.json
@@ -1,0 +1,2790 @@
+{
+  "schema_version": "0.4.0",
+  "metadata": {
+    "name": "defuse-contract",
+    "version": "0.1.0",
+    "build": {
+      "compiler": "rustc 1.80.0",
+      "builder": "cargo-near cargo-near-build 0.1.1"
+    },
+    "wasm_hash": "D7bewhihuYy4puokTW8MrAnFAJ4C3Daz2kg7dbUYhTm9"
+  },
+  "body": {
+    "functions": [
+      {
+        "name": "acl_add_admin",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "acl_add_super_admin",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "acl_get_admins",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "skip",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            {
+              "name": "limit",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AccountId"
+            }
+          }
+        }
+      },
+      {
+        "name": "acl_get_grantees",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "skip",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            {
+              "name": "limit",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AccountId"
+            }
+          }
+        }
+      },
+      {
+        "name": "acl_get_permissioned_accounts",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PermissionedAccounts"
+          }
+        }
+      },
+      {
+        "name": "acl_get_super_admins",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "skip",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            {
+              "name": "limit",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AccountId"
+            }
+          }
+        }
+      },
+      {
+        "name": "acl_grant_role",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "acl_has_any_role",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "roles",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_has_role",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_init_super_admin",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_is_admin",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_is_super_admin",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_renounce_admin",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_renounce_role",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "acl_revoke_admin",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "acl_revoke_role",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "role",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "acl_revoke_super_admin",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "acl_role_variants",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "name": "acl_storage_prefix",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      {
+        "name": "acl_transfer_super_admin",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "add_full_access_key",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/Promise"
+          }
+        }
+      },
+      {
+        "name": "add_public_key",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "add_relayer_key",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/Promise"
+          }
+        }
+      },
+      {
+        "name": "contract_source_metadata",
+        "kind": "view"
+      },
+      {
+        "name": "delete_key",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/Promise"
+          }
+        }
+      },
+      {
+        "name": "delete_relayer_key",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/Promise"
+          }
+        }
+      },
+      {
+        "name": "execute_intents",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "intents",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/SignedPayload_for_MultiStandardPayload"
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "null"
+          }
+        }
+      },
+      {
+        "name": "fee",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/Pips"
+          }
+        }
+      },
+      {
+        "name": "fee_collector",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/AccountId"
+          }
+        }
+      },
+      {
+        "name": "ft_on_transfer",
+        "doc": " Deposit fungible tokens.\n\n `msg` contains [`AccountId`] of the internal recipient.\n Empty `msg` means deposit to `sender_id`",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "sender_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "amount",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueString"
+          }
+        }
+      },
+      {
+        "name": "ft_resolve_withdraw",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "sender_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "amount",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "is_call",
+              "type_schema": {
+                "type": "boolean"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "ft_withdraw",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "amount",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueString"
+          }
+        }
+      },
+      {
+        "name": "has_public_key",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "invalidate_nonces",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "nonces",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "null"
+          }
+        }
+      },
+      {
+        "name": "is_nonce_used",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "nonce",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "mt_balance_of",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "name": "mt_batch_balance_of",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "name": "mt_batch_supply",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "mt_batch_transfer",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "amounts",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "approvals",
+              "type_schema": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": [
+                    {
+                      "$ref": "#/definitions/AccountId"
+                    },
+                    {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "mt_batch_transfer_call",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "amounts",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "approvals",
+              "type_schema": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": [
+                    {
+                      "$ref": "#/definitions/AccountId"
+                    },
+                    {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueArray_of_String"
+          }
+        }
+      },
+      {
+        "name": "mt_on_transfer",
+        "doc": " Deposit multi-tokens.\n\n `msg` contains [`AccountId`] of the internal recipient.\n Empty `msg` means deposit to `sender_id`",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "sender_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "previous_owner_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/AccountId"
+                }
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "amounts",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueArray_of_String"
+          }
+        }
+      },
+      {
+        "name": "mt_resolve_transfer",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "previous_owner_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/AccountId"
+                }
+              }
+            },
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "amounts",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "approvals",
+              "type_schema": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "$ref": "#/definitions/AccountId"
+                      },
+                      {
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "maxItems": 3,
+                    "minItems": 3
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "name": "mt_resolve_withdraw",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "sender_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "amounts",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "is_call",
+              "type_schema": {
+                "type": "boolean"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      {
+        "name": "mt_supply",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      {
+        "name": "mt_token",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Token"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "name": "mt_transfer",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "amount",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "approval",
+              "type_schema": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": [
+                  {
+                    "$ref": "#/definitions/AccountId"
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "mt_transfer_call",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "amount",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "approval",
+              "type_schema": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": [
+                  {
+                    "$ref": "#/definitions/AccountId"
+                  },
+                  {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueArray_of_String"
+          }
+        }
+      },
+      {
+        "name": "mt_withdraw",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_ids",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "amounts",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueArray_of_String"
+          }
+        }
+      },
+      {
+        "name": "new",
+        "kind": "call",
+        "modifiers": [
+          "init"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "fee",
+              "type_schema": {
+                "$ref": "#/definitions/Pips"
+              }
+            },
+            {
+              "name": "fee_collector",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "super_admins",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/AccountId"
+                }
+              }
+            },
+            {
+              "name": "admins",
+              "type_schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AccountId"
+                  }
+                }
+              }
+            },
+            {
+              "name": "grantees",
+              "type_schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AccountId"
+                  }
+                }
+              }
+            },
+            {
+              "name": "staging_duration",
+              "type_schema": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "nft_on_transfer",
+        "doc": " Deposit non-fungible token.\n\n `msg` contains [`AccountId`] of the internal recipient.\n Empty `msg` means deposit to `sender_id`",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "sender_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "previous_owner_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueBoolean"
+          }
+        }
+      },
+      {
+        "name": "nft_resolve_withdraw",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "sender_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "is_call",
+              "type_schema": {
+                "type": "boolean"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "nft_withdraw",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "token",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "receiver_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            {
+              "name": "token_id",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "memo",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "name": "msg",
+              "type_schema": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueBoolean"
+          }
+        }
+      },
+      {
+        "name": "pa_all_paused",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        }
+      },
+      {
+        "name": "pa_is_paused",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "pa_pause_feature",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "pa_storage_key",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      {
+        "name": "pa_unpause_feature",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "name": "public_keys_of",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        }
+      },
+      {
+        "name": "remove_public_key",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "public_key",
+              "type_schema": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "set_fee",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "fee",
+              "type_schema": {
+                "$ref": "#/definitions/Pips"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "set_fee_collector",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "fee_collector",
+              "type_schema": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "simulate_intents",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "intents",
+              "type_schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/DefuseMessage_for_DefuseIntents"
+                }
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "null"
+          }
+        }
+      },
+      {
+        "name": "up_apply_update_staging_duration",
+        "kind": "call"
+      },
+      {
+        "name": "up_deploy_code",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "hash",
+              "type_schema": {
+                "type": "string"
+              }
+            },
+            {
+              "name": "function_call_args",
+              "type_schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/FunctionCallArgs"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/Promise"
+          }
+        }
+      },
+      {
+        "name": "up_get_delay_status",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/UpgradableDurationStatus"
+          }
+        }
+      },
+      {
+        "name": "up_init_staging_duration",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "staging_duration",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "up_stage_code",
+        "kind": "call",
+        "params": {
+          "serialization_type": "borsh",
+          "args": [
+            {
+              "name": "code",
+              "type_schema": {
+                "declaration": "Vec<u8>",
+                "definitions": {
+                  "Vec<u8>": {
+                    "Sequence": {
+                      "length_width": 4,
+                      "length_range": {
+                        "start": 0,
+                        "end": 4294967295
+                      },
+                      "elements": "u8"
+                    }
+                  },
+                  "u8": {
+                    "Primitive": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "up_stage_update_staging_duration",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "staging_duration",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "up_staged_code",
+        "kind": "view",
+        "result": {
+          "serialization_type": "borsh",
+          "type_schema": {
+            "declaration": "Option<Vec<u8>>",
+            "definitions": {
+              "()": {
+                "Primitive": 0
+              },
+              "Option<Vec<u8>>": {
+                "Enum": {
+                  "tag_width": 1,
+                  "variants": [
+                    [
+                      0,
+                      "None",
+                      "()"
+                    ],
+                    [
+                      1,
+                      "Some",
+                      "Vec<u8>"
+                    ]
+                  ]
+                }
+              },
+              "Vec<u8>": {
+                "Sequence": {
+                  "length_width": 4,
+                  "length_range": {
+                    "start": 0,
+                    "end": 4294967295
+                  },
+                  "elements": "u8"
+                }
+              },
+              "u8": {
+                "Primitive": 1
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "up_staged_code_hash",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "maxItems": 32,
+            "minItems": 32
+          }
+        }
+      },
+      {
+        "name": "up_storage_prefix",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    ],
+    "root_schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string",
+      "definitions": {
+        "AccountId": {
+          "description": "NEAR Account Identifier.\n\nThis is a unique, syntactically valid, human-readable account identifier on the NEAR network.\n\n[See the crate-level docs for information about validation.](index.html#account-id-rules)\n\nAlso see [Error kind precedence](AccountId#error-kind-precedence).\n\n## Examples\n\n``` use near_account_id::AccountId;\n\nlet alice: AccountId = \"alice.near\".parse().unwrap();\n\nassert!(\"ƒelicia.near\".parse::<AccountId>().is_err()); // (ƒ is not f) ```",
+          "type": "string"
+        },
+        "Deadline": {
+          "oneOf": [
+            {
+              "description": "UNIX Timestamp in seconds",
+              "type": "object",
+              "required": [
+                "timestamp"
+              ],
+              "properties": {
+                "timestamp": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Block number",
+              "type": "object",
+              "required": [
+                "block_number"
+              ],
+              "properties": {
+                "block_number": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "DefuseMessage_for_DefuseIntents": {
+          "type": "object",
+          "required": [
+            "deadline",
+            "signer_id"
+          ],
+          "properties": {
+            "deadline": {
+              "$ref": "#/definitions/Deadline"
+            },
+            "intents": {
+              "description": "Sequence of intents to execute in given order. Empty list is also a valid sequence, i.e. it doesn't do anything, but still invalidates the [`nonce`](crate::nep413::Nep413Payload::nonce) for the signer",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Intent"
+              }
+            },
+            "signer_id": {
+              "$ref": "#/definitions/AccountId"
+            }
+          }
+        },
+        "FunctionCallArgs": {
+          "description": "Specifies a function call to be appended to the actions of a promise via [`near_sdk::Promise::function_call`]).",
+          "type": "object",
+          "required": [
+            "amount",
+            "arguments",
+            "function_name",
+            "gas"
+          ],
+          "properties": {
+            "amount": {
+              "description": "The amount of tokens to transfer to the receiver.",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "The arguments to pass to the function.",
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            },
+            "function_name": {
+              "description": "The name of the function to call.",
+              "type": "string"
+            },
+            "gas": {
+              "description": "The gas limit for the function call.",
+              "type": "string"
+            }
+          }
+        },
+        "Intent": {
+          "oneOf": [
+            {
+              "description": "Add public key to the signer account",
+              "type": "object",
+              "required": [
+                "intent",
+                "public_key"
+              ],
+              "properties": {
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "add_public_key"
+                  ]
+                },
+                "public_key": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "description": "Remove public key to the signer account",
+              "type": "object",
+              "required": [
+                "intent",
+                "public_key"
+              ],
+              "properties": {
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "remove_public_key"
+                  ]
+                },
+                "public_key": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "description": "Invalidate given nonces TODO: error?",
+              "type": "object",
+              "required": [
+                "intent",
+                "nonces"
+              ],
+              "properties": {
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "invalidate_nonces"
+                  ]
+                },
+                "nonces": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "amounts",
+                "intent",
+                "receiver_id",
+                "token_ids"
+              ],
+              "properties": {
+                "amounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "mt_batch_transfer"
+                  ]
+                },
+                "memo": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "receiver_id": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "amounts",
+                "intent",
+                "msg",
+                "receiver_id",
+                "token_ids"
+              ],
+              "properties": {
+                "amounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "gas_for_mt_on_transfer": {
+                  "description": "Optional static gas to attach to `mt_on_transfer`",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "mt_batch_transfer_call"
+                  ]
+                },
+                "memo": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "`msg` to pass in `mt_on_transfer`",
+                  "type": "string"
+                },
+                "receiver_id": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "amount",
+                "intent",
+                "receiver_id",
+                "token"
+              ],
+              "properties": {
+                "amount": {
+                  "type": "string"
+                },
+                "gas": {
+                  "description": "Optional static gas to attach to `ft_transfer` or `ft_transfer_call`",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "ft_withdraw"
+                  ]
+                },
+                "memo": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "Message to pass to `ft_transfer_call`. Otherwise, `ft_transfer` will be used",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "receiver_id": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token": {
+                  "$ref": "#/definitions/AccountId"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "intent",
+                "receiver_id",
+                "token",
+                "token_id"
+              ],
+              "properties": {
+                "gas": {
+                  "description": "Optional static gas to attach to `nft_transfer` or `nft_transfer_call`",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "nft_withdraw"
+                  ]
+                },
+                "memo": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "Message to pass to `nft_transfer_call`. Otherwise, `nft_transfer` will be used",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "receiver_id": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token_id": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "amounts",
+                "intent",
+                "receiver_id",
+                "token",
+                "token_ids"
+              ],
+              "properties": {
+                "amounts": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "gas": {
+                  "description": "Optional static gas to attach to `mt_batch_transfer` or `mt_batch_transfer_call`",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "mt_withdraw"
+                  ]
+                },
+                "memo": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "msg": {
+                  "description": "Message to pass to `mt_batch_transfer_call`. Otherwise, `mt_batch_transfer` will be used",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "receiver_id": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token": {
+                  "$ref": "#/definitions/AccountId"
+                },
+                "token_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "diff",
+                "intent"
+              ],
+              "properties": {
+                "diff": {
+                  "$ref": "#/definitions/TokenAmounts_for_int128"
+                },
+                "intent": {
+                  "type": "string",
+                  "enum": [
+                    "token_diff"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "PermissionedAccounts": {
+          "description": "Collects super admin accounts and accounts that have been granted permissions defined by `AccessControlRole`.\n\n# Data structure\n\nAssume `AccessControlRole` is derived for the following enum, which is then passed as `role` attribute to `AccessControllable`.\n\n```rust pub enum Role { PauseManager, UnpauseManager, } ```\n\nThen the returned data has the following structure:\n\n```ignore PermissionedAccounts { super_admins: vec![\"acc1.near\", \"acc2.near\"], roles: HashMap::from([ (\"PauseManager\", PermissionedAccountsPerRole { admins: vec![\"acc3.near\", \"acc4.near\"], grantees: vec![\"acc5.near\", \"acc6.near\"], }), (\"UnpauseManager\", PermissionedAccountsPerRole { admins: vec![\"acc7.near\", \"acc8.near\"], grantees: vec![\"acc9.near\", \"acc10.near\"], }), ]) } ```\n\n# Uniqueness and ordering\n\nAccount ids returned in vectors are unique but not ordered.",
+          "type": "object",
+          "required": [
+            "roles",
+            "super_admins"
+          ],
+          "properties": {
+            "roles": {
+              "description": "The admins and grantees of all roles.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/PermissionedAccountsPerRole"
+              }
+            },
+            "super_admins": {
+              "description": "The accounts that have super admin permissions.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          }
+        },
+        "PermissionedAccountsPerRole": {
+          "description": "Collects all admins and grantees of a role.\n\n# Uniqueness and ordering\n\nAccount ids returned in vectors are unique but not ordered.",
+          "type": "object",
+          "required": [
+            "admins",
+            "grantees"
+          ],
+          "properties": {
+            "admins": {
+              "description": "The accounts that have admin permissions for the role.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccountId"
+              }
+            },
+            "grantees": {
+              "description": "The accounts that have been granted the role.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccountId"
+              }
+            }
+          }
+        },
+        "Pips": {
+          "description": "1 pip == 1/100th of bip == 0.0001%",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "Promise": true,
+        "PromiseOrValueArray_of_String": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "PromiseOrValueBoolean": {
+          "type": "boolean"
+        },
+        "PromiseOrValueString": {
+          "type": "string"
+        },
+        "SignedPayload_for_MultiStandardPayload": {
+          "type": "object",
+          "anyOf": [
+            {
+              "type": "object",
+              "required": [
+                "public_key",
+                "signature"
+              ],
+              "properties": {
+                "public_key": {
+                  "type": "string"
+                },
+                "signature": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "signature"
+              ],
+              "properties": {
+                "signature": {
+                  "description": "Concatenated `r`, `s` and `v`",
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "message",
+                "nonce",
+                "recipient",
+                "standard"
+              ],
+              "properties": {
+                "callback_url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nonce": {
+                  "type": "string"
+                },
+                "recipient": {
+                  "type": "string"
+                },
+                "standard": {
+                  "type": "string",
+                  "enum": [
+                    "nep413"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "Token": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "owner_id": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AccountId"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        },
+        "TokenAmounts_for_int128": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "UpgradableDurationStatus": {
+          "type": "object",
+          "properties": {
+            "new_staging_duration": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "new_staging_duration_timestamp": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "staging_duration": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "staging_timestamp": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
   "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
-  "files": { "ignoreUnknown": false, "ignore": ["dist/*", "package.json"] },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["dist/*", "artifacts/*", "package.json"]
+  },
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit",
     "check": "biome check",
     "format": "biome format --write src/",
-    "prepare": "husky"
+    "prepare": "husky && ./scripts/gen-defuse-types.sh"
   },
   "dependencies": {
     "@defuse-protocol/swap-facade": "^1.0.3",

--- a/scripts/gen-defuse-types.sh
+++ b/scripts/gen-defuse-types.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+existing_json="./artifacts/defuse_contract_abi.json"
+type_output="./src/types/defuse-contracts-types.d.ts"
+
+jq_filter='.body.root_schema | del(.type) | .title = "Defuse Contract ABI"'
+
+# Ensure the output directory exists
+mkdir -p "$(dirname "$type_output")"
+
+# Step 1: Check if the JSON file exists; if not, download and extract it in memory
+if [ ! -f "$existing_json" ]; then
+  echo "JSON file not found. Downloading and processing artifact in memory..."
+
+  # Download and unzip the artifact, then apply jq filter in memory
+  schema=$(curl -L "https://github.com/defuse-protocol/defuse-contracts/actions/runs/11357099231/artifacts/2061097870" \
+    | unzip -p - "defuse_contract_abi.json" \
+    | jq "$jq_filter")
+else
+  echo "JSON file found. Processing existing file..."
+
+  # Apply jq filter to the existing file
+  schema=$(jq "$jq_filter" "$existing_json")
+fi
+
+# Step 2: Pass the modified JSON directly to json-schema-to-typescript
+echo "$schema" | npx json-schema-to-typescript -o "$type_output" --unreachableDefinitions
+# Prettify the output
+yarn -s biome format "$type_output" --write
+
+echo "Types generated successfully in "$type_output""


### PR DESCRIPTION
PR adds a bash script that runs during `yarn install` to generate TypeScript types used in `defuse-contracts`. Currently, the script uses a hardcoded JSON Schema file because the contracts repository is private, so the artifacts cannot be easily accessed. In the future, this script will be updated to fetch the JSON Schema directly from the release page of `defuse-contracts`.

<details><summary>Generated defuse-contracts-types.d.ts</summary>
<p>

```ts
/* eslint-disable */
/**
 * This file was automatically generated by json-schema-to-typescript.
 * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
 * and run json-schema-to-typescript to regenerate this file.
 */

/**
 * NEAR Account Identifier.
 *
 * This is a unique, syntactically valid, human-readable account identifier on the NEAR network.
 *
 * [See the crate-level docs for information about validation.](index.html#account-id-rules)
 *
 * Also see [Error kind precedence](AccountId#error-kind-precedence).
 *
 * ## Examples
 *
 * ``` use near_account_id::AccountId;
 *
 * let alice: AccountId = "alice.near".parse().unwrap();
 *
 * assert!("ƒelicia.near".parse::<AccountId>().is_err()); // (ƒ is not f) ```
 *
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "AccountId".
 */
export type AccountId = string
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "Deadline".
 */
export type Deadline =
  | {
      timestamp: number
    }
  | {
      block_number: number
    }
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "Intent".
 */
export type Intent =
  | {
      intent: "add_public_key"
      public_key: string
      [k: string]: unknown
    }
  | {
      intent: "remove_public_key"
      public_key: string
      [k: string]: unknown
    }
  | {
      intent: "invalidate_nonces"
      nonces: string[]
      [k: string]: unknown
    }
  | {
      amounts: string[]
      intent: "mt_batch_transfer"
      memo?: string | null
      receiver_id: AccountId
      token_ids: string[]
      [k: string]: unknown
    }
  | {
      amounts: string[]
      /**
       * Optional static gas to attach to `mt_on_transfer`
       */
      gas_for_mt_on_transfer?: string | null
      intent: "mt_batch_transfer_call"
      memo?: string | null
      /**
       * `msg` to pass in `mt_on_transfer`
       */
      msg: string
      receiver_id: AccountId
      token_ids: string[]
      [k: string]: unknown
    }
  | {
      amount: string
      /**
       * Optional static gas to attach to `ft_transfer` or `ft_transfer_call`
       */
      gas?: string | null
      intent: "ft_withdraw"
      memo?: string | null
      /**
       * Message to pass to `ft_transfer_call`. Otherwise, `ft_transfer` will be used
       */
      msg?: string | null
      receiver_id: AccountId
      token: AccountId
      [k: string]: unknown
    }
  | {
      /**
       * Optional static gas to attach to `nft_transfer` or `nft_transfer_call`
       */
      gas?: string | null
      intent: "nft_withdraw"
      memo?: string | null
      /**
       * Message to pass to `nft_transfer_call`. Otherwise, `nft_transfer` will be used
       */
      msg?: string | null
      receiver_id: AccountId
      token: AccountId
      token_id: string
      [k: string]: unknown
    }
  | {
      amounts: string[]
      /**
       * Optional static gas to attach to `mt_batch_transfer` or `mt_batch_transfer_call`
       */
      gas?: string | null
      intent: "mt_withdraw"
      memo?: string | null
      /**
       * Message to pass to `mt_batch_transfer_call`. Otherwise, `mt_batch_transfer` will be used
       */
      msg?: string | null
      receiver_id: AccountId
      token: AccountId
      token_ids: string[]
      [k: string]: unknown
    }
  | {
      diff: TokenAmountsForInt128
      intent: "token_diff"
      [k: string]: unknown
    }
/**
 * 1 pip == 1/100th of bip == 0.0001%
 *
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "Pips".
 */
export type Pips = number
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "PromiseOrValueArray_of_String".
 */
export type PromiseOrValueArrayOf_String = string[]
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "PromiseOrValueBoolean".
 */
export type PromiseOrValueBoolean = boolean
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "PromiseOrValueString".
 */
export type PromiseOrValueString = string
export type SignedPayloadFor_MultiStandardPayload =
  | {
      public_key: string
      signature: string
      [k: string]: unknown
    }
  | {
      /**
       * Concatenated `r`, `s` and `v`
       */
      signature: string
      [k: string]: unknown
    }
export type SignedPayloadFor_MultiStandardPayload1 = {
  callback_url?: string | null
  message: string
  nonce: string
  recipient: string
  standard: "nep413"
  [k: string]: unknown
}

export interface DefuseContractABI {
  [k: string]: unknown
}
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "DefuseMessage_for_DefuseIntents".
 */
export interface DefuseMessageFor_DefuseIntents {
  deadline: Deadline
  /**
   * Sequence of intents to execute in given order. Empty list is also a valid sequence, i.e. it doesn't do anything, but still invalidates the [`nonce`](crate::nep413::Nep413Payload::nonce) for the signer
   */
  intents?: Intent[]
  signer_id: AccountId
  [k: string]: unknown
}
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "TokenAmounts_for_int128".
 */
export interface TokenAmountsForInt128 {
  [k: string]: string
}
/**
 * Specifies a function call to be appended to the actions of a promise via [`near_sdk::Promise::function_call`]).
 *
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "FunctionCallArgs".
 */
export interface FunctionCallArgs {
  /**
   * The amount of tokens to transfer to the receiver.
   */
  amount: string
  /**
   * The arguments to pass to the function.
   */
  arguments: number[]
  /**
   * The name of the function to call.
   */
  function_name: string
  /**
   * The gas limit for the function call.
   */
  gas: string
  [k: string]: unknown
}
/**
 * Collects super admin accounts and accounts that have been granted permissions defined by `AccessControlRole`.
 *
 * # Data structure
 *
 * Assume `AccessControlRole` is derived for the following enum, which is then passed as `role` attribute to `AccessControllable`.
 *
 * ```rust pub enum Role { PauseManager, UnpauseManager, } ```
 *
 * Then the returned data has the following structure:
 *
 * ```ignore PermissionedAccounts { super_admins: vec!["acc1.near", "acc2.near"], roles: HashMap::from([ ("PauseManager", PermissionedAccountsPerRole { admins: vec!["acc3.near", "acc4.near"], grantees: vec!["acc5.near", "acc6.near"], }), ("UnpauseManager", PermissionedAccountsPerRole { admins: vec!["acc7.near", "acc8.near"], grantees: vec!["acc9.near", "acc10.near"], }), ]) } ```
 *
 * # Uniqueness and ordering
 *
 * Account ids returned in vectors are unique but not ordered.
 *
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "PermissionedAccounts".
 */
export interface PermissionedAccounts {
  /**
   * The admins and grantees of all roles.
   */
  roles: {
    [k: string]: PermissionedAccountsPerRole
  }
  /**
   * The accounts that have super admin permissions.
   */
  super_admins: AccountId[]
  [k: string]: unknown
}
/**
 * Collects all admins and grantees of a role.
 *
 * # Uniqueness and ordering
 *
 * Account ids returned in vectors are unique but not ordered.
 *
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "PermissionedAccountsPerRole".
 */
export interface PermissionedAccountsPerRole {
  /**
   * The accounts that have admin permissions for the role.
   */
  admins: AccountId[]
  /**
   * The accounts that have been granted the role.
   */
  grantees: AccountId[]
  [k: string]: unknown
}
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "Token".
 */
export interface Token {
  owner_id?: AccountId | null
  token_id: string
  [k: string]: unknown
}
/**
 * This interface was referenced by `DefuseContractABI`'s JSON-Schema
 * via the `definition` "UpgradableDurationStatus".
 */
export interface UpgradableDurationStatus {
  new_staging_duration?: number | null
  new_staging_duration_timestamp?: number | null
  staging_duration?: number | null
  staging_timestamp?: number | null
  [k: string]: unknown
}

```

</p>
</details> 