### PR TITLE
feat: status of intent

### DIFF
--- a/src/features/machines/queryQuoteMachine.ts
+++ b/src/features/machines/queryQuoteMachine.ts
@@ -2,14 +2,14 @@ import { fromPromise } from "xstate"
 import { quote } from "../../services/solverRelayHttpClient"
 import type { QuoteResponse } from "../../services/solverRelayHttpClient/types"
 
-export interface Input {
+export interface AggregatedQuoteParams {
   tokensIn: string[] // set of close tokens, e.g. [USDC on Solana", USDC on Ethereum, USDC on Near]
   tokensOut: string[] // set of close tokens, e.g. [USDC on Solana", USDC on Ethereum, USDC on Near]
   amountIn: bigint // total amount in
   balances: Record<string, bigint> // how many tokens of each type are available
 }
 
-export interface Output {
+export interface AggregatedQuote {
   quoteHashes: string[]
   expirationTime: number // earliest expiration time
   totalAmountIn: bigint
@@ -25,10 +25,15 @@ type QuoteResults = QuoteResponse["result"]
  * It also acts as a simple router when natively multichain assets are involved.
  */
 export const queryQuoteMachine = fromPromise(
-  async ({ input }: { input: Input }): Promise<Output> => queryQuote(input)
+  async ({
+    input,
+  }: { input: AggregatedQuoteParams }): Promise<AggregatedQuote> =>
+    queryQuote(input)
 )
 
-export async function queryQuote(input: Input): Promise<Output> {
+export async function queryQuote(
+  input: AggregatedQuoteParams
+): Promise<AggregatedQuote> {
   // Sanity checks
   const tokenOut = input.tokensOut[0]
   assert(tokenOut != null, "tokensOut is empty")
@@ -104,7 +109,9 @@ export function calculateSplitAmounts(
   return amountsToQuote
 }
 
-export function aggregateQuotes(quotes: NonNullable<QuoteResults>[]): Output {
+export function aggregateQuotes(
+  quotes: NonNullable<QuoteResults>[]
+): AggregatedQuote {
   let totalAmountIn = 0n
   let totalAmountOut = 0n
   const amountsIn: Record<string, bigint> = {}

--- a/src/features/machines/queryQuoteMachine.ts
+++ b/src/features/machines/queryQuoteMachine.ts
@@ -11,7 +11,8 @@ export interface AggregatedQuoteParams {
 
 export interface AggregatedQuote {
   quoteHashes: string[]
-  expirationTime: number // earliest expiration time
+  /** Earliest expiration time in seconds */
+  expirationTime: number
   totalAmountIn: bigint
   totalAmountOut: bigint
   amountsIn: Record<string, bigint> // amount in for each token

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -153,9 +153,20 @@ export const swapIntentMachine = setup({
       throw new Error("not implemented")
     },
     isSignatureValid: ({ context }) => {
-      // todo: Implement this guard
-      console.warn("isSignatureValid guard is not implemented")
-      return context.signature != null
+      if (context.signature == null) return false
+
+      switch (context.signature.type) {
+        case "NEP413":
+          return (
+            // For NEP-413, it's enough to ensure user didn't switch the account
+            context.signature.signatureData.accountId === context.userAddress
+          )
+        case "EIP712":
+          // For EIP-712, we need to derive the signer address from the signature
+          throw new Error("EIP712 signature is not supported")
+        default:
+          throw new Error("exhaustive check failed")
+      }
     },
     isIntentRelevant: ({ context }) => {
       // Naively assume that the quote is still relevant if the expiration time is in the future

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -4,7 +4,6 @@ import type { providers } from "near-api-js"
 import {
   type ActorRefFrom,
   type OutputFrom,
-  and,
   assign,
   fromPromise,
   setup,
@@ -152,14 +151,17 @@ export const swapIntentMachine = setup({
     isNotFoundOrInvalid: () => {
       throw new Error("not implemented")
     },
-    isSignatureValid: ({ context }) => {
-      if (context.signature == null) return false
+    isSignatureValid: (
+      { context },
+      signature: WalletSignatureResult | null
+    ) => {
+      if (signature == null) return false
 
-      switch (context.signature.type) {
+      switch (signature.type) {
         case "NEP413":
           return (
             // For NEP-413, it's enough to ensure user didn't switch the account
-            context.signature.signatureData.accountId === context.userAddress
+            signature.signatureData.accountId === context.userAddress
           )
         case "EIP712":
           // For EIP-712, we need to derive the signer address from the signature
@@ -176,7 +178,7 @@ export const swapIntentMachine = setup({
     isTrue: (_, params: boolean) => params,
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6HCAGzAGIBtABgF1FQMB7WHAnNvFkAB6IAjMIAcJACwBOAGwB2AKxiATJMnDpAZkmyANCACeiLVvkklK+iuk2tixfWmKAvi4OpMuQsQIkAyjhQePhQ1BC8YGR4AG5sANZRnMEAsnCwaDAMzEgg7JzcvPxCCFoS9FrS8irC9PSyZvJiugbGCLLNUmKOsrWSYvRicm4e6Nj4RKSBwaHhkdFxiSTJeGmwGVnCOawcXDx8uSVYKp31KgrWss7C8vTyrYhXkiRivZplMsKKKq7uIJ7jHxTIIhPBhMAAJwhbAhJAwFDQBAAZjCALbLEFrDZgbL8fJ7IqHRBYRz0EgOaxiKnVJTSZoPBAOZ6VE6WLRqW7CEb-MbeSZ+ABqkJwSMMoQABAAFACuACMKDgAMbigDSYEMUohcGIipoETwUXwiySvImvhIQohIrFYKlcoVyrVGslWtgOrACCNbEViP22VxuXxhQOoBKOhIWnoijkcjE8mkkm+wgZCeeVO0skkJzkKhO3IBfPNlutEpl8qVqvVmu1eF1cwNCwSJq8ZtIxdFpftFad1bdtY9Xp9wf9Wzxu2DxWJNkUJDUWdssmzYnEkhT6heQy0mezi5s+dNQMFwo7trLDsrztd7uokOhsPhiJREPRBdbR6tJ6gdvLjqrLpruqerE3q+rw-pMGOBT7JOCAkqIFhaJo4i1PQmjyMmRiIKowgvJI9AyJmUaZtI+4toeJAAELQmgEA+rA3C2gAkoe9aGsBSx9hAWKZDiEGBuO0FEgg2izjciZZvI1RxvYDLCDozzCJI8gaLm8hbkMvyjGR-KUdRtFoPRErMfyN5QjCcIIsiaLLMQXHpDxAY7FBhKhsSjgqC8CjSHIdzCOcsiKFosmaDOiiyL0uhWIpmZaKRgI6e2NpfsZvh0HxTkEiGggiOIs46HSAUXBoVyyXcWgkLGHTRmpSjKHFhZtseSXiilhB0KO-HOVlJQyB5Pz4dFag9NIsmJhIkm9SolQKEM9VviQADiYAEAxyWHuK-gEIi0qwKxjYcQeOlLStRnrZt22wEBcRDn6TCOXkAkudlpQzjYWZxlSZQJkoq6YQgwi7rOdSOPGgzLlmc3kcdq0tWdW0EDte1egd2nmtDp38ht8M7VdIHDndHUZROQnqSQAWmM46jnNYU2yYDVhRnc0hg4pKiQ0dy0w61BBYxdpl3hZj7Wa+UOcxjvi8wjl2DqBeDgdsD1dTBJJ3BYtymFmK72L9bSKeuymLvYKhNNISFuH8eBsBAcD8CL-KQZlysONICFIcudRoSosnhicA2DJI7JfK87PmuQVAO8Trn-TUEboXJiiiE07JDAy5wSAHxuKDIzSKTcmk8qjwIzGCEeCVHWAyBGAeiKbi53FYOuIFmshdLc04Bd5ZQh41H7NWe3Z-le-al09PXmJmyhfPYW4NCnf3Li7iGSd8ShXJUkjd34ADCvBIjgz6QCP3UiKY5KVIFflqbmdKya8EiiDc4UX+TsV-Hb5oAHJsDzABibDSngCA4oYSwxiGgBUEAj4wSzGmL4ihqi9SqDcW+ygIyLgDnSD4dx87v1IAAQVlDCIgkDOqOyEscKMFUtxhUTsuW42hb7M1nPICefk6SazEJvXSbAaJ0S5oeKB5D+jBUrgMUQW5TZ1H6FwxK4tCCCKjrUGc9dtA2DEPJAKYhSqKQjN5aw2C5KXC4ejJicMLoKOespKQWcqayFQgMOoWi-q5xdtndRbdMHGOIMKZUABRMyEILFHEcBIcKclXjG2NspJxushhkmNhPXMkZJIkXNkAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6HCAGzAGIBtABgF1FQMB7WHAnNvFkAB6IAjAGYAHCXoAmesIAsogKxLxSgOzCZAGhABPRKPnCS4uaOlqlw4dPUA2AL6PdqTLkLECJAMo4oePhQ1BC8YGR4AG5sANbhnAEAsnCwaDAMzEgg7JzcvPxCCML2JMLW9g5K9vKKoqL2ugYI9uLyJACc9KLqqrbS9kry0s6u6Nj4RKR+AUEhYRHRcSQJeMmwqenCmawcXDx8WYVYlm309v3qMvbt1pfqjYjXbeL2Nu0S8u1l0kojIG7jTxTfyBPDBMAAJwhbAhJAwFDQBAAZjCALbLEFrDZgDL8HJ7fKHRBYJT0egkFQycTU9R2JTtVoPBAqNqidqWHrSCzyS7CP4AjyTbwANUhOCReiCAAIAAoAVwARhQcABjKUAaTAellELgxBVNFCeHC+EW8TGgq8JFFEPFkrBssVyrVmu1Mt1sH1YAQprYKsR+wyuKy+LyB1AhSMJFE9Hp1xa6na8iU0mETKTz3E72qlna50s-ItEytNrt0vlStVGq1Or1eANc2NC1i5vcxdIpYl5adVddtc99e9vv9YaDWzxuzDBWJ0huJGkNVn-Vz4mEjP0iAzpiz9SGWfz7ULbaBIrFXYdFed1bdHq91Eh0Nh8MRKIh6IF7dPtvPUEdlZdNbunWBo+lEfoBrwQZMBOuT7NOCAkjYJDqKIwhfKuZJoZoTLiKmpjyPQnzVLG1SHi4-xFieJAAELQmgED+rA3AOgAkiejYmmBSwDhAWJpDi0EhpOcFEgg4jqB0LT0OIyg9EoEhGEyYg1KUPLGNIdj1FmvzkR+VG0Ww9GMcxv5sUK95QjCcIIsiaLLMQvEpPxwY7LBhIRsSpLSKYFTtHm9CaP0AyiEpaFKBS9ivPI5xyNFihHoCQrWme9qmexLnZMJ7mCIgLzIQuGioTyRh+e0SkBSUkWyNJSbsuoQwJZaHYpdKZleHQ45CW54Y5QgnzeT8hEKOcyZnGVG5FMmkjqPV7Jcnm6hZo1n4kAA4mABAmVKbWEFKPgEIicqwBxzbcZRSXrZtrUnntB0EEdoHRCOgZMBloYiR5CDKPOSYnHUaj5uISn5vOZKkom0mrg1unnVal1bTtBC3Ydx1GpxZrLLDpDw9dQrI-dsCPeBo6vZ1rkEj1kYtCQwVsoMQz2DIXLAxpoOxgFnTUgowww8eF0bQjN37SjFmPtZL52Xp-NXaxQt3Q9w4QXgUHbJl3XwSSAXIZcdRDGuiiDEpNRtPV5zKHYWZoXyfx4GwEBwPwUteDBFMayo7TIah6FaHI7S0kp30yfYCnUnYPKqMtVHkFQLtTqJCjklmNR+7O7JoRYTL9B7DLibJwgoTNPOjHzVrTKCUCxx9vVYJ80aKG8xSyLShFMgzJDyOJMg3AMfkSJHSWdqlf5Xn2QEDgalfZYUPI08mi2LaofurvcE2rh7qEzSmPTXGy8j91aBlGWgTG487XWu6JNdAxNNi12YNj1F8ZId-vzXfkPiOT5TIixlItLvLOGSNQBjXyaFoBQ0Y-IyACtYGM-RX7eBxrLPGwsCZf3gtcUGpIO4xnzgpFeYDjAe1JNYWMPJg7SQQSQAAwrwJEOA3yQHQaJKo7cGQtHQotAi5wlBKReJIGwa4fg3DZIzUQVCABybAkYADE2ByjwBAKUMJtpRDQMqCAzDPpDGeGUDQC52R+3znw1Q0YRpshkq0GBVCACCCoYREE0efOOn1ji-2zFUGwi1870HeHwzo84HDJlsAyPW4gqHrWNLaNUABRSyEItHV1JJISKYgXh2DsPVUBIgszkjsNUFMXIAqJmcM4IAA */
   context: ({ input }) => {
     return {
       quoterRef: null,
@@ -239,7 +241,10 @@ export const swapIntentMachine = setup({
         onDone: [
           {
             target: "Verifying Public Key Presence",
-            guard: { type: "isSigned", params: ({ event }) => event.output },
+            guard: {
+              type: "isSignatureValid",
+              params: ({ event }) => event.output,
+            },
 
             actions: {
               type: "setSignature",
@@ -349,7 +354,7 @@ export const swapIntentMachine = setup({
       always: [
         {
           target: "Broadcasting Intent",
-          guard: and(["isIntentRelevant", "isSignatureValid"]),
+          guard: "isIntentRelevant",
         },
         {
           target: "Not Found or Invalid",

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -157,10 +157,9 @@ export const swapIntentMachine = setup({
       console.warn("isSignatureValid guard is not implemented")
       return context.signature != null
     },
-    isIntentRelevant: () => {
-      // todo: Implement this guard
-      console.warn("isIntentRelevant guard is not implemented")
-      return true
+    isIntentRelevant: ({ context }) => {
+      // Naively assume that the quote is still relevant if the expiration time is in the future
+      return context.quote.expirationTime * 1000 > Date.now()
     },
     isSigned: (_, params: WalletSignatureResult | null) => params != null,
     isTrue: (_, params: boolean) => params,

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -42,6 +42,7 @@ type Context = {
     innerMessage: DefuseMessageFor_DefuseIntents
   }
   signature: WalletSignatureResult | null
+  error: unknown
 }
 
 type Input = {
@@ -56,7 +57,7 @@ type Input = {
 
 type Output = {
   // todo: Output is expected to include intent status, intent entity and other relevant data
-  status: "aborted" | "confirmed" | "not-found-or-invalid" | "network-error"
+  status: "aborted" | "confirmed" | "not-found-or-invalid" | "generic-error"
 }
 
 export const swapIntentMachine = setup({
@@ -66,11 +67,11 @@ export const swapIntentMachine = setup({
     output: {} as Output,
   },
   actions: {
-    setError: () => {
-      throw new Error("not implemented")
-    },
-    logError: (_, err: unknown) => {
-      console.error(err)
+    setError: assign({
+      error: (_, params: { error: unknown }) => params.error,
+    }),
+    logError: (_, params: { error: unknown }) => {
+      console.error(params.error)
     },
     assembleSignMessages: assign({
       messageToSign: ({ context }) => {
@@ -165,12 +166,13 @@ export const swapIntentMachine = setup({
     isTrue: (_, params: boolean) => params,
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6HCAGzAGIBtABgF1FQMB7WHAnNvFkAB6IAjMIAcJACwBOAGwB2AKxiATJMnDpAZkmyANCACeiLVvkklK+iuk2tixfWmKAvi4OpMuQsQIkAamAATjgAZob4UAAEAAoArgBGFDgAxlEA0mCGsUFwxCk0ELxgZHgAbmwA1iWe2PhEpIEh4ZGxiclpmdkxubD5YAj4FSlo3LwMjBP87JxjfEiCJpIkWvSKcnJi8tKSiirCBsYIO8tiYtqykirnsirXbh7odT6NwWEReNHxSakZWTl5PAFahFPAlIZVGpPbwNPxNd6tb4dP7dXr9QblNgjOYTWjCZgLGZcHjzUBCBBYDQSFSKLQ7WR7OTXbSHRAnEhnC5XG53aQPEC1GG+AJvFqfNo-Tr-HqA4HBIJsIIkDAUUahRUAWxIgvqwvhYq+7V+XQBfSBAwh2JJuKY0w4xN4-HJWC0snoJAU0nokjM1j2jn0RkQYnUJEUDOE9Hk6lU8jEsn5OpefgAyjgoHhIiDiqUKtVtem8ABZOCwNAwKaE+1zJ0mCT0Onyfb0eiyMxx3SshCyENSMQByOSMT0G6J6G60hpjNZ0HgzH5zgZkuwMsV-F22Yk2sUyRRkhRu6qUzCcP7LuyaTmeQN27yJSiOTyMdeCepwtZ+WK5WqgjqoJaxdi1LcswErVhqy3BZnR0aQpEvXcG0UeRZGEQMjgcFQSBPaQ5HoYQVF9HZn2eWESAAIQVNAIBGWBuHFABJZNszBXNIW1YgIGXVdQNtKtN0dKC2S0Eh9mjRQrjva55HsLthB0ZZhEkaN8JUaSe2cYihVICi2Comi6OiRjYWoT8lRVNVNXYvBOOAitePA-jSUWClhDjETZDbbQ8NUaRFNkulFHcxTxGQhRrE018RWaD5DKYsCQCJGtBIQURqRg+Nw2vDQL1kqNhM2Ht1mkpRlAi5MooRBi4vXPiHSc8kZEwmlvUU25dlbaRZN2CQ70agjH3OMrSIAcTAAgDKiIzfCiFMCFGOJYGYuc8yhF9ytG8bWimwgZrmggFoxYZRmtJh4sSyCyRMQKbG5OMxC0c4lPE2TbialtHG2EcxEUlQhuFDaJu2ghdvmxbZ1Yhdx3WsbAeTEH9tgQ6sWO8ZTpqhy6u3V0JAZUxnHUFQ3TuLQXruET3qjL0zh+v7SABra4dm0GTKCBUzJ-P8AKhkaYYZ2F4YOy0UbwG0CQxpLLopZwPXWVTVFvNTJFk2llhkJTI3kRSzGkMQ3HcEA8DYCA4H4JNYQ3THkspDyRNpelGVuc4SaDFKdBE4ddy0O4NA12m-HIKgLYl5z8OEFZNbkxRRDjL3zi7QmJB9VTxJ1jQNCUP2KoNCVkRNGUzQKIOLucpSPW6k97FdNs45d77YK0VzLCUC86UkTOp0zT4i4EyXKXrn0H1Qqwm29LsrlkPtrxscN1m0XX9bN4UAGFeFCHB-0gbv6pEUwwwChvVK9mwxFk+MJFEVyPNpVDaS0TOADk2GBgAxNg4msqJFUm8o0GSCAt+3FcU4J4kJqFsJeVyp9lArDanSe6IYoyuAXtzYUABBBIioiD-1qsHZ0Nh3Q6DjPhcMSkRwqFPl6ESyFdgN12D2W4mcdJ6TQLRPmvgAFWyHLJRSsFhyiFdL5FsQ5M76hit-c2ODi7kkjIFA82hj7yQZCfF2kZFIrBwtYRBclrAJmQWtUi98xooEVJUKIABRVmioOG90jO6fYahXS6BniORQFC7HUNsKsUwzdM70yqvzJmCNrHOWjFIcSBM3TiBbCOLqmg4JnF9AovWLggA */
+  /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCA6HCAGzAGIBtABgF1FQMB7WHAnNvFkAB6IAjMIAcJACwBOAGwB2AKxiATJMnDpAZkmyANCACeiLVvkklK+iuk2tixfWmKAvi4OpMuQsQIkAyjhQePhQ1BC8YGR4AG5sANZRnMEAsnCwaDAMzEgg7JzcvPxCCFoS9FrS8irC9PSyZvJiugbGCLLNUmKOsrWSYvRicm4e6Nj4RKSBwaHhkdFxiSTJeGmwGVnCOawcXDx8uSVYKp31KgrWss7C8vTyrYhXkiRivZplMsKKKq7uIJ7jHxTIIhPBhMAAJwhbAhJAwFDQBAAZjCALbLEFrDZgbL8fJ7IqHRBYRz0EgOaxiKnVJTSZoPBAOZ6VE6WLRqW7CEb-MbeSZ+ABqkJwSMMoQABAAFACuACMKDgAMbigDSYEMUohcGIipoETwUXwiySvImvhIQohIrFYKlcoVyrVGslWtgOrACCNbEViP22VxuXxhQOoBKOhIWnoijkcjE8mkkm+wgZCeeVO0skkJzkKhO3IBfPNlutEpl8qVqvVmu1eF1cwNCwSJq8ZtIxdFpftFad1bdtY9Xp9wf9Wzxu2DxWJNkUJDUWdssmzYnEkhT6heQy0mezi5s+dNQMFwo7trLDsrztd7uokOhsPhiJREPRBdbR6tJ6gdvLjqrLpruqerE3q+rw-pMGOBT7JOCAkqIFhaJo4i1PQmjyMmRiIKowgvJI9AyJmUaZtI+4toeJAAELQmgEA+rA3C2gAkoe9aGsBSx9hAWKZDiEGBuO0FEgg2izjciZZvI1RxvYDLCDozzCJI8gaLm8hbkMvyjGR-KUdRtFoPRErMfyN5QjCcIIsiaLLMQXHpDxAY7FBhKhsSjgqC8CjSHIdzCOcsiKFosmaDOiiyL0uhWIpmZaKRgI6e2NpfsZvh0HxTkEiGggiOIs46HSAUXBoVyyXcWgkLGHTRmpSjKHFhZtseSXiilhB0KO-HOVlJQyB5Pz4dFag9NIsmJhIkm9SolQKEM9VviQADiYAEAxyWHuK-gEIi0qwKxjYcQeOlLStRnrZt22wEBcRDn6TCOXkAkudlpQzjYWZxlSZQJkoq6YQgwi7rOdSOPGgzLlmc3kcdq0tWdW0EDte1egd2nmtDp38ht8M7VdIHDndHUZROQnqSQAWmM46jnNYU2yYDVhRnc0hg4pKiQ0dy0w61BBYxdpl3hZj7Wa+UOcxjvi8wjl2DqBeDgdsD1dTBJJ3BYtymFmK72L9bSKeuymLvYKhNNISFuH8eBsBAcD8CL-KQZlysONICFIcudRoSosnhicA2DJI7JfK87PmuQVAO8Trn-TUEboXJiiiE07JDAy5wSAHxuKDIzSKTcmk8qjwIzGCEeCVHWAyBGAeiKbi53FYOuIFmshdLc04Bd5ZQh41H7NWe3Z-le-al09PXmJmyhfPYW4NCnf3Li7iGSd8ShXJUkjd34ADCvBIjgz6QCP3UiKY5KVIFflqbmdKya8EiiDc4UX+TsV-Hb5oAHJsDzABibDSngCA4oYSwxiGgBUEAj4wSzGmL4ihqi9SqDcW+ygIyLgDnSD4dx87v1IAAQVlDCIgkDOqOyEscKMFUtxhUTsuW42hb7M1nPICefk6SazEJvXSbAaJ0S5oeKB5D+jBUrgMUQW5TZ1H6FwxK4tCCCKjrUGc9dtA2DEPJAKYhSqKQjN5aw2C5KXC4ejJicMLoKOespKQWcqayFQgMOoWi-q5xdtndRbdMHGOIMKZUABRMyEILFHEcBIcKclXjG2NspJxushhkmNhPXMkZJIkXNkAA */
   context: ({ input }) => {
     return {
       quoterRef: null,
       messageToSign: null,
       signature: null,
+      error: null,
       ...input,
     }
   },
@@ -202,7 +204,20 @@ export const swapIntentMachine = setup({
       invoke: {
         id: "signMessage",
 
-        onError: "Aborted",
+        onError: {
+          target: "Generic Error",
+          reenter: true,
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => event,
+            },
+          ],
+        },
 
         src: "signMessage",
 
@@ -264,12 +279,105 @@ export const swapIntentMachine = setup({
           },
         ],
         onError: {
-          target: "Aborted",
-          actions: {
-            type: "logError",
-            // @ts-expect-error Incorrect `event` type, `error` present in `event` for sure
-            params: ({ event }) => event.error,
+          target: "Generic Error",
+
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => event,
+            },
+          ],
+
+          reenter: true,
+        },
+      },
+    },
+
+    "Broadcasting Intent": {
+      invoke: {
+        id: "sendMessage",
+        input: ({ context }) => {
+          assert(context.signature != null, "Signature is not set")
+          assert(context.messageToSign != null, "Sign message is not set")
+
+          return {
+            quoteHashes: context.quote.quoteHashes,
+            signatureData: context.signature,
+          }
+        },
+        src: "broadcastMessage",
+        onError: {
+          target: "Generic Error",
+
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => event,
+            },
+          ],
+
+          reenter: true,
+        },
+        onDone: {
+          target: "Getting Intent Status",
+          reenter: true,
+        },
+      },
+      description:
+        "Send user proof of sign (signature) to solver bus \\[relay responsibility\\].\n\nResult:\n\n- Update \\[context\\] with proof of broadcasting from solver;",
+    },
+
+    "Verifying Intent": {
+      always: [
+        {
+          target: "Broadcasting Intent",
+          guard: and(["isIntentRelevant", "isSignatureValid"]),
+        },
+        {
+          target: "Not Found or Invalid",
+          reenter: true,
+        },
+      ],
+    },
+
+    "Getting Intent Status": {
+      invoke: {
+        src: "getIntentStatus",
+
+        onDone: [
+          {
+            target: "Confirmed",
+            guard: "isSettled",
+            reenter: true,
           },
+          {
+            target: "Not Found or Invalid",
+            guard: "isNotFoundOrInvalid",
+            reenter: true,
+          },
+        ],
+
+        onError: {
+          target: "Generic Error",
+          reenter: true,
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => event,
+            },
+          ],
         },
       },
     },
@@ -298,76 +406,10 @@ export const swapIntentMachine = setup({
       },
     },
 
-    "Broadcasting Intent": {
-      invoke: {
-        id: "sendMessage",
-        input: ({ context }) => {
-          assert(context.signature != null, "Signature is not set")
-          assert(context.messageToSign != null, "Sign message is not set")
-
-          return {
-            quoteHashes: context.quote.quoteHashes,
-            signatureData: context.signature,
-          }
-        },
-        src: "broadcastMessage",
-        onError: {
-          target: "Network Error",
-
-          actions: "setError",
-
-          reenter: true,
-        },
-        onDone: {
-          target: "Getting Intent Status",
-          reenter: true,
-        },
-      },
-      description:
-        "Send user proof of sign (signature) to solver bus \\[relay responsibility\\].\n\nResult:\n\n- Update \\[context\\] with proof of broadcasting from solver;",
-    },
-
-    "Verifying Intent": {
-      always: [
-        {
-          target: "Broadcasting Intent",
-          guard: and(["isIntentRelevant", "isSignatureValid"]),
-        },
-        {
-          target: "Not Found or Invalid",
-          reenter: true,
-        },
-      ],
-    },
-
-    "Network Error": {
+    "Generic Error": {
       type: "final",
       output: {
-        status: "network-error",
-      },
-    },
-
-    "Getting Intent Status": {
-      invoke: {
-        src: "getIntentStatus",
-
-        onDone: [
-          {
-            target: "Confirmed",
-            guard: "isSettled",
-            reenter: true,
-          },
-          {
-            target: "Not Found or Invalid",
-            guard: "isNotFoundOrInvalid",
-            reenter: true,
-          },
-        ],
-
-        onError: {
-          target: "Network Error",
-          reenter: true,
-        },
+        status: "generic-error",
       },
     },
   },

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -15,6 +15,20 @@ import { isBaseToken } from "../../utils"
 import type { queryQuoteMachine } from "./queryQuoteMachine"
 import type { swapIntentMachine } from "./swapIntentMachine"
 
+export type Context = {
+  error: Error | null
+  quote: OutputFrom<typeof queryQuoteMachine> | null
+  outcome: OutputFrom<typeof swapIntentMachine> | null
+  formValues: {
+    tokenIn: SwappableToken
+    tokenOut: SwappableToken
+    amountIn: string
+  }
+  parsedFormValues: {
+    amountIn: bigint
+  }
+}
+
 export const swapUIMachine = setup({
   types: {
     children: {} as {
@@ -24,19 +38,7 @@ export const swapUIMachine = setup({
       tokenIn: SwappableToken
       tokenOut: SwappableToken
     },
-    context: {} as {
-      error: Error | null
-      quote: OutputFrom<typeof queryQuoteMachine> | null
-      outcome: OutputFrom<typeof swapIntentMachine> | null
-      formValues: {
-        tokenIn: SwappableToken
-        tokenOut: SwappableToken
-        amountIn: string
-      }
-      parsedFormValues: {
-        amountIn: bigint
-      }
-    },
+    context: {} as Context,
     events: {} as
       | {
           type: "input"
@@ -182,6 +184,7 @@ export const swapUIMachine = setup({
         submit: {
           target: "submitting",
           guard: "isQuoteRelevant",
+          actions: "clearOutcome",
         },
         input: {
           target: ".validating",

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -303,13 +303,17 @@ export const swapUIMachine = setup({
 
         onDone: {
           target: "editing.validating",
-
           actions: [
             { type: "setOutcome", params: ({ event }) => event.output },
             { type: "emitSwapFinish", params: ({ event }) => event.output },
           ],
+        },
 
-          reenter: true,
+        onError: {
+          target: "editing.validating",
+          actions: ({ event }) => {
+            console.error(event.error)
+          },
         },
       },
     },

--- a/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
@@ -39,13 +39,19 @@ export function SwapUIMachineFormSyncProvider({
 
   useEffect(() => {
     const sub = actorRef.on("swap_finished", (state) => {
-      if (state.data.intentOutcome.status === "confirmed") {
-        onSuccessSwapRef.current({
-          amountIn: state.data.amountIn,
-          amountOut: state.data.amountOut,
-          tokenIn: state.data.tokenIn,
-          tokenOut: state.data.tokenOut,
-        })
+      const intentStatus = state.data.intentOutcome.status
+      switch (intentStatus) {
+        case "SETTLED": {
+          onSuccessSwapRef.current({
+            amountIn: state.data.amountIn,
+            amountOut: state.data.amountOut,
+            tokenIn: state.data.tokenIn,
+            tokenOut: state.data.tokenOut,
+            txHash: state.data.intentOutcome.txHash,
+            intentHash: state.data.intentOutcome.intentHash,
+          })
+          break
+        }
       }
     })
 

--- a/src/services/intentService.ts
+++ b/src/services/intentService.ts
@@ -1,0 +1,101 @@
+import type { WalletSignatureResult } from "../types"
+import { prepareSwapSignedData } from "../utils/prepareBroadcastRequest"
+import * as solverRelayClient from "./solverRelayHttpClient"
+import type * as types from "./solverRelayHttpClient/types"
+
+export async function submitIntent(
+  signatureData: WalletSignatureResult,
+  quoteHashes: string[]
+) {
+  // todo: retry on network error
+  const result = await solverRelayClient.publishIntent({
+    signed_data: prepareSwapSignedData(signatureData),
+    quote_hashes: quoteHashes,
+  })
+  // todo: check status, it may be "FAILED"
+  return result.intent_hash
+}
+
+export async function waitForIntentSettlement(
+  signal: AbortSignal,
+  intentHash: string
+) {
+  let attempts = 0
+  const MAX_INVALID_ATTEMPTS = 3 // ~600 ms of waiting
+
+  let lastSeenResult: types.GetStatusResponse["result"] | null = null
+  let txHash: string | null = null
+
+  while (true) {
+    signal.throwIfAborted()
+
+    // todo: add retry in case of network error
+    const res = await solverRelayClient.getStatus({
+      intent_hash: intentHash,
+    })
+
+    const status = res.status
+    switch (status) {
+      case "PENDING":
+        // Do nothing, just wait
+        break
+
+      case "TX_BROADCASTED":
+        txHash = res.data.hash
+        break
+
+      case "SETTLED":
+        return {
+          status: "SETTLED" as const,
+          txHash: res.data.hash,
+          intentHash: res.intent_hash,
+        }
+
+      case "NOT_FOUND_OR_NOT_VALID": {
+        if (
+          // If previous status differs, we're sure new result is final
+          (lastSeenResult != null && lastSeenResult.status !== res.status) ||
+          // If we've seen only NOT_VALID and keep getting it then we should abort
+          MAX_INVALID_ATTEMPTS <= ++attempts
+        ) {
+          return {
+            status: "NOT_FOUND_OR_NOT_VALID" as const,
+            txHash: txHash,
+            intentHash: res.intent_hash,
+          }
+        }
+        break
+      }
+
+      default:
+        status satisfies never
+    }
+
+    lastSeenResult = res
+
+    // Wait a bit before polling again
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+}
+
+export function doesSignatureMatchUserAddress(
+  signature: WalletSignatureResult | null,
+  userAddress: string
+) {
+  if (signature == null) return false
+
+  const signatureType = signature.type
+  switch (signatureType) {
+    case "NEP413":
+      return (
+        // For NEP-413, it's enough to ensure user didn't switch the account
+        signature.signatureData.accountId === userAddress
+      )
+    case "EIP712":
+      // For EIP-712, we need to derive the signer address from the signature
+      throw new Error("EIP712 signature is not supported")
+    default:
+      signatureType satisfies never
+      throw new Error("exhaustive check failed")
+  }
+}

--- a/src/services/solverRelayHttpClient/types.ts
+++ b/src/services/solverRelayHttpClient/types.ts
@@ -80,7 +80,7 @@ export type GetStatusResponse = JSONRPCResponse<
       data: { hash: string }
     }
   | {
-      status: "NOT_FOUND_OR_NOT_VALID_ANYMORE"
+      status: "NOT_FOUND_OR_NOT_VALID"
       intent_hash: string
     }
 >

--- a/src/services/solverRelayHttpClient/types.ts
+++ b/src/services/solverRelayHttpClient/types.ts
@@ -64,12 +64,23 @@ export type GetStatusRequest = JSONRPCRequest<
   { intent_hash: string }
 >
 
-export type GetStatusResponse = JSONRPCResponse<{
-  intent_hash: string
-  status:
-    | "PENDING"
-    | "TX_BROADCASTED"
-    | "SETTLED"
-    | "NOT_FOUND_OR_NOT_VALID_ANYMORE"
-  data?: { hash: string }
-}>
+export type GetStatusResponse = JSONRPCResponse<
+  | {
+      status: "PENDING"
+      intent_hash: string
+    }
+  | {
+      status: "TX_BROADCASTED"
+      intent_hash: string
+      data: { hash: string }
+    }
+  | {
+      status: "SETTLED"
+      intent_hash: string
+      data: { hash: string }
+    }
+  | {
+      status: "NOT_FOUND_OR_NOT_VALID_ANYMORE"
+      intent_hash: string
+    }
+>

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -73,6 +73,8 @@ export type SwapWidgetProps = {
     amountOut: bigint
     tokenIn: SwappableToken
     tokenOut: SwappableToken
+    txHash: string
+    intentHash: string
   }) => void
 }
 


### PR DESCRIPTION
# Summary
The main purpose of the PR is to formalize states of the swap flow and statuses of an intent. The main changes are made in `swapIntentMachine`. The swap flow states are grouped by intent creation outcomes:

- "sad" states (we could not create an intent)
  - `ERR_USER_DIDNT_SIGN`
  - `ERR_SIGNED_DIFFERENT_ACCOUNT`
  - `ERR_CANNOT_VERIFY_PUBLIC_KEY`
  - `ERR_CANNOT_ADD_PUBLIC_KEY`
  - `ERR_CANNOT_PUBLISH_INTENT`

- "happy" states (we managed to create an intent)
  - `SETTLED`
  - `NOT_FOUND_OR_NOT_VALID`
  - `ERR_CANNOT_OBTAIN_INTENT_STATUS`
