### PR TITLE
feat(SwapWidget)!: Add swap message generation

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,7 +1,9 @@
 import type { Settings } from "../types"
 
-let settings: Settings = {
+export let settings: Settings = {
   providerIds: [],
+  defuseContractId: "defuse.near",
+  swapExpirySec: 600, // 10 minutes
 }
 
 export const getSettings = (): Settings => settings

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -101,10 +101,10 @@ export const swapIntentMachine = setup({
 
         input: () => {
           return makeSwapMessage({
-            tokenDiff: {
-              NEAR: "100",
-              USDC: "-100",
-            },
+            tokenDiff: [
+              ["NEAR", 100n],
+              ["USDC", -100n],
+            ],
             signerId: "signer.near",
             recipient: settings.defuseContractId,
             deadlineTimestamp:

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -1,6 +1,7 @@
 import { quoteMachine } from "@defuse-protocol/swap-facade"
 import type { SolverQuote } from "@defuse-protocol/swap-facade/dist/interfaces/swap-machine.in.interface"
 import { type ActorRefFrom, assign, fromPromise, setup } from "xstate"
+import type { WalletMessage, WalletSignatureResult } from "../../types"
 
 type Context = {
   quoterRef: null | ActorRefFrom<typeof quoteMachine>
@@ -39,9 +40,11 @@ export const swapIntentMachine = setup({
     }),
   },
   actors: {
-    signMessage: fromPromise(async () => {
-      throw new Error("not implemented")
-    }),
+    signMessage: fromPromise(
+      async (_: { input: WalletMessage }): Promise<WalletSignatureResult> => {
+        throw new Error("not implemented")
+      }
+    ),
     broadcastMessage: fromPromise(async () => {
       throw new Error("not implemented")
     }),
@@ -90,6 +93,20 @@ export const swapIntentMachine = setup({
         },
 
         src: "signMessage",
+
+        input: () => {
+          // todo: This is a temporary implementation
+          const message: WalletMessage = {
+            type: "NEP-141",
+            message: {
+              message: "Hey, I want to swap 100 NEAR to 100 USDC",
+              recipient: "defuse.near",
+              nonce: crypto.getRandomValues(new Uint8Array(32)),
+            },
+          }
+
+          return message
+        },
         onDone: "Verifying Intent",
       },
       description:

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -65,9 +65,10 @@ export const swapIntentMachine = setup({
     isIntentRelevant: () => {
       throw new Error("not implemented")
     },
+    isSigned: (_, params: WalletSignatureResult) => params != null,
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6AZRyj3ygGIIB7PME-ANwYGsXZK8BZOLDQwA2gAYAuolAYGvAjiYyQAD0QBOAKwktAZi0BGLQDYNGgOxG9GgBwAaEAE9NewyQt6LFgExaLhl7GGgC+IY6omLiExATkfDS0YABOyQzJJBgANmgEAGbpALYkvFSCsMJiUipyCkp4KuoIWHri4iTiGoa2JgAsGno+Pt5+ji4ItoYmJLb9vb2G4iZL2oZhEejY+ESkAEJpaBAAxmiwinhQAAQAkjGE9Ews7Fw8xBDllWAS0kggtTiKZS-JoDEg+QwWXpaXrDXy2TxaMaIQLzEiGXqQwxDTwmWzadYgSJbO5xfYMQ4nM40G4kpKpdKZHL5IolN4fERfaq-f6AhrAxBYCG2MEmEw2VrdHxdXpIhCBbQi9HdCyiiziHwEonRHZxABqKRweSc1NuOto3xq8gB9UamnclhsFg0-RMWlMWh8ssWng6+nBJj8PlxoXChM22tiJH1yUNxouNLNokMP1kVt5toQ-R8YK04gWvQDUJWXqhwu8WZ8NhMFjxmvD20jAHEwARzldTbFLmQCLkAK6wB7MVh4DjcEr1kkkZutk0krs9gj9hDPE6874W7lpm38hAGMHOnzw2y2PR4jHQr0B7M+Nq5p3iY-ojWhrUN0jTtsJzvdvsDxhD54x1fScP1nHV51-ZcRwYVd6nXZNLTqIFQCaPRcRIV09BsaEYWWIY9EvIYwVvcR70fGE6yiN84lA+MO0ICDFwHFI0gybJcgKZJimAnUpxbT96IIRilxXXI4KkDdUyQvkUIFBVXQ0YZbCDWE0JlZxkX0XoSDmAJSPRLw7DCUM8AYCA4BUHjYkQ61kLUAU9F6YVOm6PoBmxXxEQ0hAtFmEgDBsSxOk6bxKOJXiKCoGgbPTHcsFRTovFPcFvB6ExDFlAJhVzMV+g9BZDAhMKI1IABhJg8hwLjIBi7dZLlLDdGwtxhkGKUHG81zhUKiFRX0KZ9D0YrqJIAA5BghIAMQYXs8AgS50hpNg0CyHAIFquymhhbTJjdXws0sCEvVsXz-MLGwT1mUitGGycAEEACN0iIdbN2kjMsEPPQwUWRyzAhKYsOOjR2mGNzK3ELCrBMW7eLJClTgEkkNpk+zmicr10Q0GZxEKtCujaJzYcjaNYzA6y3ts1GmkKnROlMEH0vMDF1S9Nps3RWxxC0AZAeMIaXwnXjRpbFB0k4S4AFF6WSFGPsWUGsV6NTXVdB8vPGboQbBFUs1aKHTGJ99+PJhifyYuWd0hHScNw3GubaDrNYWbH+mPLx1TsAWwiAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6AZRyj3ygGIIB7PME-ANwYGsXZK8BZOLDQwA2gAYAuolAYGvAjiYyQAD0QBWAMwktARj0AOAGziNAFnMB2PQE5xhgDQgAnolv6SVrVavnjAExa5rZ2WgC+4c6omLiExATkfDS0YABOaQxpJBgANmgEAGZZALYkvFSCsMJiUipyCkp4KuoIWMHmJAHmhuJaQeZa4uLG-s5uCIZ6ViTGJhrdvUNWJpHR6Nj4RKQAQploEADGaLCKeFAABACS8YT0TCzsXDzEEFU1YBLSSCANOIrKH6tDxdabmCwBXwBQzeDTjRB6DokPTWcx6AKQrRzWwaNYgGKbW6JPYMA7HU40a5E1IZLI5fJFUrlV7vESfOo-P4A5pAxBYaaGLrGYxaDziIwBULmeEIRE4oUooxWYVWcQBPEEuLbRIANXSOEKLkpN21tC+9Xk-yaLXcehItm8DtsIWMGg0roCMr04m8JDM-T0gQW2I1Gy1CRIerSBqN5ypptEem+skt3JtCBCAS6GnEaP83RzxlsXvBgt8maCtmMK1sodiWwjAHEwAQzpcTQkLmQCAUAK6we7MVh4DjccphhukZut41Ers9gj9hBPY7cr7mzmp628hBaDRdZ3QlaGLSGZ1WCxewJZgLDHNWeyGKbmdVRfETokkadt+Od7t9gdGCHJ4x01SdEm-WdtXnADlxHBhVyadckwtRpAVAVosUFV0tFFCwX1MDEtCvDEujvH1H2fV91nrT9ILjDtCBgxcB3STJsjyApijSMowLolsf0YghmKXFcCiQqQNxTNCeQwvl5VdWxIUMAJAl8LFpVcBFtE6EJrG9GxBgfQw60JbUkioFIgMeeDQL4VkxBQzcZPTLBumMWYAg0FE8O8cVjBlDw7W8Xx3WmWxbCfWs8TwBgIDgFQ+O1VCrXQtQ+VFG8ej6AYhhGMYtIQDRDE6PdzGGJ9VNzUVTPDUgKEs84UrTHcsEsP0PG8FTphWYU9BlGxBULYIcW6Axplq8CSAAYSYQocB4yBmu3OTZVwkhtBxfRMQxSKvRMQVxuVHDA20CI3ySiMADkGGEgAxBhezwCALiyKk2DQXIcAgZa0taF9OimN0rG6JSHWmfbit0QJBki09yovSbPwAQQAIyyIgfuc1LZPStpoR0AJvWCItpkDXD9vsLplUzIZcIvYwkfMkkyROQSiV+3HWjapxCoMEISF6AwsVCYYeiZiMoxjKCEk59MDH3cQcSLEY7HPNUvWGLMUV6DQgpFPRtAl0grpbFAsk4C4AFFaTSOXWu9cRQW6DTXVdBw4T5s8nchUYlLpnx3WNiCBJlpj-xY+3Vr8EhwUsAjxV6CqSzsWPIpPVVJRPSJIiAA */
   context: ({ input }: { input: Input }) => {
     return {
       quoterRef: null,
@@ -107,8 +108,18 @@ export const swapIntentMachine = setup({
 
           return message
         },
-        onDone: "Verifying Intent",
+        onDone: [
+          {
+            target: "Verifying Intent",
+            guard: { type: "isSigned", params: ({ event }) => event.output },
+          },
+          {
+            target: "Aborted",
+            reenter: true,
+          },
+        ],
       },
+
       description:
         "Generating sign message, wait for the proof of sign (signature).\n\nResult:\n\n- Update \\[context\\] with selected best quote;\n- Callback event to user for signing the solver message by wallet;",
     },

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -41,7 +41,9 @@ export const swapIntentMachine = setup({
   },
   actors: {
     signMessage: fromPromise(
-      async (_: { input: WalletMessage }): Promise<WalletSignatureResult> => {
+      async (_: {
+        input: WalletMessage
+      }): Promise<WalletSignatureResult | null> => {
         throw new Error("not implemented")
       }
     ),
@@ -65,7 +67,7 @@ export const swapIntentMachine = setup({
     isIntentRelevant: () => {
       throw new Error("not implemented")
     },
-    isSigned: (_, params: WalletSignatureResult) => params != null,
+    isSigned: (_, params: WalletSignatureResult | null) => params != null,
   },
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6AZRyj3ygGIIB7PME-ANwYGsXZK8BZOLDQwA2gAYAuolAYGvAjiYyQAD0QBWAMwktARj0AOAGziNAFnMB2PQE5xhgDQgAnolv6SVrVavnjAExa5rZ2WgC+4c6omLiExATkfDS0YABOaQxpJBgANmgEAGZZALYkvFSCsMJiUipyCkp4KuoIWMHmJAHmhuJaQeZa4uLG-s5uCIZ6ViTGJhrdvUNWJpHR6Nj4RKQAQploEADGaLCKeFAABACS8YT0TCzsXDzEEFU1YBLSSCANOIrKH6tDxdabmCwBXwBQzeDTjRB6DokPTWcx6AKQrRzWwaNYgGKbW6JPYMA7HU40a5E1IZLI5fJFUrlV7vESfOo-P4A5pAxBYaaGLrGYxaDziIwBULmeEIRE4oUooxWYVWcQBPEEuLbRIANXSOEKLkpN21tC+9Xk-yaLXcehItm8DtsIWMGg0roCMr04m8JDM-T0gQW2I1Gy1CRIerSBqN5ypptEem+skt3JtCBCAS6GnEaP83RzxlsXvBgt8maCtmMK1sodiWwjAHEwAQzpcTQkLmQCAUAK6we7MVh4DjccphhukZut41Ers9gj9hBPY7cr7mzmp628hBaDRdZ3QlaGLSGZ1WCxewJZgLDHNWeyGKbmdVRfETokkadt+Od7t9gdGCHJ4x01SdEm-WdtXnADlxHBhVyadckwtRpAVAVosUFV0tFFCwX1MDEtCvDEujvH1H2fV91nrT9ILjDtCBgxcB3STJsjyApijSMowLolsf0YghmKXFcCiQqQNxTNCeQwvl5VdWxIUMAJAl8LFpVcBFtE6EJrG9GxBgfQw60JbUkioFIgMeeDQL4VkxBQzcZPTLBumMWYAg0FE8O8cVjBlDw7W8Xx3WmWxbCfWs8TwBgIDgFQ+O1VCrXQtQ+VFG8ej6AYhhGMYtIQDRDE6PdzGGJ9VNzUVTPDUgKEs84UrTHcsEsP0PG8FTphWYU9BlGxBULYIcW6Axplq8CSAAYSYQocB4yBmu3OTZVwkhtBxfRMQxSKvRMQVxuVHDA20CI3ySiMADkGGEgAxBhezwCALiyKk2DQXIcAgZa0taF9OimN0rG6JSHWmfbit0QJBki09yovSbPwAQQAIyyIgfuc1LZPStpoR0AJvWCItpkDXD9vsLplUzIZcIvYwkfMkkyROQSiV+3HWjapxCoMEISF6AwsVCYYeiZiMoxjKCEk59MDH3cQcSLEY7HPNUvWGLMUV6DQgpFPRtAl0grpbFAsk4C4AFFaTSOXWu9cRQW6DTXVdBw4T5s8nchUYlLpnx3WNiCBJlpj-xY+3Vr8EhwUsAjxV6CqSzsWPIpPVVJRPSJIiAA */
@@ -98,11 +100,13 @@ export const swapIntentMachine = setup({
         input: () => {
           // todo: This is a temporary implementation
           const message: WalletMessage = {
-            type: "NEP-141",
-            message: {
+            NEP141: {
               message: "Hey, I want to swap 100 NEAR to 100 USDC",
               recipient: "defuse.near",
               nonce: crypto.getRandomValues(new Uint8Array(32)),
+            },
+            EIP712: {
+              json: "{}",
             },
           }
 

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -15,6 +15,10 @@ export const swapUIMachine = setup({
       quotes: QuoteTmp[] | null
       outcome: Output | null
     },
+    events: {} as
+      | { type: "input" }
+      | { type: "submit" }
+      | { type: "startOver" },
   },
   actors: {
     formValidation: fromPromise(async (): Promise<boolean> => {

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -73,8 +73,8 @@ export const SwapForm = ({
   return (
     <div className="md:max-w-[472px] rounded-[1rem] p-5 shadow-paper bg-white dark:shadow-paper-dark dark:bg-black-800">
       <Form<SwapFormValues>
-        handleSubmit={handleSubmit((values) => {
-          swapUIActorRef.send({ type: "SUBMIT", params: values })
+        handleSubmit={handleSubmit(() => {
+          swapUIActorRef.send({ type: "submit" })
         })}
         register={register}
       >

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -30,7 +30,6 @@ enum ErrorEnum {
 export interface SwapFormProps {
   selectTokenIn?: BaseTokenInfo
   selectTokenOut?: BaseTokenInfo
-  onSubmit: (values: OnSubmitValues) => void
   onSelect: (fieldName: string, selectToken: BaseTokenInfo) => void
   onSwitch: (e: React.MouseEvent<HTMLButtonElement>) => void
   isFetching: boolean
@@ -39,7 +38,6 @@ export interface SwapFormProps {
 export const SwapForm = ({
   selectTokenIn,
   selectTokenOut,
-  onSubmit,
   onSelect,
   onSwitch,
   isFetching,
@@ -75,9 +73,9 @@ export const SwapForm = ({
   return (
     <div className="md:max-w-[472px] rounded-[1rem] p-5 shadow-paper bg-white dark:shadow-paper-dark dark:bg-black-800">
       <Form<SwapFormValues>
-        handleSubmit={handleSubmit((values: SwapFormValues) =>
-          onSubmit(values as OnSubmitValues)
-        )}
+        handleSubmit={handleSubmit((values) => {
+          swapUIActorRef.send({ type: "SUBMIT", params: values })
+        })}
         register={register}
       >
         <FieldComboInput<SwapFormValues>

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -15,7 +15,7 @@ export const SwapUIMachineContext = createActorContext(swapUIMachine)
 interface SwapUIMachineProviderProps extends PropsWithChildren {
   assetIn: BaseTokenInfo
   assetOut: BaseTokenInfo
-  signMessage: (params: WalletMessage) => Promise<WalletSignatureResult>
+  signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
 }
 
 export function SwapUIMachineProvider({

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react"
 import { useFormContext } from "react-hook-form"
 import { formatUnits } from "viem"
 import { fromPromise } from "xstate"
+import type { WalletMessage, WalletSignatureResult } from "../../../types"
 import type { BaseTokenInfo } from "../../../types/base"
 import { swapIntentMachine } from "../../machines/swapIntentMachine"
 import { type QuoteTmp, swapUIMachine } from "../../machines/swapUIMachine"
@@ -14,12 +15,14 @@ export const SwapUIMachineContext = createActorContext(swapUIMachine)
 interface SwapUIMachineProviderProps extends PropsWithChildren {
   assetIn: BaseTokenInfo
   assetOut: BaseTokenInfo
+  signMessage: (params: WalletMessage) => Promise<WalletSignatureResult>
 }
 
 export function SwapUIMachineProvider({
   children,
   assetIn,
   assetOut,
+  signMessage,
 }: SwapUIMachineProviderProps) {
   const { trigger, getValues, setValue, resetField } =
     useFormContext<SwapFormValues>()
@@ -60,7 +63,11 @@ export function SwapUIMachineProvider({
             return [{ amount_out: ((amountInParsed * 3n) / 2n).toString() }]
           }),
           // @ts-expect-error For some reason `swapIntentMachine` does not satisfy `swap` actor type
-          swap: swapIntentMachine,
+          swap: swapIntentMachine.provide({
+            actors: {
+              signMessage: fromPromise(({ input }) => signMessage(input)),
+            },
+          }),
         },
       })}
     >

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -3,12 +3,12 @@ import { useEffect, useState } from "react"
 import { SwapWidgetProvider } from "../../../providers"
 import { useModalStore } from "../../../providers/ModalStoreProvider"
 import { ModalType } from "../../../stores/modalStore"
-import type { SwapWidgetProps, WalletMessage } from "../../../types"
+import type { SwapWidgetProps } from "../../../types"
 import type { BaseTokenInfo } from "../../../types/base"
 
 import type { ModalSelectAssetsPayload } from "src/components/Modal/ModalSelectAssets"
 import { useTokensStore } from "../../../providers/TokensStoreProvider"
-import { type OnSubmitValues, SwapForm } from "./SwapForm"
+import { SwapForm } from "./SwapForm"
 import { SwapFormProvider } from "./SwapFormProvider"
 import { SwapUIMachineFormSyncProvider } from "./SwapUIMachineFormSyncProvider"
 import { SwapUIMachineProvider } from "./SwapUIMachineProvider"
@@ -30,20 +30,6 @@ export const SwapWidget = ({ tokenList, signMessage }: SwapWidgetProps) => {
   const { setModalType, payload, onCloseModal } = useModalStore(
     (state) => state
   )
-
-  const handleSubmit = async (values: OnSubmitValues) => {
-    // TODO Get message for sign from swapFacade
-    const message: WalletMessage = {
-      type: "NEP-141",
-      message: {
-        message: "",
-        recipient: "",
-        nonce: Buffer.from([]),
-      },
-    }
-    const signature = await signMessage(message)
-    console.log(signature)
-  }
 
   const handleSelect = (
     fieldName: string,
@@ -91,13 +77,13 @@ export const SwapWidget = ({ tokenList, signMessage }: SwapWidgetProps) => {
         <SwapUIMachineProvider
           assetIn={selectTokenIn}
           assetOut={selectTokenOut}
+          signMessage={signMessage}
         >
           <SwapUIMachineFormSyncProvider>
             <SwapForm
               selectTokenIn={selectTokenIn}
               selectTokenOut={selectTokenOut}
               onSwitch={handleSwitch}
-              onSubmit={handleSubmit}
               onSelect={handleSelect}
               isFetching={false}
             />

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import { SwapWidgetProvider } from "../../../providers"
 import { useModalStore } from "../../../providers/ModalStoreProvider"
 import { ModalType } from "../../../stores/modalStore"
-import type { SwapMessageParams, SwapWidgetProps } from "../../../types"
+import type { SwapWidgetProps, WalletMessage } from "../../../types"
 import type { BaseTokenInfo } from "../../../types/base"
 
 import type { ModalSelectAssetsPayload } from "src/components/Modal/ModalSelectAssets"
@@ -13,7 +13,7 @@ import { SwapFormProvider } from "./SwapFormProvider"
 import { SwapUIMachineFormSyncProvider } from "./SwapUIMachineFormSyncProvider"
 import { SwapUIMachineProvider } from "./SwapUIMachineProvider"
 
-export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
+export const SwapWidget = ({ tokenList, signMessage }: SwapWidgetProps) => {
   const { updateTokens } = useTokensStore((state) => state)
 
   assert(tokenList.length > 2, "Token list must have at least 2 tokens")
@@ -33,12 +33,15 @@ export const SwapWidget = ({ tokenList, onSign }: SwapWidgetProps) => {
 
   const handleSubmit = async (values: OnSubmitValues) => {
     // TODO Get message for sign from swapFacade
-    const message: SwapMessageParams = {
-      message: "",
-      recipient: "",
-      nonce: Buffer.from([]),
+    const message: WalletMessage = {
+      type: "NEP-141",
+      message: {
+        message: "",
+        recipient: "",
+        nonce: Buffer.from([]),
+      },
     }
-    const signature = await onSign(message)
+    const signature = await signMessage(message)
     console.log(signature)
   }
 

--- a/src/types/quoting.ts
+++ b/src/types/quoting.ts
@@ -22,4 +22,6 @@ export type EstimateProvider = (
 
 export interface Settings {
   providerIds: EstimateProvider[]
+  defuseContractId: string
+  swapExpirySec: number
 }

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -2,28 +2,24 @@ import type { BaseTokenInfo } from "./base"
 
 // Message for EVM wallets
 export type EIP712Message = {
-  type: "EIP-712"
-  // biome-ignore lint/complexity/noBannedTypes: todo: populate with actual EIP-712 type
-  message: {}
+  // todo: update to real field, now it's just a placeholder
+  json: string
 }
 
 export type EIP712SignatureData = {
-  type: "EIP-712"
+  type: "EIP712"
   signatureData: string
 }
 
 // Message for NEAR wallets
 export type NEP141Message = {
-  type: "NEP-141"
-  message: {
-    message: string
-    recipient: string
-    nonce: Uint8Array
-  }
+  message: string
+  recipient: string
+  nonce: Uint8Array
 }
 
 export type NEP141SignatureData = {
-  type: "NEP-141"
+  type: "NEP141"
   signatureData: {
     accountId: string
     publicKey: string
@@ -31,11 +27,12 @@ export type NEP141SignatureData = {
   }
 }
 
-export type WalletMessage = EIP712Message | NEP141Message
-export type WalletSignatureResult =
-  | EIP712SignatureData
-  | NEP141SignatureData
-  | null // null is meant to represent a cancelled signature request
+export type WalletMessage = {
+  EIP712: EIP712Message
+  NEP141: NEP141Message
+}
+
+export type WalletSignatureResult = EIP712SignatureData | NEP141SignatureData
 
 export type SwapEvent = {
   type: string
@@ -47,7 +44,7 @@ export type SwapWidgetProps = {
   theme?: "dark" | "light"
   tokenList: BaseTokenInfo[]
   onEmit?: (event: SwapEvent) => void
-  signMessage: (params: WalletMessage) => Promise<WalletSignatureResult>
+  signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
 }
 
 export enum QueueTransactionsEnum {

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -1,13 +1,41 @@
 import type { BaseTokenInfo } from "./base"
 
-// TODO: Must be moved to @defuse/swap-facade
-export type SwapMessageParams = {
-  message: string
-  recipient: string
-  nonce: Buffer
-  callbackUrl?: string
-  state?: string
+// Message for EVM wallets
+export type EIP712Message = {
+  type: "EIP-712"
+  // biome-ignore lint/complexity/noBannedTypes: todo: populate with actual EIP-712 type
+  message: {}
 }
+
+export type EIP712SignatureData = {
+  type: "EIP-712"
+  signatureData: string
+}
+
+// Message for NEAR wallets
+export type NEP141Message = {
+  type: "NEP-141"
+  message: {
+    message: string
+    recipient: string
+    nonce: Uint8Array
+  }
+}
+
+export type NEP141SignatureData = {
+  type: "NEP-141"
+  signatureData: {
+    accountId: string
+    publicKey: string
+    signature: string
+  }
+}
+
+export type WalletMessage = EIP712Message | NEP141Message
+export type WalletSignatureResult =
+  | EIP712SignatureData
+  | NEP141SignatureData
+  | null // null is meant to represent a cancelled signature request
 
 export type SwapEvent = {
   type: string
@@ -19,7 +47,7 @@ export type SwapWidgetProps = {
   theme?: "dark" | "light"
   tokenList: BaseTokenInfo[]
   onEmit?: (event: SwapEvent) => void
-  onSign: (params: SwapMessageParams) => Promise<{ signature: string }>
+  signMessage: (params: WalletMessage) => Promise<WalletSignatureResult>
 }
 
 export enum QueueTransactionsEnum {

--- a/src/utils/messageFactory.test.ts
+++ b/src/utils/messageFactory.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { makeSwapMessage } from "./messageFactory"
+
+describe("makeSwapMessage()", () => {
+  it("should return a WalletMessage object", () => {
+    const message = makeSwapMessage({
+      tokenDiff: [["foo.near", 100n]],
+      signerId: "user.near",
+      recipient: "recipient.near",
+      deadlineTimestamp: 1000000,
+      nonce: new Uint8Array(32),
+    })
+
+    expect(message).toEqual({
+      NEP141: {
+        message: `{"deadline":{"timestamp":1000000},"intents":[{"intent":"token_diff","diff":{"foo.near":"100"}}],"signer_id":"user.near"}`,
+        recipient: "recipient.near",
+        nonce: new Uint8Array(32),
+      },
+      EIP712: {
+        json: "{}",
+      },
+    })
+  })
+
+  it("should return a WalletMessage with random nonce", () => {
+    const msg1 = makeSwapMessage({
+      tokenDiff: [["foo.near", 100n]],
+      signerId: "signerId",
+      recipient: "recipient.near",
+      deadlineTimestamp: 1000000,
+    })
+
+    const msg2 = makeSwapMessage({
+      tokenDiff: [["foo.near", 100n]],
+      signerId: "signerId",
+      recipient: "recipient.near",
+      deadlineTimestamp: 1000000,
+    })
+
+    expect(msg1.NEP141.nonce).not.toEqual(msg2.NEP141.nonce)
+  })
+})

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -1,0 +1,46 @@
+import type { WalletMessage } from "../types"
+import type {
+  DefuseMessageFor_DefuseIntents,
+  TokenAmountsForInt128,
+} from "../types/defuse-contracts-types"
+
+export function makeSwapMessage({
+  tokenDiff,
+  signerId,
+  recipient,
+  deadlineTimestamp,
+  nonce = randomBytes(32),
+}: {
+  tokenDiff: TokenAmountsForInt128
+  signerId: string
+  recipient: string
+  deadlineTimestamp: number
+  nonce?: Uint8Array
+}): WalletMessage {
+  const nep141Message: DefuseMessageFor_DefuseIntents = {
+    deadline: { timestamp: deadlineTimestamp },
+    intents: [
+      {
+        intent: "token_diff",
+        diff: tokenDiff,
+      },
+    ],
+    signer_id: signerId,
+  }
+
+  return {
+    NEP141: {
+      message: JSON.stringify(nep141Message),
+      recipient,
+      nonce,
+    },
+    EIP712: {
+      // todo: This is a temporary implementation
+      json: "{}",
+    },
+  }
+}
+
+function randomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length))
+}

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -11,18 +11,23 @@ export function makeSwapMessage({
   deadlineTimestamp,
   nonce = randomBytes(32),
 }: {
-  tokenDiff: TokenAmountsForInt128
+  tokenDiff: [string, bigint][]
   signerId: string
   recipient: string
   deadlineTimestamp: number
   nonce?: Uint8Array
 }): WalletMessage {
+  const serializedTokenDiff = tokenDiff.reduce((acc, [tokenId, amount]) => {
+    acc[tokenId] = amount.toString()
+    return acc
+  }, {} as TokenAmountsForInt128)
+
   const nep141Message: DefuseMessageFor_DefuseIntents = {
     deadline: { timestamp: deadlineTimestamp },
     intents: [
       {
         intent: "token_diff",
-        diff: tokenDiff,
+        diff: serializedTokenDiff,
       },
     ],
     signer_id: signerId,

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -9,7 +9,7 @@ export function makeSwapMessage({
   signerId,
   recipient,
   deadlineTimestamp,
-  nonce = randomBytes(32),
+  nonce = randomDefuseNonce(),
 }: {
   tokenDiff: [string, bigint][]
   signerId: string
@@ -44,6 +44,10 @@ export function makeSwapMessage({
       json: "{}",
     },
   }
+}
+
+function randomDefuseNonce(): Uint8Array {
+  return randomBytes(32)
 }
 
 function randomBytes(length: number): Uint8Array {


### PR DESCRIPTION
PR: 
- adds generation of a swap message to a machine level
- updates the signature of SwapWidget to enable singing messages of different standards

Here is an example of usage the SwapWidget (I will update FE repository eventually):
```ts
<SwapWidget
  tokenList={LIST_TOKENS}
  signMessage={async (params) => {
    const sig = await signMessage({
      ...params.NEP141,
      nonce: Buffer.from(params.NEP141.nonce),
    })

    if (!sig) {
      throw new Error("No signature")
    }

    return { type: "NEP141", signatureData: sig }
  }}
/>
```