### PR TITLE
feat: verify public key after singing swap message 

### DIFF
--- a/src/features/machines/publicKeyVerifierMachine.ts
+++ b/src/features/machines/publicKeyVerifierMachine.ts
@@ -1,0 +1,111 @@
+import type { providers } from "near-api-js"
+import type { CodeResult } from "near-api-js/lib/providers/provider"
+import { fromPromise } from "xstate"
+import { settings } from "../../config/settings"
+import type { Transaction } from "../../types/deposit"
+
+export type SendNearTransaction = (
+  tx: Transaction
+) => Promise<{ txHash: string } | null>
+
+export const publicKeyVerifierMachine = fromPromise(
+  async ({
+    input: { nearAccount, nearClient, sendNearTransaction },
+  }: {
+    input: {
+      nearAccount: { accountId: string; publicKey: string } | null
+      nearClient: providers.Provider
+      sendNearTransaction: SendNearTransaction
+    }
+  }): Promise<boolean> => {
+    // Don't need to verify public key if it is not Near account,
+    // because public key cannot change for non-Near accounts.
+    if (nearAccount == null) {
+      return true
+    }
+    return verifyPublicKey({ nearAccount, nearClient, sendNearTransaction })
+  }
+)
+
+async function verifyPublicKey({
+  nearAccount,
+  nearClient,
+  sendNearTransaction,
+}: {
+  nearClient: providers.Provider
+  nearAccount: { accountId: string; publicKey: string }
+  sendNearTransaction: SendNearTransaction
+}): Promise<boolean> {
+  let pubKeyIsOnchain: boolean
+  try {
+    pubKeyIsOnchain = await checkPublicKeyOnchain({ nearAccount, nearClient })
+  } catch (err: unknown) {
+    throw new Error("Error checking public key onchain", { cause: err })
+  }
+
+  if (pubKeyIsOnchain) {
+    return true
+  }
+
+  try {
+    return await addPublicKeyToContract({
+      pubKey: nearAccount.publicKey,
+      sendNearTransaction,
+    })
+  } catch (err: unknown) {
+    throw new Error("Error adding public key to contract", { cause: err })
+  }
+}
+
+async function checkPublicKeyOnchain({
+  nearAccount,
+  nearClient,
+}: {
+  nearClient: providers.Provider
+  nearAccount: { accountId: string; publicKey: string }
+}): Promise<boolean> {
+  const output = await nearClient.query<CodeResult>({
+    request_type: "call_function",
+    account_id: settings.defuseContractId,
+    method_name: "has_public_key",
+    args_base64: btoa(
+      JSON.stringify({
+        account_id: nearAccount.accountId,
+        public_key: nearAccount.publicKey,
+      })
+    ),
+    finality: "optimistic",
+  })
+
+  const stringData = String.fromCharCode(...output.result)
+  const value = JSON.parse(stringData)
+  if (typeof value !== "boolean") {
+    throw new Error("Unexpected response from has_public_key")
+  }
+
+  return value
+}
+
+async function addPublicKeyToContract({
+  pubKey,
+  sendNearTransaction,
+}: {
+  pubKey: string
+  sendNearTransaction: SendNearTransaction
+}): Promise<boolean> {
+  const tx: Transaction = {
+    receiverId: settings.defuseContractId,
+    actions: [
+      {
+        type: "FunctionCall",
+        params: {
+          methodName: "add_public_key",
+          args: { public_key: pubKey },
+          gas: "300000000000000",
+          deposit: "1",
+        },
+      },
+    ],
+  }
+  return (await sendNearTransaction(tx)) != null
+}

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -1,4 +1,5 @@
 import { parseUnits } from "ethers"
+import type { providers } from "near-api-js"
 import {
   type InputFrom,
   type OutputFrom,
@@ -9,6 +10,7 @@ import {
   setup,
 } from "xstate"
 import type { SwappableToken } from "../../types"
+import type { Transaction } from "../../types/deposit"
 import { isBaseToken } from "../../utils"
 import type { queryQuoteMachine } from "./queryQuoteMachine"
 import type { swapIntentMachine } from "./swapIntentMachine"
@@ -44,7 +46,16 @@ export const swapUIMachine = setup({
             amountIn: string
           }>
         }
-      | { type: "submit"; params: { userAddress: string } },
+      | {
+          type: "submit"
+          params: {
+            userAddress: string
+            nearClient: providers.Provider
+            sendNearTransaction: (
+              tx: Transaction
+            ) => Promise<{ txHash: string } | null>
+          }
+        },
 
     emitted: {} as {
       type: "swap_finished"
@@ -281,6 +292,8 @@ export const swapUIMachine = setup({
 
           return {
             userAddress: event.params.userAddress,
+            nearClient: event.params.nearClient,
+            sendNearTransaction: event.params.sendNearTransaction,
             quote,
             tokenIn: context.formValues.tokenIn,
             tokenOut: context.formValues.tokenOut,

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useContext, useEffect } from "react"
 import { useFormContext } from "react-hook-form"
 import { ButtonCustom, ButtonSwitch } from "../../../components/Button"
 import { Form } from "../../../components/Form"
@@ -7,6 +7,7 @@ import type { ModalSelectAssetsPayload } from "../../../components/Modal/ModalSe
 import { useModalStore } from "../../../providers/ModalStoreProvider"
 import { ModalType } from "../../../stores/modalStore"
 import type { SwappableToken } from "../../../types"
+import { SwapSubmitterContext } from "./SwapSubmitter"
 import { SwapUIMachineContext } from "./SwapUIMachineProvider"
 
 export type SwapFormValues = {
@@ -14,11 +15,7 @@ export type SwapFormValues = {
   amountOut: string
 }
 
-export interface SwapFormProps {
-  userAddress: string | null
-}
-
-export const SwapForm = ({ userAddress }: SwapFormProps) => {
+export const SwapForm = () => {
   const {
     handleSubmit,
     register,
@@ -73,16 +70,12 @@ export const SwapForm = ({ userAddress }: SwapFormProps) => {
     }
   }, [payload, onCloseModal, swapUIActorRef])
 
+  const { onSubmit } = useContext(SwapSubmitterContext)
+
   return (
     <div className="md:max-w-[472px] rounded-[1rem] p-5 shadow-paper bg-white dark:shadow-paper-dark dark:bg-black-800">
       <Form<SwapFormValues>
-        handleSubmit={handleSubmit(() => {
-          if (userAddress != null) {
-            swapUIActorRef.send({ type: "submit", params: { userAddress } })
-          } else {
-            console.warn("User address is not authenticated")
-          }
-        })}
+        handleSubmit={handleSubmit(onSubmit)}
         register={register}
       >
         <FieldComboInput<SwapFormValues>

--- a/src/features/swap/components/SwapSubmitter.tsx
+++ b/src/features/swap/components/SwapSubmitter.tsx
@@ -1,0 +1,55 @@
+import { providers } from "near-api-js"
+import { type ReactNode, createContext, useEffect } from "react"
+import type { SendNearTransaction } from "../../machines/publicKeyVerifierMachine"
+import { SwapUIMachineContext } from "./SwapUIMachineProvider"
+
+export const SwapSubmitterContext = createContext<{
+  onSubmit: () => void
+}>({
+  onSubmit: () => {},
+})
+
+export function SwapSubmitterProvider({
+  children,
+  userAddress,
+  sendNearTransaction,
+}: {
+  children: ReactNode
+  userAddress: string | null
+  sendNearTransaction: SendNearTransaction
+}) {
+  const actorRef = SwapUIMachineContext.useActorRef()
+
+  useEffect(() => {
+    const sub = actorRef.subscribe((state) => {
+      console.log("SwapSubmitterProvider state", state.value, state)
+    })
+    return () => {
+      sub.unsubscribe()
+    }
+  }, [actorRef])
+
+  const onSubmit = () => {
+    if (userAddress == null) {
+      console.warn("No user address provided")
+      return
+    }
+
+    actorRef.send({
+      type: "submit",
+      params: {
+        userAddress,
+        nearClient: new providers.JsonRpcProvider({
+          url: "https://rpc.mainnet.near.org",
+        }),
+        sendNearTransaction,
+      },
+    })
+  }
+
+  return (
+    <SwapSubmitterContext.Provider value={{ onSubmit }}>
+      {children}
+    </SwapSubmitterContext.Provider>
+  )
+}

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -4,12 +4,14 @@ import { useTokensStore } from "../../../providers/TokensStoreProvider"
 import type { SwapWidgetProps } from "../../../types"
 import { SwapForm } from "./SwapForm"
 import { SwapFormProvider } from "./SwapFormProvider"
+import { SwapSubmitterProvider } from "./SwapSubmitter"
 import { SwapUIMachineFormSyncProvider } from "./SwapUIMachineFormSyncProvider"
 import { SwapUIMachineProvider } from "./SwapUIMachineProvider"
 
 export const SwapWidget = ({
   tokenList,
   userAddress,
+  sendNearTransaction,
   signMessage,
   onSuccessSwap,
 }: SwapWidgetProps) => {
@@ -29,7 +31,12 @@ export const SwapWidget = ({
           signMessage={signMessage}
         >
           <SwapUIMachineFormSyncProvider onSuccessSwap={onSuccessSwap}>
-            <SwapForm userAddress={userAddress} />
+            <SwapSubmitterProvider
+              userAddress={userAddress}
+              sendNearTransaction={sendNearTransaction}
+            >
+              <SwapForm />
+            </SwapSubmitterProvider>
           </SwapUIMachineFormSyncProvider>
         </SwapUIMachineProvider>
       </SwapFormProvider>

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -1,3 +1,4 @@
+import type { SendNearTransaction } from "../features/machines/publicKeyVerifierMachine"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "./base"
 
 // Message for EVM wallets
@@ -63,6 +64,8 @@ export type SwapWidgetProps = {
    * `null` if the user is not authenticated.
    */
   userAddress: string | null
+
+  sendNearTransaction: SendNearTransaction
 
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
   onSuccessSwap: (params: {


### PR DESCRIPTION
# Background
Public key is important part of Defuse protocol. Most blockchain accounts one way or another have public keys. In most blockchains accounts have a single immutable pub key, but on Near accounts can manage their public keys (add or delete them). 

When user signs a message, they use a public key. In order to allow a particular public key to manage user's assets, user needs to tell us about that key by sending a transaction (`add_public_key` to defuse contract). 

# Changes
PR adds an extra step before publishing an intent. On that step it checks presence of the public key (extracted from signature), and if not it urges the user to send a `add_public_key` transaction.