### PR TITLE
feat: add real quoting via relay api

### DIFF
--- a/src/features/machines/queryQuoteMachine.test.ts
+++ b/src/features/machines/queryQuoteMachine.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  aggregateQuotes,
+  calculateSplitAmounts,
+  queryQuote,
+} from "./queryQuoteMachine"
+
+import * as relayClient from "../../services/solverRelayHttpClient"
+
+vi.spyOn(relayClient, "quote")
+
+describe("queryQuote()", () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("quotes full amount if total available is less than requested", async () => {
+    const input = {
+      tokensIn: ["token1"],
+      tokensOut: ["tokenOut"],
+      amountIn: 150n,
+      balances: { token1: 100n },
+    }
+
+    vi.mocked(relayClient.quote).mockImplementationOnce(async () => [
+      {
+        quote_hash: "q1",
+        defuse_asset_identifier_in: "token1",
+        defuse_asset_identifier_out: "tokenOut",
+        amount_in: "150",
+        amount_out: "200",
+        expiration_time: 500,
+      },
+    ])
+
+    const result = await queryQuote(input)
+
+    expect(relayClient.quote).toHaveBeenCalledTimes(1)
+    expect(relayClient.quote).toHaveBeenCalledWith({
+      defuse_asset_identifier_in: "token1",
+      defuse_asset_identifier_out: "tokenOut",
+      amount_in: "150",
+      min_deadline_ms: 120_000,
+    })
+    expect(result).toEqual({
+      amountsIn: { token1: 150n },
+      amountsOut: { tokenOut: 200n },
+      expirationTime: 500,
+      quoteHashes: ["q1"],
+      totalAmountIn: 150n,
+      totalAmountOut: 200n,
+    })
+  })
+
+  it("splits amount across tokens if available balance is sufficient", async () => {
+    const input = {
+      tokensIn: ["token1", "token2"],
+      tokensOut: ["tokenOut"],
+      amountIn: 150n,
+      balances: { token1: 100n, token2: 100n },
+    }
+
+    vi.mocked(relayClient.quote)
+      .mockImplementationOnce(async () => [
+        {
+          quote_hash: "q1",
+          defuse_asset_identifier_in: "token1",
+          defuse_asset_identifier_out: "tokenOut",
+          amount_in: "100",
+          amount_out: "20",
+          expiration_time: 500,
+        },
+      ])
+      .mockImplementationOnce(async () => [
+        {
+          quote_hash: "q2",
+          defuse_asset_identifier_in: "token2",
+          defuse_asset_identifier_out: "tokenOut",
+          amount_in: "50",
+          amount_out: "10",
+          expiration_time: 500,
+        },
+      ])
+
+    const result = await queryQuote(input)
+
+    expect(relayClient.quote).toHaveBeenCalledTimes(2)
+    expect(relayClient.quote).toHaveBeenCalledWith({
+      defuse_asset_identifier_in: "token1",
+      defuse_asset_identifier_out: "tokenOut",
+      amount_in: "100",
+      min_deadline_ms: 120_000,
+    })
+    expect(relayClient.quote).toHaveBeenCalledWith({
+      defuse_asset_identifier_in: "token2",
+      defuse_asset_identifier_out: "tokenOut",
+      amount_in: "50",
+      min_deadline_ms: 120_000,
+    })
+    expect(result).toEqual({
+      amountsIn: { token1: 100n, token2: 50n },
+      amountsOut: { tokenOut: 30n },
+      expirationTime: 500,
+      quoteHashes: ["q1", "q2"],
+      totalAmountIn: 150n,
+      totalAmountOut: 30n,
+    })
+  })
+
+  it("takes only first quote", async () => {
+    const input = {
+      tokensIn: ["token1"],
+      tokensOut: ["tokenOut"],
+      amountIn: 150n,
+      balances: { token1: 100n },
+    }
+
+    vi.mocked(relayClient.quote).mockImplementationOnce(async () => [
+      {
+        quote_hash: "q1",
+        defuse_asset_identifier_in: "token1",
+        defuse_asset_identifier_out: "tokenOut",
+        amount_in: "150",
+        amount_out: "200",
+        expiration_time: 500,
+      },
+      {
+        quote_hash: "q2",
+        defuse_asset_identifier_in: "token1",
+        defuse_asset_identifier_out: "tokenOut",
+        amount_in: "150",
+        amount_out: "180",
+        expiration_time: 500,
+      },
+    ])
+
+    const result = await queryQuote(input)
+
+    expect(result).toEqual({
+      amountsIn: { token1: 150n },
+      amountsOut: { tokenOut: 200n },
+      expirationTime: 500,
+      quoteHashes: ["q1"],
+      totalAmountIn: 150n,
+      totalAmountOut: 200n,
+    })
+  })
+
+  it("returns empty result if quote is null", async () => {
+    const input = {
+      tokensIn: ["token1"],
+      tokensOut: ["tokenOut"],
+      amountIn: 150n,
+      balances: { token1: 100n },
+    }
+
+    vi.mocked(relayClient.quote)
+      .mockImplementationOnce(async () => null)
+      .mockImplementationOnce(async () => [])
+
+    await expect(queryQuote(input)).resolves.toEqual({
+      amountsIn: {},
+      amountsOut: {},
+      expirationTime: 0,
+      quoteHashes: [],
+      totalAmountIn: 0n,
+      totalAmountOut: 0n,
+    })
+
+    await expect(queryQuote(input)).resolves.toEqual({
+      amountsIn: {},
+      amountsOut: {},
+      expirationTime: 0,
+      quoteHashes: [],
+      totalAmountIn: 0n,
+      totalAmountOut: 0n,
+    })
+  })
+})
+
+it("calculateSplitAmounts(): splits amounts correctly", () => {
+  const tokensIn = ["token1", "token2", "token3"]
+  const amountIn = 150n
+  const balances = {
+    token1: 100n,
+    token2: 50n,
+    token3: 200n,
+  }
+
+  const result = calculateSplitAmounts(tokensIn, amountIn, balances)
+  expect(result).toEqual({
+    token1: 100n,
+    token2: 50n,
+  })
+})
+
+it("aggregateQuotes(): aggregates quotes correctly", () => {
+  const quotes = [
+    [
+      {
+        quote_hash: "q1",
+        defuse_asset_identifier_in: "token1",
+        defuse_asset_identifier_out: "tokenOut",
+        amount_in: "100",
+        amount_out: "200",
+        expiration_time: 5000,
+      },
+    ],
+    [
+      {
+        quote_hash: "q2",
+        defuse_asset_identifier_in: "token2",
+        defuse_asset_identifier_out: "tokenOut",
+        amount_in: "50",
+        amount_out: "100",
+        expiration_time: 4000,
+      },
+    ],
+  ]
+
+  const result = aggregateQuotes(quotes)
+
+  expect(result).toEqual({
+    amountsIn: { token1: 100n, token2: 50n },
+    amountsOut: { tokenOut: 300n },
+    expirationTime: 4000,
+    quoteHashes: ["q1", "q2"],
+    totalAmountIn: 150n,
+    totalAmountOut: 300n,
+  })
+})

--- a/src/features/machines/queryQuoteMachine.ts
+++ b/src/features/machines/queryQuoteMachine.ts
@@ -1,18 +1,171 @@
-import { setup } from "xstate"
+import { fromPromise } from "xstate"
+import { quote } from "../../services/solverRelayHttpClient"
+import type { QuoteResponse } from "../../services/solverRelayHttpClient/types"
 
-export const queryQuoteMachine = setup({
-  types: {
-    input: {} as {
-      tokensIn: string[]
-      tokensOut: string[]
-      amountIn: bigint
-      balances: Record<string, bigint>
-    },
-    output: {} as {
-      quoteHashes: string[]
-      expirationTime: number
-      totalAmountOut: bigint
-      amountsOut: Record<string, bigint>
-    },
-  },
-}).createMachine({})
+export interface Input {
+  tokensIn: string[] // set of close tokens, e.g. [USDC on Solana", USDC on Ethereum, USDC on Near]
+  tokensOut: string[] // set of close tokens, e.g. [USDC on Solana", USDC on Ethereum, USDC on Near]
+  amountIn: bigint // total amount in
+  balances: Record<string, bigint> // how many tokens of each type are available
+}
+
+export interface Output {
+  quoteHashes: string[]
+  expirationTime: number // earliest expiration time
+  totalAmountIn: bigint
+  totalAmountOut: bigint
+  amountsIn: Record<string, bigint> // amount in for each token
+  amountsOut: Record<string, bigint> // amount out for each token
+}
+
+type QuoteResults = QuoteResponse["result"]
+
+/**
+ * Machine to query quotes for a given input.
+ * It also acts as a simple router when natively multichain assets are involved.
+ */
+export const queryQuoteMachine = fromPromise(
+  async ({ input }: { input: Input }): Promise<Output> => queryQuote(input)
+)
+
+export async function queryQuote(input: Input): Promise<Output> {
+  // Sanity checks
+  const tokenOut = input.tokensOut[0]
+  assert(tokenOut != null, "tokensOut is empty")
+
+  const tokenIn = input.tokensIn[0]
+  assert(tokenIn != null, "tokensIn is empty")
+
+  // Calculate the total amount available across all input tokens
+  const totalAvailableIn = input.tokensIn.reduce((sum, token) => {
+    return sum + (input.balances[token] ?? 0n)
+  }, 0n)
+
+  // If total available is less than requested, just quote the full amount from one token
+  if (totalAvailableIn < input.amountIn) {
+    const q = await quote({
+      defuse_asset_identifier_in: tokenIn,
+      defuse_asset_identifier_out: tokenOut,
+      amount_in: input.amountIn.toString(),
+      min_deadline_ms: 120_000,
+    })
+
+    return aggregateQuotes([onlyValidQuotes(q)])
+  }
+
+  const amountsToQuote = calculateSplitAmounts(
+    input.tokensIn,
+    input.amountIn,
+    input.balances
+  )
+
+  const quotes = await fetchQuotesForTokens(
+    input.tokensIn,
+    tokenOut,
+    amountsToQuote
+  )
+
+  return aggregateQuotes(quotes)
+}
+
+function min(a: bigint, b: bigint): bigint {
+  return a < b ? a : b
+}
+
+function assert(condition: unknown, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg)
+  }
+}
+
+/**
+ * Function to calculate how to split the input amounts based on available balances
+ */
+export function calculateSplitAmounts(
+  tokensIn: string[],
+  amountIn: bigint,
+  balances: Record<string, bigint>
+): Record<string, bigint> {
+  let remainingAmountIn = amountIn
+  const amountsToQuote: Record<string, bigint> = {}
+
+  for (const tokenIn of tokensIn) {
+    const availableIn = balances[tokenIn] ?? 0n
+    const amountToQuote = min(availableIn, remainingAmountIn)
+
+    if (amountToQuote > 0n) {
+      amountsToQuote[tokenIn] = amountToQuote
+      remainingAmountIn -= amountToQuote
+    }
+
+    if (remainingAmountIn === 0n) break
+  }
+
+  return amountsToQuote
+}
+
+export function aggregateQuotes(quotes: NonNullable<QuoteResults>[]): Output {
+  let totalAmountIn = 0n
+  let totalAmountOut = 0n
+  const amountsIn: Record<string, bigint> = {}
+  const amountsOut: Record<string, bigint> = {}
+  const quoteHashes: string[] = []
+  let expirationTime = Number.POSITIVE_INFINITY
+
+  for (const qList of quotes) {
+    const q = qList[0] // It is expected to be the best quote
+    if (q === undefined) continue
+
+    const amountOut = BigInt(q.amount_out)
+    const amountIn = BigInt(q.amount_in)
+
+    totalAmountIn += amountIn
+    totalAmountOut += amountOut
+
+    expirationTime = Math.min(expirationTime, q.expiration_time)
+
+    amountsIn[q.defuse_asset_identifier_in] ??= 0n
+    amountsIn[q.defuse_asset_identifier_in] += amountIn
+    amountsOut[q.defuse_asset_identifier_out] ??= 0n
+    amountsOut[q.defuse_asset_identifier_out] += amountOut
+
+    quoteHashes.push(q.quote_hash)
+  }
+
+  return {
+    quoteHashes,
+    expirationTime:
+      expirationTime === Number.POSITIVE_INFINITY ? 0 : expirationTime,
+    totalAmountIn,
+    totalAmountOut,
+    amountsIn,
+    amountsOut,
+  }
+}
+
+export async function fetchQuotesForTokens(
+  tokensIn: string[],
+  tokenOut: string,
+  amountsToQuote: Record<string, bigint>
+): Promise<NonNullable<QuoteResults>[]> {
+  const quotes = await Promise.all(
+    tokensIn.map(async (tokenIn) => {
+      const amountIn = amountsToQuote[tokenIn]
+      if (amountIn === undefined || amountIn === 0n) return null
+
+      return quote({
+        defuse_asset_identifier_in: tokenIn,
+        defuse_asset_identifier_out: tokenOut,
+        amount_in: amountIn.toString(),
+        min_deadline_ms: 120_000,
+      })
+    })
+  )
+
+  return quotes.map(onlyValidQuotes)
+}
+
+function onlyValidQuotes(quotes: QuoteResults): NonNullable<QuoteResults> {
+  if (quotes === null) return []
+  return quotes.filter((q): q is NonNullable<typeof q> => q !== null)
+}

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -113,6 +113,9 @@ export const swapUIMachine = setup({
     updateUIAmountOut: () => {
       throw new Error("not implemented")
     },
+    setQuote: assign({
+      quote: (_, value: OutputFrom<typeof queryQuoteMachine>) => value,
+    }),
     clearQuote: assign({ quote: null }),
     clearError: assign({ error: null }),
     setOutcome: assign({
@@ -191,7 +194,7 @@ export const swapUIMachine = setup({
             id: "quoteQuerier",
             src: "queryQuote",
 
-            input: ({ context }) => ({
+            input: ({ context }): InputFrom<typeof queryQuoteMachine> => ({
               tokensIn: isBaseToken(context.formValues.tokenIn)
                 ? [context.formValues.tokenIn.defuseAssetId]
                 : context.formValues.tokenIn.groupedTokens.map(
@@ -208,7 +211,10 @@ export const swapUIMachine = setup({
 
             onDone: {
               target: "quoted",
-              actions: assign({ quote: ({ event }) => event.output }),
+              actions: {
+                type: "setQuote",
+                params: ({ event }) => event.output,
+              },
               reenter: true,
             },
 

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -1,5 +1,4 @@
 import { createActorContext } from "@xstate/react"
-import { parseUnits } from "ethers"
 import type { PropsWithChildren } from "react"
 import { useFormContext } from "react-hook-form"
 import { formatUnits } from "viem"
@@ -9,6 +8,7 @@ import type {
   WalletMessage,
   WalletSignatureResult,
 } from "../../../types"
+import { queryQuoteMachine } from "../../machines/queryQuoteMachine"
 import { swapIntentMachine } from "../../machines/swapIntentMachine"
 import { swapUIMachine } from "../../machines/swapUIMachine"
 import type { SwapFormValues } from "./SwapForm"
@@ -61,39 +61,7 @@ export function SwapUIMachineProvider({
             // We validate only `amountIn` and not entire form, because currently `amountOut` is also part of the form
             return trigger("amountIn")
           }),
-          queryQuote: fromPromise(async ({ input }) => {
-            const { amountIn } = getValues()
-
-            // todo: may throw if too many decimals, need to write safe parser
-            const amountInParsed = parseUnits(amountIn, assetIn.decimals)
-
-            // todo: replace code below with real quote request
-            console.warn("Do real quote request here")
-
-            // Simulate quote with a random factor around 1.5x amountInParsed
-            const baseAmountOut = (amountInParsed * 3n) / 2n
-
-            const randomFactor = (min: number, max: number) =>
-              BigInt(Math.floor(Math.random() * (max - min + 1) + min))
-
-            // Apply random factor within ±3%
-            const minFactor = 97
-            const maxFactor = 103
-            const randomMultiplier = randomFactor(minFactor, maxFactor)
-
-            const amountOutRandomized =
-              (baseAmountOut * randomMultiplier) / 100n
-
-            return {
-              quoteHashes: ["quoteHash"],
-              expirationTime: Math.floor(Date.now() / 1000) + 10 * 60,
-              totalAmountOut: amountOutRandomized,
-              amountsOut: {
-                // biome-ignore lint/style/noNonNullAssertion: <reason>
-                [input.tokensOut[0]!]: amountOutRandomized,
-              },
-            }
-          }),
+          queryQuote: queryQuoteMachine,
           // @ts-expect-error For some reason `swapIntentMachine` does not satisfy `swap` actor type
           swap: swapIntentMachine.provide({
             actors: {


### PR DESCRIPTION
# Background
Quoting natively multichain asset is challenging, because it depends on users actual balance. On one hand, we ought to give user a quote for any give input even if user does not have funds (e.g. user didn't connect). On other hand, we have to consider user balance, when user quotes for swap, for example, user has 1000 USDC on Solana, so it does not make sense to quote for 1000 USDC on Near, as they cannot do anything with this quote.

# Changes 
- add a couple of functions that solves client routing problem
- update swapUIMachine to use real quoting

(didn't update swapIntentMachine, because it won't directly use queryQuoteMachine)