### PR TITLE
feat: add solver relay rpc http client

### DIFF
--- a/src/services/solverRelayHttpClient/apis.ts
+++ b/src/services/solverRelayHttpClient/apis.ts
@@ -1,0 +1,29 @@
+import { jsonRPCRequest } from "./runtime"
+import type * as types from "./types"
+
+export async function quote(
+  params: types.QuoteRequest["params"][0]
+): Promise<types.QuoteResponse["result"]> {
+  const json = await jsonRPCRequest<types.QuoteRequest>("quote", params)
+  return json.result
+}
+
+export async function publishIntent(
+  params: types.PublishIntentRequest["params"][0]
+): Promise<types.PublishIntentResponse["result"]> {
+  const json = await jsonRPCRequest<types.PublishIntentRequest>(
+    "publish_intent",
+    params
+  )
+  return json.result
+}
+
+export async function getStatus(
+  params: types.GetStatusRequest["params"][0]
+): Promise<types.GetStatusResponse["result"]> {
+  const json = await jsonRPCRequest<types.GetStatusRequest>(
+    "get_status",
+    params
+  )
+  return json.result
+}

--- a/src/services/solverRelayHttpClient/index.ts
+++ b/src/services/solverRelayHttpClient/index.ts
@@ -1,0 +1,2 @@
+export type * as types from "./types"
+export * from "./apis"

--- a/src/services/solverRelayHttpClient/runtime.ts
+++ b/src/services/solverRelayHttpClient/runtime.ts
@@ -1,0 +1,50 @@
+import type * as types from "./types"
+
+const BASE_URL = "https://solver-relay-v2.chaindefuser.com"
+
+async function request(url: string, body: unknown): Promise<Response> {
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    })
+  } catch (err) {
+    throw new FetchError("The request failed", { cause: err })
+  }
+
+  if (response.ok) {
+    return response
+  }
+
+  throw new ResponseError(response, "Response returned an error code")
+}
+
+export async function jsonRPCRequest<
+  T extends types.JSONRPCRequest<unknown, unknown>,
+>(method: T["method"], params: T["params"][0]) {
+  const response = await request(`${BASE_URL}/rpc`, {
+    id: "dontcare",
+    jsonrpc: "2.0",
+    method,
+    params: params !== undefined ? [params] : undefined,
+  })
+  return response.json()
+}
+
+class FetchError extends Error {
+  name = "FetchError"
+}
+
+class ResponseError extends Error {
+  name = "ResponseError"
+  constructor(
+    public response: Response,
+    msg?: string
+  ) {
+    super(msg)
+  }
+}

--- a/src/services/solverRelayHttpClient/types.ts
+++ b/src/services/solverRelayHttpClient/types.ts
@@ -1,0 +1,75 @@
+import type { DefuseMessageFor_DefuseIntents } from "../../types/defuse-contracts-types"
+
+export type JSONRPCRequest<Method, Params> = {
+  id: string
+  jsonrpc: "2.0"
+  method: Method
+  params: Params[]
+}
+
+export type JSONRPCResponse<Result> = {
+  id: string
+  jsonrpc: "2.0"
+  result: Result
+}
+
+export type QuoteRequest = JSONRPCRequest<
+  "quote",
+  {
+    defuse_asset_identifier_in: string
+    defuse_asset_identifier_out: string
+    amount_in: string
+    min_deadline_ms?: number
+  }
+>
+
+export type QuoteResponse = JSONRPCResponse<null | Array<{
+  quote_hash: string
+  defuse_asset_identifier_in: string
+  defuse_asset_identifier_out: string
+  amount_in: string
+  amount_out: string
+  expiration_time: number
+}>>
+
+export type PublishIntentRequest = JSONRPCRequest<
+  "publish_intent",
+  {
+    quote_hashes: string[]
+    signed_data: {
+      standard: string
+      message: DefuseMessageFor_DefuseIntents[]
+      signature: string
+      public_key: string
+      nonce: string
+      recipient: string
+    }
+  }
+>
+
+export type PublishIntentResponse = JSONRPCResponse<
+  | {
+      intent_hash: string
+      status: "OK"
+    }
+  | {
+      intent_hash: string
+      status: "FAILED"
+      reason: string | "expired" | "internal"
+    }
+>
+
+export type GetStatusRequest = JSONRPCRequest<
+  "get_status",
+  { intent_hash: string }
+>
+
+export type GetStatusResponse = JSONRPCResponse<{
+  intent_hash: string
+  status:
+    | "PENDING"
+    | "TX_BROADCASTED"
+    | "SETTLED"
+    | "NOT_FOUND_OR_NOT_VALID_ANYMORE"
+  data?: { hash: string }
+}>


### PR DESCRIPTION
I couldn't generate a client using JSON Schema and wrote a core implementation. It lacks of response data validation and proper JSON-RPC error propagation though. But for now as a starting point it is fine.