### PR TITLE
fix: Fix singing with `callbackUrl`

### DIFF
--- a/src/services/solverRelayHttpClient/types.ts
+++ b/src/services/solverRelayHttpClient/types.ts
@@ -1,5 +1,3 @@
-import type { DefuseMessageFor_DefuseIntents } from "../../types/defuse-contracts-types"
-
 export type JSONRPCRequest<Method, Params> = {
   id: string
   jsonrpc: "2.0"
@@ -23,6 +21,8 @@ export type QuoteRequest = JSONRPCRequest<
   }
 >
 
+export type Params<T extends JSONRPCRequest<unknown, unknown>> = T["params"][0]
+
 export type QuoteResponse = JSONRPCResponse<null | Array<{
   quote_hash: string
   defuse_asset_identifier_in: string
@@ -38,7 +38,8 @@ export type PublishIntentRequest = JSONRPCRequest<
     quote_hashes: string[]
     signed_data: {
       standard: string
-      message: DefuseMessageFor_DefuseIntents[]
+      message: string
+      callbackUrl?: string
       signature: string
       public_key: string
       nonce: string

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -16,6 +16,7 @@ export type NEP141Message = {
   message: string
   recipient: string
   nonce: Uint8Array
+  callbackUrl?: string
 }
 
 export type NEP141SignatureData = {
@@ -30,6 +31,11 @@ export type NEP141SignatureData = {
     /** Base64-encoded signature */
     signature: string
   }
+  /**
+   * The exact data that was signed. Wallet connectors may modify this during the signing process,
+   * so this property contains the actual data that was signed by the wallet.
+   */
+  signedData: NEP141Message
 }
 
 export type WalletMessage = {

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -12,15 +12,15 @@ export type EIP712SignatureData = {
 }
 
 // Message for NEAR wallets
-export type NEP141Message = {
+export type NEP413Message = {
   message: string
   recipient: string
   nonce: Uint8Array
   callbackUrl?: string
 }
 
-export type NEP141SignatureData = {
-  type: "NEP141"
+export type NEP413SignatureData = {
+  type: "NEP413"
   signatureData: {
     accountId: string
     /**
@@ -35,15 +35,15 @@ export type NEP141SignatureData = {
    * The exact data that was signed. Wallet connectors may modify this during the signing process,
    * so this property contains the actual data that was signed by the wallet.
    */
-  signedData: NEP141Message
+  signedData: NEP413Message
 }
 
 export type WalletMessage = {
   EIP712: EIP712Message
-  NEP141: NEP141Message
+  NEP413: NEP413Message
 }
 
-export type WalletSignatureResult = EIP712SignatureData | NEP141SignatureData
+export type WalletSignatureResult = EIP712SignatureData | NEP413SignatureData
 
 export type SwapEvent = {
   type: string

--- a/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
+++ b/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
@@ -2,11 +2,12 @@
 
 exports[`prepareSwapSignedData() > should return the correct signed data for a NEP141 signature 1`] = `
 {
+  "callbackUrl": undefined,
   "message": "{"foo":"bar"}",
   "nonce": "esXbbxyJNApGznX1v8kT5ojuat7jqUv84Ib+Q6hWdzI=",
   "public_key": "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
   "recipient": "defuse.near",
   "signature": "ed25519:D33GxHszz1ZpkXpnEWYAwkQxeYBU9YCkTMKZ5uwDS1B9",
-  "standard": "nep141",
+  "standard": "nep413",
 }
 `;

--- a/src/utils/messageFactory.test.ts
+++ b/src/utils/messageFactory.test.ts
@@ -16,7 +16,7 @@ describe("makeSwapMessage()", () => {
     })
 
     expect(message).toEqual({
-      NEP141: {
+      NEP413: {
         message: `{"deadline":{"timestamp":1000000},"intents":[{"intent":"token_diff","diff":{"foo.near":"100"}}],"signer_id":"user.near"}`,
         recipient: "recipient.near",
         nonce: new Uint8Array(32),
@@ -38,6 +38,6 @@ describe("makeSwapMessage()", () => {
       recipient: "recipient.near",
     })
 
-    expect(msg1.NEP141.nonce).not.toEqual(msg2.NEP141.nonce)
+    expect(msg1.NEP413.nonce).not.toEqual(msg2.NEP413.nonce)
   })
 })

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -40,7 +40,7 @@ export function makeSwapMessage({
   nonce?: Uint8Array
 }): WalletMessage {
   return {
-    NEP141: {
+    NEP413: {
       message: JSON.stringify(innerMessage),
       recipient,
       nonce,

--- a/src/utils/prepareBroadcastRequest.test.ts
+++ b/src/utils/prepareBroadcastRequest.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, it } from "vitest"
-import type { NEP141SignatureData, WalletMessage } from "../types"
+import type { NEP413SignatureData, WalletMessage } from "../types"
 import { prepareSwapSignedData } from "./prepareBroadcastRequest"
 
 describe("prepareSwapSignedData()", () => {
   it("should return the correct signed data for a NEP141 signature", () => {
-    const signature: NEP141SignatureData = {
-      type: "NEP141",
-      signatureData: {
-        accountId: "user.near",
-        publicKey: "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
-        signature: "stH6JnShG+GwWCsfN9iu/m4un6qwYLN9Df+5oQYsL7Q=",
-      },
-    }
-
     const walletMessage: WalletMessage = {
-      NEP141: {
+      NEP413: {
         message: `{"foo":"bar"}`,
         recipient: "defuse.near",
         nonce: Buffer.from(
@@ -25,6 +16,16 @@ describe("prepareSwapSignedData()", () => {
       EIP712: {
         json: "{}",
       },
+    }
+
+    const signature: NEP413SignatureData = {
+      type: "NEP413",
+      signatureData: {
+        accountId: "user.near",
+        publicKey: "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
+        signature: "stH6JnShG+GwWCsfN9iu/m4un6qwYLN9Df+5oQYsL7Q=",
+      },
+      signedData: walletMessage.NEP413,
     }
 
     expect(prepareSwapSignedData(signature, walletMessage)).toMatchSnapshot()

--- a/src/utils/prepareBroadcastRequest.ts
+++ b/src/utils/prepareBroadcastRequest.ts
@@ -1,17 +1,22 @@
 import { base58, base64 } from "@scure/base"
+import type {
+  Params,
+  PublishIntentRequest,
+} from "../services/solverRelayHttpClient/types"
 import type { WalletMessage, WalletSignatureResult } from "../types"
 
 export function prepareSwapSignedData(
   signature: WalletSignatureResult,
-  walletMessage: WalletMessage
-) /* todo: type should be inferred from API schema */ {
+  _walletMessage: WalletMessage
+): Params<PublishIntentRequest>["signed_data"] {
   switch (signature.type) {
     case "NEP141": {
       return {
         standard: "nep141",
-        message: walletMessage.NEP141.message,
-        nonce: base64.encode(walletMessage.NEP141.nonce),
-        recipient: walletMessage.NEP141.recipient,
+        message: signature.signedData.message,
+        nonce: base64.encode(signature.signedData.nonce),
+        recipient: signature.signedData.recipient,
+        callbackUrl: signature.signedData.callbackUrl,
         public_key: signature.signatureData.publicKey, // publicKey is already in the correct format
         signature: transformNEP141Signature(signature.signatureData.signature),
       }

--- a/src/utils/prepareBroadcastRequest.ts
+++ b/src/utils/prepareBroadcastRequest.ts
@@ -10,9 +10,9 @@ export function prepareSwapSignedData(
   _walletMessage: WalletMessage
 ): Params<PublishIntentRequest>["signed_data"] {
   switch (signature.type) {
-    case "NEP141": {
+    case "NEP413": {
       return {
-        standard: "nep141",
+        standard: "nep413",
         message: signature.signedData.message,
         nonce: base64.encode(signature.signedData.nonce),
         recipient: signature.signedData.recipient,


### PR DESCRIPTION
`callbackUrl` is important part of singing a message. It used to incorrect handle it. PR fix it as well as incorrect standard naming.