### PR TITLE
feat: add unified token

### DIFF
--- a/src/components/Asset/AssetComboIcon.tsx
+++ b/src/components/Asset/AssetComboIcon.tsx
@@ -17,13 +17,15 @@ export const AssetComboIcon = ({
           className="w-full h-full object-contain"
         />
       </div>
-      <div className="absolute bottom-0 -right-[7px] flex justify-center items-center p-1 bg-black-300 rounded-full border-2 border-white dark:border-black-950">
-        <img
-          src={chainIcon ?? ""}
-          alt={chainName || "Network Logo"}
-          className="w-[6px] h-[6px]"
-        />
-      </div>
+      {chainIcon != null ? (
+        <div className="absolute bottom-0 -right-[7px] flex justify-center items-center p-1 bg-black-300 rounded-full border-2 border-white dark:border-black-950">
+          <img
+            src={chainIcon}
+            alt={chainName || "Network Logo"}
+            className="w-[6px] h-[6px]"
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/components/Asset/AssetList.tsx
+++ b/src/components/Asset/AssetList.tsx
@@ -4,13 +4,13 @@ import React, { type ReactNode } from "react"
 
 import type { BaseTokenInfo } from "../../types/base"
 import { balanceToCurrency, balanceToDecimal } from "../../utils/balanceTo"
-import type { TokenListWithNotSelectableToken } from "../Modal/ModalSelectAssets"
+import type { SelectableToken } from "../Modal/ModalSelectAssets"
 
 import { AssetComboIcon } from "./AssetComboIcon"
 
 type Props = {
   title?: string
-  assets: TokenListWithNotSelectableToken[]
+  assets: SelectableToken[]
   emptyState?: ReactNode
   className?: string
   handleSelectToken?: (token: BaseTokenInfo) => void
@@ -72,7 +72,7 @@ export const AssetList = ({
             symbol,
             balance,
             balanceUsd,
-            isNotSelectable,
+            disabled,
             decimals,
             ...rest
           },
@@ -83,7 +83,7 @@ export const AssetList = ({
             type={"button"}
             className={clsx(
               "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",
-              isNotSelectable && "opacity-50 pointer-events-none"
+              disabled && "opacity-50 pointer-events-none"
             )}
             // biome-ignore lint/style/noNonNullAssertion: i is always within bounds
             onClick={() => handleSelectToken?.(assets[i]!)}

--- a/src/components/Asset/AssetList.tsx
+++ b/src/components/Asset/AssetList.tsx
@@ -8,15 +8,15 @@ import type { SelectableToken } from "../Modal/ModalSelectAssets"
 
 import { AssetComboIcon } from "./AssetComboIcon"
 
-type Props = {
+type Props<T> = {
   title?: string
-  assets: SelectableToken[]
+  assets: SelectableToken<T>[]
   emptyState?: ReactNode
   className?: string
-  handleSelectToken?: (token: BaseTokenInfo) => void
+  handleSelectToken?: (token: SelectableToken<T>) => void
 }
 
-const EmptyAssetList = ({ className }: Pick<Props, "className">) => {
+const EmptyAssetList = ({ className }: Pick<Props<unknown>, "className">) => {
   return (
     <div
       className={clsx(
@@ -42,13 +42,15 @@ const EmptyAssetList = ({ className }: Pick<Props, "className">) => {
   )
 }
 
-export const AssetList = ({
+type Token = BaseTokenInfo
+
+export const AssetList = <T extends Token>({
   title,
   assets,
   emptyState,
   className,
   handleSelectToken,
-}: Props) => {
+}: Props<T>) => {
   if (!assets.length) {
     return emptyState || <EmptyAssetList className={className ?? ""} />
   }
@@ -64,62 +66,52 @@ export const AssetList = ({
           {title}
         </Text>
       </div>
-      {assets.map(
-        (
-          {
-            name,
-            chainName,
-            symbol,
-            balance,
-            balanceUsd,
-            disabled,
-            decimals,
-            ...rest
-          },
-          i
-        ) => (
-          <button
-            key={rest.defuseAssetId}
-            type={"button"}
-            className={clsx(
-              "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",
-              disabled && "opacity-50 pointer-events-none"
-            )}
-            // biome-ignore lint/style/noNonNullAssertion: i is always within bounds
-            onClick={() => handleSelectToken?.(assets[i]!)}
-          >
-            <AssetComboIcon
-              name={name as string}
-              chainName={chainName as string}
-              {...rest}
-            />
-            <div className="grow flex flex-col">
-              <div className="flex justify-between items-center">
-                <Text as="span" size="2" weight="medium">
-                  {name}
-                </Text>
-                <Text as="span" size="2" weight="medium">
-                  {balance
-                    ? Number(balanceToDecimal(balance, decimals)) < 0.00001
-                      ? "< 0.00001"
-                      : Number(balanceToDecimal(balance, decimals)).toFixed(7)
-                    : null}
-                </Text>
-              </div>
-              <div className="flex justify-between items-center text-gray-600 dark:text-gray-500">
-                <Text as="span" size="2">
-                  {symbol ? symbol : null}
-                </Text>
-                <Text as="span" size="2">
-                  {balanceUsd
-                    ? `$${balanceToCurrency(Number(balanceUsd))}`
-                    : null}
-                </Text>
-              </div>
+      {assets.map(({ token, disabled, balance }, i) => (
+        <button
+          key={token.defuseAssetId}
+          type={"button"}
+          className={clsx(
+            "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",
+            disabled && "opacity-50 pointer-events-none"
+          )}
+          // biome-ignore lint/style/noNonNullAssertion: i is always within bounds
+          onClick={() => handleSelectToken?.(assets[i]!)}
+        >
+          <AssetComboIcon
+            icon={token.icon}
+            name={token.name}
+            chainIcon={token.chainIcon}
+            chainName={token.chainName}
+          />
+          <div className="grow flex flex-col">
+            <div className="flex justify-between items-center">
+              <Text as="span" size="2" weight="medium">
+                {token.name}
+              </Text>
+              <Text as="span" size="2" weight="medium">
+                {balance
+                  ? Number(balanceToDecimal(balance.balance, token.decimals)) <
+                    0.00001
+                    ? "< 0.00001"
+                    : Number(
+                        balanceToDecimal(balance.balance, token.decimals)
+                      ).toFixed(7)
+                  : null}
+              </Text>
             </div>
-          </button>
-        )
-      )}
+            <div className="flex justify-between items-center text-gray-600 dark:text-gray-500">
+              <Text as="span" size="2">
+                {token.symbol}
+              </Text>
+              <Text as="span" size="2">
+                {token.balanceUsd
+                  ? `$${balanceToCurrency(Number(token.balanceUsd))}`
+                  : null}
+              </Text>
+            </div>
+          </div>
+        </button>
+      ))}
     </div>
   )
 }

--- a/src/components/Asset/AssetList.tsx
+++ b/src/components/Asset/AssetList.tsx
@@ -2,10 +2,11 @@ import { Text } from "@radix-ui/themes"
 import clsx from "clsx"
 import React, { type ReactNode } from "react"
 
-import type { BaseTokenInfo } from "../../types/base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../../types/base"
 import { balanceToCurrency, balanceToDecimal } from "../../utils/balanceTo"
 import type { SelectItemToken } from "../Modal/ModalSelectAssets"
 
+import { isBaseToken } from "../../utils"
 import { AssetComboIcon } from "./AssetComboIcon"
 
 type Props<T> = {
@@ -42,7 +43,7 @@ const EmptyAssetList = ({ className }: Pick<Props<unknown>, "className">) => {
   )
 }
 
-type Token = BaseTokenInfo
+type Token = BaseTokenInfo | UnifiedTokenInfo
 
 export const AssetList = <T extends Token>({
   title,
@@ -80,8 +81,8 @@ export const AssetList = <T extends Token>({
           <AssetComboIcon
             icon={token.icon}
             name={token.name}
-            chainIcon={token.chainIcon}
-            chainName={token.chainName}
+            chainIcon={isBaseToken(token) ? token.chainIcon : undefined}
+            chainName={isBaseToken(token) ? token.chainName : undefined}
           />
           <div className="grow flex flex-col">
             <div className="flex justify-between items-center">
@@ -104,8 +105,8 @@ export const AssetList = <T extends Token>({
                 {token.symbol}
               </Text>
               <Text as="span" size="2">
-                {token.balanceUsd
-                  ? `$${balanceToCurrency(Number(token.balanceUsd))}`
+                {balance
+                  ? `$${balanceToCurrency(Number(balance.balanceUsd))}`
                   : null}
               </Text>
             </div>

--- a/src/components/Asset/AssetList.tsx
+++ b/src/components/Asset/AssetList.tsx
@@ -4,16 +4,16 @@ import React, { type ReactNode } from "react"
 
 import type { BaseTokenInfo } from "../../types/base"
 import { balanceToCurrency, balanceToDecimal } from "../../utils/balanceTo"
-import type { SelectableToken } from "../Modal/ModalSelectAssets"
+import type { SelectItemToken } from "../Modal/ModalSelectAssets"
 
 import { AssetComboIcon } from "./AssetComboIcon"
 
 type Props<T> = {
   title?: string
-  assets: SelectableToken<T>[]
+  assets: SelectItemToken<T>[]
   emptyState?: ReactNode
   className?: string
-  handleSelectToken?: (token: SelectableToken<T>) => void
+  handleSelectToken?: (token: SelectItemToken<T>) => void
 }
 
 const EmptyAssetList = ({ className }: Pick<Props<unknown>, "className">) => {
@@ -66,9 +66,9 @@ export const AssetList = <T extends Token>({
           {title}
         </Text>
       </div>
-      {assets.map(({ token, disabled, balance }, i) => (
+      {assets.map(({ itemId, token, disabled, balance }, i) => (
         <button
-          key={token.defuseAssetId}
+          key={itemId}
           type={"button"}
           className={clsx(
             "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -8,7 +8,7 @@ import type {
   UseFormRegister,
 } from "react-hook-form"
 
-import type { BaseTokenInfo } from "../../types/base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../../types/base"
 import {
   BlockMultiBalances,
   type BlockMultiBalancesProps,
@@ -23,7 +23,7 @@ interface Props<T extends FieldValues> {
   label?: string | React.ReactNode
   price?: string
   balance?: string | bigint
-  selected?: BaseTokenInfo
+  selected?: BaseTokenInfo | UnifiedTokenInfo
   handleSelect?: () => void
   handleSetMaxValue?: () => void
   className?: string

--- a/src/components/Modal/ModalDepositSelectAssets.tsx
+++ b/src/components/Modal/ModalDepositSelectAssets.tsx
@@ -2,7 +2,6 @@ import { Text } from "@radix-ui/themes"
 import React, { useState, useDeferredValue, useEffect } from "react"
 
 import { useModalStore } from "../../providers/ModalStoreProvider"
-import type { NetworkTokenWithSwapRoute } from "../../types"
 import type { BaseTokenInfo } from "../../types/base"
 import { BlockchainEnum } from "../../types/deposit"
 import { AssetList } from "../Asset/AssetList"
@@ -23,7 +22,7 @@ export type ModalDepositSelectAssetsPayload = {
 
 export const ModalDepositSelectAssets = () => {
   const [searchValue, setSearchValue] = useState("")
-  const [assetList, setAssetList] = useState<NetworkTokenWithSwapRoute[]>([])
+  const [assetList, setAssetList] = useState<BaseTokenInfo[]>([])
 
   const { onCloseModal, modalType, payload } = useModalStore((state) => state)
   const deferredQuery = useDeferredValue(searchValue)

--- a/src/components/Modal/ModalDepositSelectAssets.tsx
+++ b/src/components/Modal/ModalDepositSelectAssets.tsx
@@ -37,7 +37,7 @@ export const ModalDepositSelectAssets = () => {
       .toLocaleUpperCase()
       .includes(deferredQuery.toLocaleUpperCase())
 
-  const handleSelectToken = (token: BaseTokenInfo) => {
+  const handleSelectToken = ({ token }: { token: BaseTokenInfo }) => {
     onCloseModal({
       ...(payload as { fieldName: string }),
       modalType,
@@ -70,7 +70,13 @@ export const ModalDepositSelectAssets = () => {
         </div>
         <div className="flex-1 flex flex-col justify-between border-b border-gray-100 px-2.5 overflow-y-auto dark:border-black-950">
           <AssetList
-            assets={deferredQuery ? assetList.filter(filterPattern) : assetList}
+            assets={(deferredQuery
+              ? assetList.filter(filterPattern)
+              : assetList
+            ).map((token) => ({
+              token,
+              disabled: false,
+            }))}
             title={deferredQuery ? "Search results" : "Popular tokens"}
             className="h-full"
             handleSelectToken={handleSelectToken}

--- a/src/components/Modal/ModalDepositSelectAssets.tsx
+++ b/src/components/Modal/ModalDepositSelectAssets.tsx
@@ -74,6 +74,7 @@ export const ModalDepositSelectAssets = () => {
               ? assetList.filter(filterPattern)
               : assetList
             ).map((token) => ({
+              itemId: token.defuseAssetId,
               token,
               disabled: false,
             }))}

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -4,7 +4,6 @@ import React, { useState, useDeferredValue, useEffect } from "react"
 import { useModalStore } from "../../providers/ModalStoreProvider"
 import { useTokensStore } from "../../providers/TokensStoreProvider"
 import type { ModalType } from "../../stores/modalStore"
-import type { NetworkTokenWithSwapRoute } from "../../types"
 import type { BaseTokenInfo } from "../../types/base"
 import { AssetList } from "../Asset/AssetList"
 import { SearchBar } from "../SearchBar"
@@ -17,15 +16,15 @@ export type ModalSelectAssetsPayload = {
   fieldName?: string
 }
 
-export interface SelectableToken extends NetworkTokenWithSwapRoute {
+export interface SelectableToken extends BaseTokenInfo {
   disabled?: boolean
 }
 
 export const ModalSelectAssets = () => {
   const [searchValue, setSearchValue] = useState("")
-  const [assetList, setAssetList] = useState<NetworkTokenWithSwapRoute[]>([])
+  const [assetList, setAssetList] = useState<BaseTokenInfo[]>([])
   const [assetListWithBalances, setAssetListWithBalances] = useState<
-    NetworkTokenWithSwapRoute[]
+    BaseTokenInfo[]
   >([])
 
   const { onCloseModal, modalType, payload } = useModalStore((state) => state)
@@ -55,7 +54,7 @@ export const ModalSelectAssets = () => {
       return
     }
     const { selectToken, fieldName } = payload as {
-      selectToken: NetworkTokenWithSwapRoute | undefined
+      selectToken: BaseTokenInfo | undefined
       fieldName: string
     }
 

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -16,7 +16,8 @@ export type ModalSelectAssetsPayload = {
   fieldName?: string
 }
 
-export type SelectableToken<T = Token> = {
+export type SelectItemToken<T = Token> = {
+  itemId: string
   token: T
   disabled: boolean
   balance?: BaseTokenBalance
@@ -24,9 +25,9 @@ export type SelectableToken<T = Token> = {
 
 export const ModalSelectAssets = () => {
   const [searchValue, setSearchValue] = useState("")
-  const [assetList, setAssetList] = useState<SelectableToken[]>([])
+  const [assetList, setAssetList] = useState<SelectItemToken[]>([])
   const [assetListWithBalances, setAssetListWithBalances] = useState<
-    SelectableToken[]
+    SelectItemToken[]
   >([])
 
   const { onCloseModal, modalType, payload } = useModalStore((state) => state)
@@ -35,7 +36,7 @@ export const ModalSelectAssets = () => {
 
   const handleSearchClear = () => setSearchValue("")
 
-  const filterPattern = (asset: SelectableToken) =>
+  const filterPattern = (asset: SelectItemToken) =>
     asset.token.name
       .toLocaleUpperCase()
       .includes(deferredQuery.toLocaleUpperCase()) ||
@@ -44,7 +45,7 @@ export const ModalSelectAssets = () => {
         .toLocaleUpperCase()
         .includes(deferredQuery.toLocaleUpperCase()))
 
-  const handleSelectToken = (token: SelectableToken) => {
+  const handleSelectToken = (token: SelectItemToken) => {
     onCloseModal({
       ...(payload as { fieldName: string }),
       modalType,
@@ -63,8 +64,8 @@ export const ModalSelectAssets = () => {
 
     const selectedTokenId = selectToken ? selectToken.defuseAssetId : undefined
 
-    const getAssetList: SelectableToken[] = []
-    const getAssetListWithBalances: SelectableToken[] = []
+    const getAssetList: SelectItemToken[] = []
+    const getAssetListWithBalances: SelectItemToken[] = []
     for (const [tokenId, token] of data) {
       // We do not filter "tokenIn" as give full access to tokens in first step
       // Filtration by routes should happen only at "tokenOut"
@@ -76,7 +77,8 @@ export const ModalSelectAssets = () => {
         token.convertedLast != null
       ) {
         getAssetListWithBalances.push({
-          token: token,
+          itemId: tokenId,
+          token,
           disabled,
           balance: {
             balance: token.balance,
@@ -86,7 +88,7 @@ export const ModalSelectAssets = () => {
         })
       }
 
-      getAssetList.push({ token: token, disabled })
+      getAssetList.push({ itemId: tokenId, token, disabled })
     }
     setAssetList(getAssetList)
     setAssetListWithBalances(getAssetListWithBalances)

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -51,7 +51,7 @@ export const ModalSelectAssets = () => {
           .includes(deferredQuery.toLocaleUpperCase())
       : true)
 
-  const handleSelectToken = (token: SelectItemToken) => {
+  const handleSelectToken = (selectedItem: SelectItemToken) => {
     if (modalType !== ModalType.MODAL_SELECT_ASSETS) {
       throw new Error("Invalid modal type")
     }
@@ -59,7 +59,7 @@ export const ModalSelectAssets = () => {
     const newPayload: ModalSelectAssetsPayload = {
       ...(payload as ModalSelectAssetsPayload),
       modalType: ModalType.MODAL_SELECT_ASSETS,
-      token: token.token,
+      token: selectedItem.token,
     }
     onCloseModal(newPayload)
   }

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -87,11 +87,7 @@ export const ModalSelectAssets = () => {
       const disabled = selectedTokenId != null && tokenId === selectedTokenId
 
       if (isBaseToken(token)) {
-        if (
-          token.balance != null &&
-          token.balanceUsd != null &&
-          token.convertedLast != null
-        ) {
+        if (token.balance != null) {
           getAssetListWithBalances.push({
             itemId: tokenId,
             token,

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -17,9 +17,8 @@ export type ModalSelectAssetsPayload = {
   fieldName?: string
 }
 
-export interface TokenListWithNotSelectableToken
-  extends NetworkTokenWithSwapRoute {
-  isNotSelectable?: boolean
+export interface SelectableToken extends NetworkTokenWithSwapRoute {
+  disabled?: boolean
 }
 
 export const ModalSelectAssets = () => {
@@ -60,26 +59,23 @@ export const ModalSelectAssets = () => {
       fieldName: string
     }
 
-    const getAssetList: TokenListWithNotSelectableToken[] = []
-    const getAssetListWithBalances: TokenListWithNotSelectableToken[] = []
+    const getAssetList: SelectableToken[] = []
+    const getAssetListWithBalances: SelectableToken[] = []
     for (const value of data.values()) {
-      let isNotSelectable = false
       // We do not filter "tokenIn" as give full access to tokens in first step
       // Filtration by routes should happen only at "tokenOut"
-      const isAlreadySelected =
-        selectToken && value.defuseAssetId === selectToken.defuseAssetId
-      if (isAlreadySelected) {
-        isNotSelectable = true
-      }
+      const disabled = selectToken
+        ? value.defuseAssetId === selectToken.defuseAssetId
+        : false
 
       if (value?.balance) {
         getAssetListWithBalances.push({
           ...value,
           balance: value?.balance,
-          isNotSelectable,
+          disabled,
         })
       }
-      getAssetList.push({ ...value, isNotSelectable })
+      getAssetList.push({ ...value, disabled })
     }
     setAssetList(getAssetList)
     setAssetListWithBalances(getAssetListWithBalances)

--- a/src/components/Network/AssetList.tsx
+++ b/src/components/Network/AssetList.tsx
@@ -5,11 +5,11 @@ import React, { type ReactNode } from "react"
 import type { BaseTokenInfo } from "../../types/base"
 import { balanceToCurrency, balanceToDecimal } from "../../utils/balanceTo"
 import { AssetComboIcon } from "../Asset/AssetComboIcon"
-import type { TokenListWithNotSelectableToken } from "../Modal/ModalSelectAssets"
+import type { SelectableToken } from "../Modal/ModalSelectAssets"
 
 type Props = {
   title?: string
-  assets: TokenListWithNotSelectableToken[]
+  assets: SelectableToken[]
   emptyState?: ReactNode
   className?: string
   handleSelectToken?: (token: BaseTokenInfo) => void
@@ -66,7 +66,7 @@ const AssetList = ({
             symbol,
             balance,
             balanceUsd,
-            isNotSelectable,
+            disabled,
             decimals,
             ...rest
           },
@@ -77,7 +77,7 @@ const AssetList = ({
             type={"button"}
             className={clsx(
               "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-950 dark:hover:bg-black-950",
-              isNotSelectable && "opacity-50 pointer-events-none"
+              disabled && "opacity-50 pointer-events-none"
             )}
             onClick={() =>
               handleSelectToken &&

--- a/src/components/Network/AssetList.tsx
+++ b/src/components/Network/AssetList.tsx
@@ -1,3 +1,4 @@
+/*
 import { Text } from "@radix-ui/themes"
 import clsx from "clsx"
 import React, { type ReactNode } from "react"
@@ -122,3 +123,4 @@ const AssetList = ({
 }
 
 export default AssetList
+*/

--- a/src/components/SelectAssets.tsx
+++ b/src/components/SelectAssets.tsx
@@ -1,12 +1,12 @@
 import { CaretDownIcon } from "@radix-ui/react-icons"
 import type React from "react"
 
-import type { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../types/base"
 
 import { AssetComboIcon } from "./Asset/AssetComboIcon"
 
 type Props = {
-  selected?: BaseTokenInfo
+  selected?: BaseTokenInfo | UnifiedTokenInfo
   handleSelect?: () => void
 }
 
@@ -29,10 +29,14 @@ export const SelectAssets = ({ selected, handleSelect }: Props) => {
     >
       {selected?.icon ? (
         <AssetComboIcon
-          icon={selected?.icon as string}
-          name={selected?.name as string}
-          chainIcon={selected?.chainIcon as string}
-          chainName={selected?.chainName as string}
+          icon={selected.icon as string}
+          name={selected.name as string}
+          chainIcon={
+            "defuseAssetId" in selected ? selected.chainIcon : undefined
+          }
+          chainName={
+            "defuseAssetId" in selected ? selected.chainName : undefined
+          }
         />
       ) : (
         <EmptyIcon />

--- a/src/features/deposit/components/Form/DepositFormNear/index.tsx
+++ b/src/features/deposit/components/Form/DepositFormNear/index.tsx
@@ -10,7 +10,6 @@ import { Form } from "../../../../../components/Form"
 import { FieldComboInput } from "../../../../../components/Form/FieldComboInput"
 import { DepositService } from "../../../../../features/deposit/services/depositService"
 import { depositNearMachine } from "../../../../../features/machines/depositNearMachine"
-import type { NetworkTokenWithSwapRoute } from "../../../../../types"
 import type { BaseTokenInfo } from "../../../../../types/base"
 import type { BaseAssetInfo, Transaction } from "../../../../../types/deposit"
 import { balanceToBignumberString } from "../../../../../utils/balanceTo"
@@ -34,7 +33,7 @@ export const DepositFormNear = ({
   signAndSendTransactionsNear,
   accountId,
 }: DepositFormNearProps) => {
-  const [selectToken, setSelectToken] = useState<NetworkTokenWithSwapRoute>()
+  const [selectToken, setSelectToken] = useState<BaseTokenInfo>()
   const {
     handleSubmit,
     register,

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -2,21 +2,24 @@ import { quoteMachine } from "@defuse-protocol/swap-facade"
 import type { SolverQuote } from "@defuse-protocol/swap-facade/dist/interfaces/swap-machine.in.interface"
 import { type ActorRefFrom, assign, fromPromise, setup } from "xstate"
 import { settings } from "../../config/settings"
-import type { WalletMessage, WalletSignatureResult } from "../../types"
-import type { BaseTokenInfo } from "../../types/base"
+import type {
+  SwappableToken,
+  WalletMessage,
+  WalletSignatureResult,
+} from "../../types"
 import { makeSwapMessage } from "../../utils/messageFactory"
 
 type Context = {
   quoterRef: null | ActorRefFrom<typeof quoteMachine>
-  tokenIn: BaseTokenInfo
-  tokenOut: BaseTokenInfo
+  tokenIn: SwappableToken
+  tokenOut: SwappableToken
   amountIn: bigint
   amountOut: bigint
 }
 
 type Input = {
-  tokenIn: BaseTokenInfo
-  tokenOut: BaseTokenInfo
+  tokenIn: SwappableToken
+  tokenOut: SwappableToken
   amountIn: bigint
   amountOut: bigint
 }
@@ -118,6 +121,9 @@ export const swapIntentMachine = setup({
         src: "signMessage",
 
         input: ({ context }) => {
+          assert(!("groupedTokens" in context.tokenIn), "TokenIn is unified")
+          assert(!("groupedTokens" in context.tokenOut), "TokenOut is unified")
+
           return makeSwapMessage({
             tokenDiff: [
               [context.tokenIn.defuseAssetId, -context.amountIn],
@@ -238,3 +244,9 @@ export const swapIntentMachine = setup({
     },
   },
 })
+
+function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg)
+  }
+}

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -7,7 +7,7 @@ import {
   fromPromise,
   setup,
 } from "xstate"
-import type { BaseTokenInfo } from "../../types/base"
+import type { SwappableToken } from "../../types"
 import type { swapIntentMachine } from "./swapIntentMachine"
 
 export type QuoteTmp = {
@@ -20,16 +20,16 @@ export const swapUIMachine = setup({
       quoteQuerier: "queryQuote"
     },
     input: {} as {
-      tokenIn: BaseTokenInfo
-      tokenOut: BaseTokenInfo
+      tokenIn: SwappableToken
+      tokenOut: SwappableToken
     },
     context: {} as {
       error: Error | null
       quotes: QuoteTmp[] | null
       outcome: OutputFrom<typeof swapIntentMachine> | null
       formValues: {
-        tokenIn: BaseTokenInfo
-        tokenOut: BaseTokenInfo
+        tokenIn: SwappableToken
+        tokenOut: SwappableToken
         amountIn: string
       }
       parsedFormValues: {
@@ -40,8 +40,8 @@ export const swapUIMachine = setup({
       | {
           type: "input"
           params: Partial<{
-            tokenIn: BaseTokenInfo
-            tokenOut: BaseTokenInfo
+            tokenIn: SwappableToken
+            tokenOut: SwappableToken
             amountIn: string
           }>
         }
@@ -51,8 +51,8 @@ export const swapUIMachine = setup({
       type: "swap_finished"
       data: {
         intentOutcome: OutputFrom<typeof swapIntentMachine>
-        tokenIn: BaseTokenInfo
-        tokenOut: BaseTokenInfo
+        tokenIn: SwappableToken
+        tokenOut: SwappableToken
         amountIn: bigint
         amountOut: bigint
       }
@@ -81,8 +81,8 @@ export const swapUIMachine = setup({
           data,
         }: {
           data: Partial<{
-            tokenIn: BaseTokenInfo
-            tokenOut: BaseTokenInfo
+            tokenIn: SwappableToken
+            tokenOut: SwappableToken
             amountIn: string
           }>
         }

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -6,7 +6,7 @@ import { Form } from "../../../components/Form"
 import { FieldComboInput } from "../../../components/Form/FieldComboInput"
 import { WarnBox } from "../../../components/WarnBox"
 import { NEAR_TOKEN_META } from "../../../constants"
-import type { BaseTokenInfo } from "../../../types/base"
+import type { SwappableToken } from "../../../types"
 import { SwapUIMachineContext } from "./SwapUIMachineProvider"
 
 export type SwapFormValues = {
@@ -28,9 +28,9 @@ enum ErrorEnum {
 }
 
 export interface SwapFormProps {
-  selectTokenIn?: BaseTokenInfo
-  selectTokenOut?: BaseTokenInfo
-  onSelect: (fieldName: string, selectToken: BaseTokenInfo) => void
+  selectTokenIn?: SwappableToken
+  selectTokenOut?: SwappableToken
+  onSelect: (fieldName: string, selectToken: SwappableToken) => void
   onSwitch: (e: React.MouseEvent<HTMLButtonElement>) => void
   isFetching: boolean
 }
@@ -89,9 +89,10 @@ export const SwapForm = ({
       >
         <FieldComboInput<SwapFormValues>
           fieldName="amountIn"
-          selected={selectTokenIn as BaseTokenInfo}
+          selected={selectTokenIn}
           handleSelect={() => {
-            onSelect("tokenIn", selectTokenOut as BaseTokenInfo)
+            assert(selectTokenOut, "selectTokenOut is not defined")
+            onSelect("tokenIn", selectTokenOut)
             swapUIActorRef.send({
               type: "input",
               params: { tokenIn: selectTokenOut },
@@ -107,9 +108,10 @@ export const SwapForm = ({
         </div>
         <FieldComboInput<SwapFormValues>
           fieldName="amountOut"
-          selected={selectTokenOut as BaseTokenInfo}
+          selected={selectTokenOut}
           handleSelect={() => {
-            onSelect("tokenOut", selectTokenIn as BaseTokenInfo)
+            assert(selectTokenIn, "selectTokenOut is not defined")
+            onSelect("tokenOut", selectTokenIn)
             swapUIActorRef.send({
               type: "input",
               params: { tokenOut: selectTokenOut },
@@ -121,6 +123,7 @@ export const SwapForm = ({
           errorSelect={errorSelectTokenOut}
           disabled={true}
         />
+        {/*
         {selectTokenIn?.defuseAssetId === NEAR_TOKEN_META.defuseAssetId &&
           errorMsg !== ErrorEnum.INSUFFICIENT_BALANCE &&
           errorMsg !== ErrorEnum.NO_QUOTES && (
@@ -133,6 +136,7 @@ export const SwapForm = ({
               }}
             />
           )}
+        */}
         <ButtonCustom
           type="submit"
           size="lg"
@@ -145,4 +149,10 @@ export const SwapForm = ({
       </Form>
     </div>
   )
+}
+
+function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg)
+  }
 }

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -4,8 +4,11 @@ import type { PropsWithChildren } from "react"
 import { useFormContext } from "react-hook-form"
 import { formatUnits } from "viem"
 import { fromPromise } from "xstate"
-import type { WalletMessage, WalletSignatureResult } from "../../../types"
-import type { BaseTokenInfo } from "../../../types/base"
+import type {
+  SwappableToken,
+  WalletMessage,
+  WalletSignatureResult,
+} from "../../../types"
 import { swapIntentMachine } from "../../machines/swapIntentMachine"
 import { type QuoteTmp, swapUIMachine } from "../../machines/swapUIMachine"
 import type { SwapFormValues } from "./SwapForm"
@@ -13,8 +16,8 @@ import type { SwapFormValues } from "./SwapForm"
 export const SwapUIMachineContext = createActorContext(swapUIMachine)
 
 interface SwapUIMachineProviderProps extends PropsWithChildren {
-  assetIn: BaseTokenInfo
-  assetOut: BaseTokenInfo
+  assetIn: SwappableToken
+  assetOut: SwappableToken
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
 }
 

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -3,8 +3,7 @@ import { useEffect, useState } from "react"
 import { SwapWidgetProvider } from "../../../providers"
 import { useModalStore } from "../../../providers/ModalStoreProvider"
 import { ModalType } from "../../../stores/modalStore"
-import type { SwapWidgetProps } from "../../../types"
-import type { BaseTokenInfo } from "../../../types/base"
+import type { SwapWidgetProps, SwappableToken } from "../../../types"
 
 import type { ModalSelectAssetsPayload } from "src/components/Modal/ModalSelectAssets"
 import { useTokensStore } from "../../../providers/TokensStoreProvider"
@@ -22,11 +21,11 @@ export const SwapWidget = ({
 
   assert(tokenList.length > 2, "Token list must have at least 2 tokens")
 
-  const [selectTokenIn, setSelectTokenIn] = useState<BaseTokenInfo>(
+  const [selectTokenIn, setSelectTokenIn] = useState<SwappableToken>(
     // biome-ignore lint/style/noNonNullAssertion: tokenList[0] is guaranteed to be defined
     tokenList[0]!
   )
-  const [selectTokenOut, setSelectTokenOut] = useState<BaseTokenInfo>(
+  const [selectTokenOut, setSelectTokenOut] = useState<SwappableToken>(
     // biome-ignore lint/style/noNonNullAssertion: tokenList[1] is guaranteed to be defined
     tokenList[1]!
   )
@@ -37,7 +36,7 @@ export const SwapWidget = ({
 
   const handleSelect = (
     fieldName: string,
-    selectToken: BaseTokenInfo | undefined
+    selectToken: SwappableToken | undefined
   ) => {
     setModalType(ModalType.MODAL_SELECT_ASSETS, { fieldName, selectToken })
   }

--- a/src/stores/tokensStore.ts
+++ b/src/stores/tokensStore.ts
@@ -1,16 +1,15 @@
 import { createStore } from "zustand/vanilla"
-
-import type { NetworkTokenWithSwapRoute } from "../types"
+import type { BaseTokenInfo } from "../types/base"
 
 export type TokensState = {
-  data: Map<string, NetworkTokenWithSwapRoute>
+  data: Map<string, BaseTokenInfo>
   isLoading: boolean
   isFetched: boolean
 }
 
 export type TokensActions = {
   onLoad: () => void
-  updateTokens: (data: NetworkTokenWithSwapRoute[]) => void
+  updateTokens: (data: BaseTokenInfo[]) => void
 }
 
 export type TokensStore = TokensState & TokensActions
@@ -35,7 +34,7 @@ export const createTokensStore = (
   return createStore<TokensStore>()((set) => ({
     ...initState,
     onLoad: () => set({ isLoading: true }),
-    updateTokens: (data: NetworkTokenWithSwapRoute[]) =>
+    updateTokens: (data: BaseTokenInfo[]) =>
       set((state) => {
         const updatedData = new Map(state.data)
         for (const item of data) {

--- a/src/stores/tokensStore.ts
+++ b/src/stores/tokensStore.ts
@@ -1,15 +1,15 @@
 import { createStore } from "zustand/vanilla"
-import type { BaseTokenInfo } from "../types/base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../types/base"
 
 export type TokensState = {
-  data: Map<string, BaseTokenInfo>
+  data: Map<string, BaseTokenInfo | UnifiedTokenInfo>
   isLoading: boolean
   isFetched: boolean
 }
 
 export type TokensActions = {
   onLoad: () => void
-  updateTokens: (data: BaseTokenInfo[]) => void
+  updateTokens: (data: (BaseTokenInfo | UnifiedTokenInfo)[]) => void
 }
 
 export type TokensStore = TokensState & TokensActions
@@ -34,11 +34,14 @@ export const createTokensStore = (
   return createStore<TokensStore>()((set) => ({
     ...initState,
     onLoad: () => set({ isLoading: true }),
-    updateTokens: (data: BaseTokenInfo[]) =>
+    updateTokens: (data: (BaseTokenInfo | UnifiedTokenInfo)[]) =>
       set((state) => {
         const updatedData = new Map(state.data)
         for (const item of data) {
-          updatedData.set(item.defuseAssetId, item)
+          updatedData.set(
+            "defuseAssetId" in item ? item.defuseAssetId : item.unifiedAssetId,
+            item
+          )
         }
         return { data: updatedData, isFetched: true, isLoading: false }
       }),

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -22,3 +22,20 @@ export interface BaseTokenInfo extends Partial<BaseTokenBalance> {
   chainName: string
   routes: string[]
 }
+
+/**
+ * A virtual aggregation of the same token across multiple blockchains.
+ * This is not an on-chain token but a unified view of network-specific tokens
+ * with shared properties.
+ *
+ * The name avoids "NativeMultichainAsset" to clarify that it doesn't represent
+ * an actual multichain token, just a virtual abstraction.
+ */
+export interface UnifiedTokenInfo {
+  unifiedAssetId: string
+  symbol: string
+  name: string
+  decimals: number
+  icon: string
+  groupedTokens: BaseTokenInfo[]
+}

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -4,8 +4,8 @@ export enum BaseTokenConvertEnum {
 
 export type BaseTokenBalance = {
   balance: string
-  balanceUsd: string
-  convertedLast: {
+  balanceUsd?: string
+  convertedLast?: {
     [key in BaseTokenConvertEnum]: string
   }
 }

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -1,4 +1,4 @@
-import type { BaseTokenInfo } from "./base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "./base"
 
 // Message for EVM wallets
 export type EIP712Message = {
@@ -40,16 +40,18 @@ export type SwapEvent = {
   error?: string
 }
 
+export type SwappableToken = BaseTokenInfo | UnifiedTokenInfo
+
 export type SwapWidgetProps = {
   theme?: "dark" | "light"
-  tokenList: BaseTokenInfo[]
+  tokenList: SwappableToken[]
   onEmit?: (event: SwapEvent) => void
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
   onSuccessSwap: (params: {
     amountIn: bigint
     amountOut: bigint
-    tokenIn: BaseTokenInfo
-    tokenOut: BaseTokenInfo
+    tokenIn: SwappableToken
+    tokenOut: SwappableToken
   }) => void
 }
 

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -71,10 +71,6 @@ export type EstimateSwap = {
   selectTokenOut: SelectToken
 }
 
-export interface NetworkTokenWithSwapRoute extends BaseTokenInfo {
-  routes: string[]
-}
-
 export type EstimateQueueTransactions = {
   queueTransactionsTrack: QueueTransactionsEnum[]
   queueInTrack: number

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,4 +1,5 @@
 import { formatUnits } from "viem"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../types/base"
 
 export const smallBalanceToFormat = (balance: string, toFixed = 14): string => {
   if (!Number.parseFloat(balance)) {
@@ -27,4 +28,16 @@ export const tokenBalanceToFormatUnits = ({
   ).toString()
 
   return smallBalanceToFormat(balanceToUnits, 7)
+}
+
+export function isBaseToken(
+  token: BaseTokenInfo | UnifiedTokenInfo
+): token is BaseTokenInfo {
+  return "defuseAssetId" in token
+}
+
+export function isUnifiedToken(
+  token: BaseTokenInfo | UnifiedTokenInfo
+): token is UnifiedTokenInfo {
+  return "unifiedAssetId" in token
 }


### PR DESCRIPTION
# Summary

PR introduces `UnifiedTokenInfo` type, which solves natively multichain assets problem. 

```ts
/**
 * A virtual aggregation of the same token across multiple blockchains.
 * This is not an on-chain token but a unified view of network-specific tokens
 * with shared properties.
 *
 * The name avoids "NativeMultichainAsset" to clarify that it doesn't represent
 * an actual multichain token, just a virtual abstraction.
 */
export interface UnifiedTokenInfo {
  unifiedAssetId: string
  symbol: string
  name: string
  decimals: number
  icon: string
  groupedTokens: BaseTokenInfo[]
}
```

<details><summary>Example of definition of USDC</summary>
<p>

```ts
{
    unifiedAssetId: "usdc",
    symbol: "USDC",
    name: "USDC",
    decimals: 6,
    icon: "https://assets.coingecko.com/coins/images/6319/standard/usdc.png",
    groupedTokens: [
      {
        defuseAssetId:
          "near:mainnet:17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
        address:
          "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
        decimals: 6,
        icon: "https://assets.coingecko.com/coins/images/6319/standard/usdc.png",
        chainId: "mainnet",
        chainIcon: "/static/icons/network/near.svg",
        chainName: "NEAR",
        routes: [],
        symbol: "USDC",
        name: "USDC",
      },
      // and USDCs on other networks
    ],
  }
```

</p>
</details> 

# Changes
- add `UnifiedTokenInfo` types and type-guards to distinguish `UnifiedTokenInfo` and `BaseTokenInfo`
- update token select and modal to support new type of token

# Motivation

Why `UnifiedTokenInfo`, but not `NativelyMultichainAsset`? Because is just a virtual aggregation, it is not a real token or asset. In the future we may have an actual token which will represent multiple tokens on different chains. But for now it is just FE abstraction.

# Screenshots

<details><summary>Select UI</summary>
<p>

<img width="489" alt="Screenshot 2024-10-19 at 16 48 51" src="https://github.com/user-attachments/assets/eba3cd01-54f1-4870-a14f-ef461bc84aae">

<img width="545" alt="Screenshot 2024-10-19 at 16 48 57" src="https://github.com/user-attachments/assets/61bf99f6-72b0-4005-ae12-c24fb39c0c00">



</p>
</details> 

