### PR TITLE
feat(swap): transform signature to base58

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/themes": "^3.1.1",
     "@ref-finance/ref-sdk": "^1.3.8",
+    "@scure/base": "^1.1.9",
     "@statelyai/inspect": "^0.4.0",
     "@xstate/react": "^4.1.3",
     "axios": "^1.7.7",

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -22,7 +22,12 @@ export type NEP141SignatureData = {
   type: "NEP141"
   signatureData: {
     accountId: string
+    /**
+     * Base58-encoded signature with curve prefix. Example:
+     * ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga
+     */
     publicKey: string
+    /** Base64-encoded signature */
     signature: string
   }
 }

--- a/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
+++ b/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`prepareSwapSignedData() > should return the correct signed data for a NEP141 signature 1`] = `
+{
+  "message": "{"foo":"bar"}",
+  "nonce": "esXbbxyJNApGznX1v8kT5ojuat7jqUv84Ib+Q6hWdzI=",
+  "public_key": "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
+  "recipient": "defuse.near",
+  "signature": "ed25519:D33GxHszz1ZpkXpnEWYAwkQxeYBU9YCkTMKZ5uwDS1B9",
+  "standard": "nep141",
+}
+`;

--- a/src/utils/messageFactory.test.ts
+++ b/src/utils/messageFactory.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest"
-import { makeSwapMessage } from "./messageFactory"
+import { makeInnerSwapMessage, makeSwapMessage } from "./messageFactory"
 
 describe("makeSwapMessage()", () => {
+  const innerMessage = makeInnerSwapMessage({
+    tokenDiff: [["foo.near", 100n]],
+    signerId: "user.near",
+    deadlineTimestamp: 1000000,
+  })
+
   it("should return a WalletMessage object", () => {
     const message = makeSwapMessage({
-      tokenDiff: [["foo.near", 100n]],
-      signerId: "user.near",
+      innerMessage,
       recipient: "recipient.near",
-      deadlineTimestamp: 1000000,
       nonce: new Uint8Array(32),
     })
 
@@ -25,17 +29,13 @@ describe("makeSwapMessage()", () => {
 
   it("should return a WalletMessage with random nonce", () => {
     const msg1 = makeSwapMessage({
-      tokenDiff: [["foo.near", 100n]],
-      signerId: "signerId",
+      innerMessage,
       recipient: "recipient.near",
-      deadlineTimestamp: 1000000,
     })
 
     const msg2 = makeSwapMessage({
-      tokenDiff: [["foo.near", 100n]],
-      signerId: "signerId",
+      innerMessage,
       recipient: "recipient.near",
-      deadlineTimestamp: 1000000,
     })
 
     expect(msg1.NEP141.nonce).not.toEqual(msg2.NEP141.nonce)

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -4,25 +4,21 @@ import type {
   TokenAmountsForInt128,
 } from "../types/defuse-contracts-types"
 
-export function makeSwapMessage({
+export function makeInnerSwapMessage({
   tokenDiff,
   signerId,
-  recipient,
   deadlineTimestamp,
-  nonce = randomDefuseNonce(),
 }: {
   tokenDiff: [string, bigint][]
   signerId: string
-  recipient: string
   deadlineTimestamp: number
-  nonce?: Uint8Array
-}): WalletMessage {
+}): DefuseMessageFor_DefuseIntents {
   const serializedTokenDiff = tokenDiff.reduce((acc, [tokenId, amount]) => {
     acc[tokenId] = amount.toString()
     return acc
   }, {} as TokenAmountsForInt128)
 
-  const nep141Message: DefuseMessageFor_DefuseIntents = {
+  return {
     deadline: { timestamp: deadlineTimestamp },
     intents: [
       {
@@ -32,10 +28,20 @@ export function makeSwapMessage({
     ],
     signer_id: signerId,
   }
+}
 
+export function makeSwapMessage({
+  innerMessage,
+  recipient,
+  nonce = randomDefuseNonce(),
+}: {
+  innerMessage: DefuseMessageFor_DefuseIntents
+  recipient: string
+  nonce?: Uint8Array
+}): WalletMessage {
   return {
     NEP141: {
-      message: JSON.stringify(nep141Message),
+      message: JSON.stringify(innerMessage),
       recipient,
       nonce,
     },

--- a/src/utils/prepareBroadcastRequest.test.ts
+++ b/src/utils/prepareBroadcastRequest.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import type { NEP141SignatureData, WalletMessage } from "../types"
+import { prepareSwapSignedData } from "./prepareBroadcastRequest"
+
+describe("prepareSwapSignedData()", () => {
+  it("should return the correct signed data for a NEP141 signature", () => {
+    const signature: NEP141SignatureData = {
+      type: "NEP141",
+      signatureData: {
+        accountId: "user.near",
+        publicKey: "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
+        signature: "stH6JnShG+GwWCsfN9iu/m4un6qwYLN9Df+5oQYsL7Q=",
+      },
+    }
+
+    const walletMessage: WalletMessage = {
+      NEP141: {
+        message: `{"foo":"bar"}`,
+        recipient: "defuse.near",
+        nonce: Buffer.from(
+          "esXbbxyJNApGznX1v8kT5ojuat7jqUv84Ib+Q6hWdzI=",
+          "base64"
+        ),
+      },
+      EIP712: {
+        json: "{}",
+      },
+    }
+
+    expect(prepareSwapSignedData(signature, walletMessage)).toMatchSnapshot()
+  })
+})

--- a/src/utils/prepareBroadcastRequest.ts
+++ b/src/utils/prepareBroadcastRequest.ts
@@ -1,0 +1,30 @@
+import { base58, base64 } from "@scure/base"
+import type { WalletMessage, WalletSignatureResult } from "../types"
+
+export function prepareSwapSignedData(
+  signature: WalletSignatureResult,
+  walletMessage: WalletMessage
+) /* todo: type should be inferred from API schema */ {
+  switch (signature.type) {
+    case "NEP141": {
+      return {
+        standard: "nep141",
+        message: walletMessage.NEP141.message,
+        nonce: base64.encode(walletMessage.NEP141.nonce),
+        recipient: walletMessage.NEP141.recipient,
+        public_key: signature.signatureData.publicKey, // publicKey is already in the correct format
+        signature: transformNEP141Signature(signature.signatureData.signature),
+      }
+    }
+    case "EIP712": {
+      throw new Error("EIP712 signature is not supported")
+    }
+    default:
+      throw new Error("exhaustive check failed")
+  }
+}
+
+function transformNEP141Signature(signature: string) {
+  const encoded = base58.encode(base64.decode(signature))
+  return `ed25519:${encoded}`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,7 +1700,7 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz#0574d7e87b44ee8511d08cc7f914bcb802b70818"
   integrity sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==
 
-"@scure/base@~1.1.6", "@scure/base@~1.1.8":
+"@scure/base@^1.1.9", "@scure/base@~1.1.6", "@scure/base@~1.1.8":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
   integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==


### PR DESCRIPTION
PR:
- adds `@scure/base` package for base58 utility functions (it is already used by some of the dependencies)
- updates machines to store signature and signed message
- add transform functions that prepare data for sending to API