### PR TITLE
refactor: separate intent

### DIFF
--- a/src/features/machines/intentStatusMachine.ts
+++ b/src/features/machines/intentStatusMachine.ts
@@ -40,7 +40,7 @@ export const intentStatusMachine = setup({
       settlementResult.status === "SETTLED",
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QEsB2AXMGDK6CG6ArrAHQAOWEaUAxAMIASAonQNIDaADALqKhkB7WMnTIBqPiAAeiAIwAWAGwlFAJlWdVAVk5aAzLMUB2AJyKANCACecziZJbZnI88WOjADhOrFAX1+WaJg4+ESkAMYAFmDhANbUNBDiYCRoAG4CsSlBWOi4BMQkUTHxqFAI6QLhBGKoXNz1koLCouKSMghaqh4kHlpa8npeWkayqvKyljYIHrIkeuomCsYeemaq-oEYuflhRdFxCUmo2agZWanbIQURB6XlldWtdTzssrxIIM0ite2IXXNVAZOLIloMXEYpnIzPMRgZTF0PN15BsAiActc9sVDmUaGAAE74gT48gAGwIADNiQBbS7BPKhQrY+4VM5VGrieqNT7fZ5-BCqJYkTjwkGyUYmEX6KECnwkIxKLp6LSKRRKRSyLSbdFXBk3EgEon4mgAJSYABUTQBNbn8IQ-NqfDryLQqeSSjyrVRGAz9LQyvTyHpGb0jXScThBtX+NGoAQQOCSDF6sJNe18p2IAC03RI3hFa09QyMqrcMqzPS63o8QeREccHm1yd2hQoqCoZTTLV+mYQoOFplVYo1QL0yplTlUJFUCiRgZdKxdTd1LduJWoXYdEl73uUOj0oz0nFWSLMMs8vQjYwUnEUZlMJmX9NXJFghHC4Tg8B56Z7oA6JizCQQbyM4JgHh4IIqhOEZ5ookE1t4EzKkGT47IypBxugAD6aR4KSyAQJuGb-ogJimMBKrhh4pgeG48gTuB05GJ4LETEikFaI2aLNhhBqEsSxF-tIiDKnoDi6KqKIzoKsiBgGQbzCY-QKIGhagjGvhAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QEsB2AXMGDK6CG6ArrAHQAOWEaUAxANoAMAuoqGQPazLrLuqsgAHogCMAFgBsJCQCYZDGQFYGigMwiJAdgCcEgDQgAnqIbaSikQ01WJFzQA5tMiQF8XBtJhz4ipAMYAFmB+ANbUNBB8YCRoAG7sIdGeWOi4BMQkgcFhqFAIcex+BLyojExlAhxcPHwCwgiKMvYk9oqKYqqOipoiMmIiBsYI9iIkqnLa4lr2qroybh4YKWm+mUGh4ZGoSajxiTFL3un+6zl5BUU1pcx0IixIIFXcJXWIjaMy6gwikx3WmoNRLoxt11DpGvYmmJ5u4QMkjqsshtcjQwAAnNHsNHkAA2BAAZliALYHLypHwZJFnfK7QrFPhlCoPJ5XV4IGSTEgMMHfEQ9bTctSA9nOEiaSSNVSKCQSSQSESKBZww7k44kdGYtE0ABKAFEACragCaTLYnGetQe9TEimkYgF9hmMk06jaimFqjEzU0zu6KgYDC9srcsNQ7AgcAE8NVvkq5tZVsQAFomiQnNzZo7OpoZbZhUnmo1nfYFPYOmIbfaldGVhkKKgqLk49UXomED8uToZbz5Z9VFLhZYZCQZOJIZ6bdMbdWVbWTtlqM2Lfw286pMpVD1VAwZpDdMKHC0A71xAwJLodNoZ2S5yRYIQ-H44PBmfHW6B6toRiQvWIrNpNxLBV9CMEwGDTCQSzLJx+ilL1r2WClSDDdAAH1YjwHFkAgJcEw-RBtB0H9pX9ewdHsWwxEHACR00Bw6P6SES0UewEIRDINSxXD3yERApVUcwVBlaFRw5ERPQ9L0xm0NpxE9TMfhDFwgA */
   id: "intentStatus",
   initial: "pending",
   context: ({ input }) => {
@@ -51,9 +51,7 @@ export const intentStatusMachine = setup({
   },
   states: {
     pending: {
-      on: {
-        CHECK: "checking",
-      },
+      always: "checking",
     },
     checking: {
       invoke: {

--- a/src/features/machines/intentStatusMachine.ts
+++ b/src/features/machines/intentStatusMachine.ts
@@ -1,0 +1,100 @@
+import { assign, fromPromise, setup } from "xstate"
+import {
+  type IntentSettlementResult,
+  waitForIntentSettlement,
+} from "../../services/intentService"
+
+export const intentStatusMachine = setup({
+  types: {
+    input: {} as {
+      intentHash: string
+    },
+    context: {} as {
+      intentHash: string
+      txHash: string | null
+    },
+  },
+  actions: {
+    logError: (_, params: { error: unknown }) => {
+      console.error(params.error)
+    },
+    setSettlementResult: assign({
+      txHash: (_, settlementResult: IntentSettlementResult) =>
+        settlementResult.txHash,
+    }),
+  },
+  actors: {
+    checkIntentStatus: fromPromise(
+      ({
+        input,
+        signal,
+      }: {
+        input: { intentHash: string }
+        signal: AbortSignal
+      }): Promise<IntentSettlementResult> =>
+        waitForIntentSettlement(signal, input.intentHash)
+    ),
+  },
+  guards: {
+    isSettled: (_, settlementResult: IntentSettlementResult) =>
+      settlementResult.status === "SETTLED",
+  },
+}).createMachine({
+  /** @xstate-layout N4IgpgJg5mDOIC5QEsB2AXMGDK6CG6ArrAHQAOWEaUAxAMIASAonQNIDaADALqKhkB7WMnTIBqPiAAeiAIwAWAGwlFAJlWdVAVk5aAzLMUB2AJyKANCACecziZJbZnI88WOjADhOrFAX1+WaJg4+ESkAMYAFmDhANbUNBDiYCRoAG4CsSlBWOi4BMQkUTHxqFAI6QLhBGKoXNz1koLCouKSMghaqh4kHlpa8npeWkayqvKyljYIHrIkeuomCsYeemaq-oEYuflhRdFxCUmo2agZWanbIQURB6XlldWtdTzssrxIIM0ite2IXXNVAZOLIloMXEYpnIzPMRgZTF0PN15BsAiActc9sVDmUaGAAE74gT48gAGwIADNiQBbS7BPKhQrY+4VM5VGrieqNT7fZ5-BCqJYkTjwkGyUYmEX6KECnwkIxKLp6LSKRRKRSyLSbdFXBk3EgEon4mgAJSYABUTQBNbn8IQ-NqfDryLQqeSSjyrVRGAz9LQyvTyHpGb0jXScThBtX+NGoAQQOCSDF6sJNe18p2IAC03RI3hFa09QyMqrcMqzPS63o8QeREccHm1yd2hQoqCoZTTLV+mYQoOFplVYo1QL0yplTlUJFUCiRgZdKxdTd1LduJWoXYdEl73uUOj0oz0nFWSLMMs8vQjYwUnEUZlMJmX9NXJFghHC4Tg8B56Z7oA6JizCQQbyM4JgHh4IIqhOEZ5ookE1t4EzKkGT47IypBxugAD6aR4KSyAQJuGb-ogJimMBKrhh4pgeG48gTuB05GJ4LETEikFaI2aLNhhBqEsSxF-tIiDKnoDi6KqKIzoKsiBgGQbzCY-QKIGhagjGvhAA */
+  id: "intentStatus",
+  initial: "pending",
+  context: ({ input }) => {
+    return {
+      intentHash: input.intentHash,
+      txHash: null,
+    }
+  },
+  states: {
+    pending: {
+      on: {
+        CHECK: "checking",
+      },
+    },
+    checking: {
+      invoke: {
+        src: "checkIntentStatus",
+        input: ({ context }) => ({ intentHash: context.intentHash }),
+        onDone: [
+          {
+            target: "success",
+            guard: {
+              type: "isSettled",
+              params: ({ event }) => event.output,
+            },
+            actions: {
+              type: "setSettlementResult",
+              params: ({ event }) => event.output,
+            },
+          },
+          {
+            target: "not_valid",
+            reenter: true,
+          },
+        ],
+        onError: {
+          target: "error",
+          actions: {
+            type: "logError",
+            params: ({ event }) => event,
+          },
+        },
+      },
+    },
+    success: {
+      type: "final",
+    },
+    not_valid: {
+      type: "final",
+    },
+    error: {
+      on: {
+        RETRY: "pending",
+      },
+    },
+  },
+})

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -317,6 +317,7 @@ export const swapUIMachine = setup({
                 if (event.output.status !== "INTENT_PUBLISHED")
                   return context.intentRefs
 
+                // todo: take quote from result of `swap`
                 assert(context.quote != null, "quote is null")
 
                 const intentRef = spawn("intentStatus", {
@@ -330,7 +331,7 @@ export const swapUIMachine = setup({
                   },
                 })
 
-                return [...context.intentRefs, intentRef]
+                return [intentRef, ...context.intentRefs]
               },
             }),
             {

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from "@xstate/react"
-import { useContext, useEffect } from "react"
+import { Fragment, useContext, useEffect } from "react"
 import { useFormContext } from "react-hook-form"
+import { formatUnits } from "viem"
 import type { ActorRefFrom } from "xstate"
 import { ButtonCustom, ButtonSwitch } from "../../../components/Button"
 import { Form } from "../../../components/Form"
@@ -133,8 +134,13 @@ function Intents({
 }: { intentRefs: ActorRefFrom<typeof intentStatusMachine>[] }) {
   return (
     <div>
-      {intentRefs.map((intentRef) => {
-        return <Intent key={intentRef.id} intentRef={intentRef} />
+      {intentRefs.map((intentRef, i, list) => {
+        return (
+          <Fragment key={intentRef.id}>
+            <Intent intentRef={intentRef} />
+            {i < list.length - 1 && <hr />}
+          </Fragment>
+        )
       })}
     </div>
   )
@@ -145,26 +151,49 @@ function Intent({
 }: { intentRef: ActorRefFrom<typeof intentStatusMachine> }) {
   const snapshot = useSelector(intentRef, (state) => state)
 
+  const amountIn = formatUnits(
+    snapshot.context.quote.totalAmountIn,
+    snapshot.context.tokenIn.decimals
+  )
+  const amountOut = formatUnits(
+    snapshot.context.quote.totalAmountOut,
+    snapshot.context.tokenOut.decimals
+  )
+
+  const swapInfo = `${amountIn} ${snapshot.context.tokenIn.symbol} -> ${amountOut} ${snapshot.context.tokenOut.symbol}`
+
   const value = snapshot.value
   switch (value) {
     case "pending":
       return (
         <div>
+          {swapInfo} 💤
+          <br />
           Checking intent status... intentHash: {snapshot.context.intentHash}
         </div>
       )
     case "checking":
       return (
         <div>
+          {swapInfo} 💤
+          <br />
           Checking intent status... intentHash: {snapshot.context.intentHash}{" "}
           tx: {snapshot.context.txHash}
         </div>
       )
     case "success":
-      return <div>Intent settled! tx: {snapshot.context.txHash}</div>
+      return (
+        <div>
+          {swapInfo} ✅
+          <br />
+          Intent settled! tx: {snapshot.context.txHash}
+        </div>
+      )
     case "not_valid":
       return (
         <div>
+          {swapInfo} ❌
+          <br />
           Intent not valid! tx: {snapshot.context.txHash} intent:{" "}
           {snapshot.context.intentHash}
         </div>
@@ -172,6 +201,8 @@ function Intent({
     case "error":
       return (
         <div>
+          {swapInfo} 😓
+          <br />
           Error checking intent status! tx: {snapshot.context.txHash} intent:{" "}
           {snapshot.context.intentHash}
           <button

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -1,5 +1,7 @@
+import { useSelector } from "@xstate/react"
 import { useContext, useEffect } from "react"
 import { useFormContext } from "react-hook-form"
+import type { ActorRefFrom } from "xstate"
 import { ButtonCustom, ButtonSwitch } from "../../../components/Button"
 import { Form } from "../../../components/Form"
 import { FieldComboInput } from "../../../components/Form/FieldComboInput"
@@ -7,6 +9,7 @@ import type { ModalSelectAssetsPayload } from "../../../components/Modal/ModalSe
 import { useModalStore } from "../../../providers/ModalStoreProvider"
 import { ModalType } from "../../../stores/modalStore"
 import type { SwappableToken } from "../../../types"
+import type { intentStatusMachine } from "../../machines/intentStatusMachine"
 import type { Context } from "../../machines/swapUIMachine"
 import { SwapSubmitterContext } from "./SwapSubmitter"
 import { SwapUIMachineContext } from "./SwapUIMachineProvider"
@@ -25,7 +28,7 @@ export const SwapForm = () => {
 
   const swapUIActorRef = SwapUIMachineContext.useActorRef()
   const snapshot = SwapUIMachineContext.useSelector((snapshot) => snapshot)
-  const intentOutcome = snapshot.context.outcome
+  const intentCreationResult = snapshot.context.intentCreationResult
 
   const { tokenIn, tokenOut } = SwapUIMachineContext.useSelector(
     (snapshot) => snapshot.context.formValues
@@ -108,7 +111,7 @@ export const SwapForm = () => {
           disabled={true}
         />
 
-        {renderIntentOutcome(intentOutcome)}
+        {renderIntentCreationResult(intentCreationResult)}
 
         <ButtonCustom
           type="submit"
@@ -119,46 +122,89 @@ export const SwapForm = () => {
           Swap
         </ButtonCustom>
       </Form>
+
+      <Intents intentRefs={snapshot.context.intentRefs} />
     </div>
   )
 }
 
-function renderIntentOutcome(intentOutcome: Context["outcome"]) {
-  if (!intentOutcome) {
+function Intents({
+  intentRefs,
+}: { intentRefs: ActorRefFrom<typeof intentStatusMachine>[] }) {
+  return (
+    <div>
+      {intentRefs.map((intentRef) => {
+        return <Intent key={intentRef.id} intentRef={intentRef} />
+      })}
+    </div>
+  )
+}
+
+function Intent({
+  intentRef,
+}: { intentRef: ActorRefFrom<typeof intentStatusMachine> }) {
+  const snapshot = useSelector(intentRef, (state) => state)
+
+  const value = snapshot.value
+  switch (value) {
+    case "pending":
+      return (
+        <div>
+          Checking intent status... intentHash: {snapshot.context.intentHash}
+        </div>
+      )
+    case "checking":
+      return (
+        <div>
+          Checking intent status... intentHash: {snapshot.context.intentHash}{" "}
+          tx: {snapshot.context.txHash}
+        </div>
+      )
+    case "success":
+      return <div>Intent settled! tx: {snapshot.context.txHash}</div>
+    case "not_valid":
+      return (
+        <div>
+          Intent not valid! tx: {snapshot.context.txHash} intent:{" "}
+          {snapshot.context.intentHash}
+        </div>
+      )
+    case "error":
+      return (
+        <div>
+          Error checking intent status! tx: {snapshot.context.txHash} intent:{" "}
+          {snapshot.context.intentHash}
+          <button
+            type={"button"}
+            onClick={() => intentRef.send({ type: "RETRY" })}
+          >
+            retry
+          </button>
+        </div>
+      )
+    default:
+      value satisfies never
+      return null
+  }
+}
+
+function renderIntentCreationResult(
+  intentCreationResult: Context["intentCreationResult"]
+) {
+  if (!intentCreationResult) {
     return null
   }
 
-  const status = intentOutcome.status
+  const status = intentCreationResult.status
   switch (status) {
-    case "SETTLED":
+    case "INTENT_PUBLISHED":
       return null
 
-    case "NOT_FOUND_OR_NOT_VALID":
-      return (
-        <div className="text-red-500 text-sm">
-          Missed deadline or don't have enough funds!
-          {intentOutcome.txHash == null ? null : (
-            <>
-              <br />
-              Tx: {intentOutcome.txHash}
-            </>
-          )}
-          {intentOutcome.intentHash == null ? null : (
-            <>
-              <br />
-              Intent: {intentOutcome.intentHash}
-            </>
-          )}
-        </div>
-      )
+    case "ERR_QUOTE_EXPIRED_RETURN_IS_LOWER":
+      return <div className="text-red-500 text-sm">Missed deadline</div>
 
-    case "ERR_CANNOT_OBTAIN_INTENT_STATUS":
-      return (
-        <div className="text-red-500 text-sm">
-          Cannot confirm intent status! Tx: {intentOutcome.txHash} Intent:{" "}
-          {intentOutcome.intentHash}
-        </div>
-      )
+    case "ERR_CANNOT_PUBLISH_INTENT":
+      return <div className="text-red-500 text-sm">Cannot publish intent</div>
 
     default:
       return <div className="text-red-500 text-sm">Swap failed! {status}</div>

--- a/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
@@ -38,21 +38,15 @@ export function SwapUIMachineFormSyncProvider({
   }, [watch, actorRef])
 
   useEffect(() => {
-    const sub = actorRef.on("swap_finished", (state) => {
-      const intentStatus = state.data.intentOutcome.status
-      switch (intentStatus) {
-        case "INTENT_PUBLISHED": {
-          onSuccessSwapRef.current({
-            amountIn: state.data.amountIn,
-            amountOut: state.data.amountOut,
-            tokenIn: state.data.tokenIn,
-            tokenOut: state.data.tokenOut,
-            txHash: "",
-            intentHash: state.data.intentOutcome.intentHash,
-          })
-          break
-        }
-      }
+    const sub = actorRef.on("INTENT_SETTLED", ({ data }) => {
+      onSuccessSwapRef.current({
+        amountIn: data.quote.totalAmountIn,
+        amountOut: data.quote.totalAmountOut,
+        tokenIn: data.tokenIn,
+        tokenOut: data.tokenOut,
+        txHash: data.txHash,
+        intentHash: data.intentHash,
+      })
     })
 
     return () => {

--- a/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
@@ -41,13 +41,13 @@ export function SwapUIMachineFormSyncProvider({
     const sub = actorRef.on("swap_finished", (state) => {
       const intentStatus = state.data.intentOutcome.status
       switch (intentStatus) {
-        case "SETTLED": {
+        case "INTENT_PUBLISHED": {
           onSuccessSwapRef.current({
             amountIn: state.data.amountIn,
             amountOut: state.data.amountOut,
             tokenIn: state.data.tokenIn,
             tokenOut: state.data.tokenOut,
-            txHash: state.data.intentOutcome.txHash,
+            txHash: "",
             intentHash: state.data.intentOutcome.intentHash,
           })
           break

--- a/src/services/intentService.ts
+++ b/src/services/intentService.ts
@@ -16,6 +16,10 @@ export async function submitIntent(
   return result.intent_hash
 }
 
+export type IntentSettlementResult = Awaited<
+  ReturnType<typeof waitForIntentSettlement>
+>
+
 export async function waitForIntentSettlement(
   signal: AbortSignal,
   intentHash: string


### PR DESCRIPTION
# Summary

This PR is follow-up of https://github.com/defuse-protocol/defuse-sdk/pull/64 
The main goal of this PR is to separate intent statuses from `swapIntentMachine`.

`swapIntentMachine` will just create an intent and return its hash. `swapUIMachine` will grab the result and create another actor which will be responsible for storing the status of the intent and poll API for a settlement status.

Such separation enables granular control over the intents, so we could render them easily concurrently.

<details><summary>Screenshot: How we can render multiple concurrent intents</summary>
<p>

<img width="536" alt="Screenshot 2024-10-25 at 20 21 43" src="https://github.com/user-attachments/assets/058319b7-e95e-4988-9bd7-9f1ca8cc10cd">


</p>
</details> 