### PR TITLE
fix: fix pub key window blocking

### DIFF
--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -110,7 +110,6 @@ export const FieldComboInput = <T extends FieldValues>({
 
       // @ts-expect-error React hack for emitting change event
       const tracker = inputRef.current._valueTracker
-      console.log(tracker)
       if (tracker) {
         tracker.setValue(lastValue)
       }

--- a/src/components/Modal/ModalConfirmAddPubkey.tsx
+++ b/src/components/Modal/ModalConfirmAddPubkey.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@radix-ui/themes"
+import { useModalStore } from "../../providers/ModalStoreProvider"
+import { ModalDialog } from "./ModalDialog"
+
+export type ModalConfirmAddPubkeyPayload = {
+  accountId: string
+  onConfirm: () => void
+  onAbort: () => void
+}
+
+export const ModalConfirmAddPubkey = () => {
+  const { onCloseModal, payload } = useModalStore((state) => state)
+  const { accountId, onConfirm, onAbort } =
+    payload as ModalConfirmAddPubkeyPayload
+
+  return (
+    <ModalDialog
+      onClose={() => {
+        onAbort()
+      }}
+    >
+      Is it you {accountId}?
+      <Button
+        onClick={() => {
+          onConfirm()
+        }}
+      >
+        Confirm
+      </Button>
+      <Button
+        onClick={() => {
+          // `onCloseModal` does not call `onClose` prop passed to `ModalDialog`, so we need to call abort manually
+          onAbort()
+          onCloseModal()
+        }}
+      >
+        Cancel
+      </Button>
+    </ModalDialog>
+  )
+}

--- a/src/components/Modal/ModalConfirmAddPubkey.tsx
+++ b/src/components/Modal/ModalConfirmAddPubkey.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@radix-ui/themes"
+import { Button, Flex, Text } from "@radix-ui/themes"
 import { useModalStore } from "../../providers/ModalStoreProvider"
 import { ModalDialog } from "./ModalDialog"
 
@@ -19,23 +19,40 @@ export const ModalConfirmAddPubkey = () => {
         onAbort()
       }}
     >
-      Is it you {accountId}?
-      <Button
-        onClick={() => {
-          onConfirm()
-        }}
-      >
-        Confirm
-      </Button>
-      <Button
-        onClick={() => {
-          // `onCloseModal` does not call `onClose` prop passed to `ModalDialog`, so we need to call abort manually
-          onAbort()
-          onCloseModal()
-        }}
-      >
-        Cancel
-      </Button>
+      <Flex direction={"column"} gap={"4"}>
+        <Flex>
+          <Text size={"8"}>Confirm Your Account</Text>
+        </Flex>
+
+        <Text>
+          To verify your account (NEAR ID:{" "}
+          <Text weight={"bold"}>{accountId}</Text>), please send a one-time
+          transaction.
+        </Text>
+
+        <Flex gap={"3"} justify={"end"}>
+          <Button
+            color={"gray"}
+            variant={"outline"}
+            onClick={() => {
+              // `onCloseModal` does not call `onClose` prop passed to `ModalDialog`, so we need to call abort manually
+              onAbort()
+              onCloseModal()
+            }}
+          >
+            Cancel
+          </Button>
+
+          <Button
+            color={"orange"}
+            onClick={() => {
+              onConfirm()
+            }}
+          >
+            Confirm Account
+          </Button>
+        </Flex>
+      </Flex>
     </ModalDialog>
   )
 }

--- a/src/components/Modal/ModalContainer.tsx
+++ b/src/components/Modal/ModalContainer.tsx
@@ -4,6 +4,7 @@ import { useModalStore } from "../../providers/ModalStoreProvider"
 
 import { ModalType } from "../../stores/modalStore"
 
+import { ModalConfirmAddPubkey } from "./ModalConfirmAddPubkey"
 import { ModalSelectAssets } from "./ModalSelectAssets"
 
 export const ModalContainer = () => {
@@ -12,6 +13,8 @@ export const ModalContainer = () => {
   switch (modalType) {
     case ModalType.MODAL_SELECT_ASSETS:
       return <ModalSelectAssets />
+    case ModalType.MODAL_CONFIRM_ADD_PUBKEY:
+      return <ModalConfirmAddPubkey />
     default:
       return null
   }

--- a/src/components/Modal/ModalDialog/index.tsx
+++ b/src/components/Modal/ModalDialog/index.tsx
@@ -13,7 +13,12 @@ import { useModalStore } from "../../../providers/ModalStoreProvider"
 
 import "./styles.css"
 
-export const ModalDialog = ({ children }: PropsWithChildren) => {
+export const ModalDialog = ({
+  children,
+  onClose,
+}: PropsWithChildren<{
+  onClose?: () => void
+}>) => {
   const { onCloseModal } = useModalStore((state) => state)
   const [open, setOpen] = useState(true)
   const [containerWidth, setContainerWidth] = useState<number>(0)
@@ -23,8 +28,11 @@ export const ModalDialog = ({ children }: PropsWithChildren) => {
   const defaultMaxWidth = "512px"
 
   const handleCloseModal = useCallback(() => {
-    if (!open) onCloseModal()
-  }, [open, onCloseModal])
+    if (!open) {
+      onCloseModal()
+      onClose?.()
+    }
+  }, [open, onCloseModal, onClose])
 
   useEffect(() => {
     handleCloseModal()

--- a/src/features/machines/publicKeyVerifierMachine.ts
+++ b/src/features/machines/publicKeyVerifierMachine.ts
@@ -1,6 +1,6 @@
 import type { providers } from "near-api-js"
 import type { CodeResult } from "near-api-js/lib/providers/provider"
-import { fromPromise } from "xstate"
+import { assign, fromPromise, setup } from "xstate"
 import { settings } from "../../config/settings"
 import type { Transaction } from "../../types/deposit"
 
@@ -8,54 +8,153 @@ export type SendNearTransaction = (
   tx: Transaction
 ) => Promise<{ txHash: string } | null>
 
-export const publicKeyVerifierMachine = fromPromise(
-  async ({
-    input: { nearAccount, nearClient, sendNearTransaction },
-  }: {
-    input: {
-      nearAccount: { accountId: string; publicKey: string } | null
-      nearClient: providers.Provider
-      sendNearTransaction: SendNearTransaction
-    }
-  }): Promise<boolean> => {
-    // Don't need to verify public key if it is not Near account,
-    // because public key cannot change for non-Near accounts.
-    if (nearAccount == null) {
-      return true
-    }
-    return verifyPublicKey({ nearAccount, nearClient, sendNearTransaction })
-  }
-)
-
-async function verifyPublicKey({
-  nearAccount,
-  nearClient,
-  sendNearTransaction,
-}: {
+type Input = {
+  nearAccount: { accountId: string; publicKey: string } | null
   nearClient: providers.Provider
-  nearAccount: { accountId: string; publicKey: string }
   sendNearTransaction: SendNearTransaction
-}): Promise<boolean> {
-  let pubKeyIsOnchain: boolean
-  try {
-    pubKeyIsOnchain = await checkPublicKeyOnchain({ nearAccount, nearClient })
-  } catch (err: unknown) {
-    throw new Error("Error checking public key onchain", { cause: err })
-  }
-
-  if (pubKeyIsOnchain) {
-    return true
-  }
-
-  try {
-    return await addPublicKeyToContract({
-      pubKey: nearAccount.publicKey,
-      sendNearTransaction,
-    })
-  } catch (err: unknown) {
-    throw new Error("Error adding public key to contract", { cause: err })
-  }
 }
+
+type Output = boolean
+
+type Context = Input & {
+  error: string | null
+}
+
+export const publicKeyVerifierMachine = setup({
+  types: {
+    context: {} as Context,
+    input: {} as Input,
+    output: {} as Output,
+    children: {},
+  },
+  actors: {
+    checkPubKeyActor: fromPromise(
+      ({ input }: { input: Parameters<typeof checkPublicKeyOnchain>[0] }) => {
+        return checkPublicKeyOnchain(input)
+      }
+    ),
+    addPubKeyActor: fromPromise(
+      ({ input }: { input: Parameters<typeof addPublicKeyToContract>[0] }) => {
+        return addPublicKeyToContract(input)
+      }
+    ),
+  },
+}).createMachine({
+  /** @xstate-layout N4IgpgJg5mDOIC5QAcCuAjANgSwMYGkwBPANTACdsAzbCgOmwkzAGIBtABgF1EUB7WNgAu2PgDteIAB6IAjACYArHQBsigBybZK+QE5dHWQGZ5AGhBFE62XRN7tugOwAWWbsWKVAXy-m0WPEJSCmpacgYmVjZZHiQQZAFhUQk4mQQFZTVNax19QxNzSwR5dSM6DgNdayNnZxLPHz8MHAJiMkoaelwACzBcAGtsMSgWCHEwBjEANz5+iZ6+-oAFDCCAJTAqTlj+QRFxSTSVdXly40NtFRd1WsLEPVPHDgr1FWc1N0UjRvjmwLaQp1wgsBkMRmMxBMhjM5nQQctVsQNlsYpIEntkodEJ5HipdLInrp5G4bs47ggjNZbESCSZtDVHIofv4WkF2qEur1QcMWBRyHxwshMABDIRUAUAWzhXIR6HWm22aMS+xSoDSsg4RmUJKMul1RjxzgN5KUKlUeI47y1VUMjkczL+rWCHTC0sWkBYAEEACLegD6SwAqgAhAAyAEkAMJ+-AAUQAmoq4uikgdUohHLIbCpddpHKUOEpdCpyYo3HRjOpFCUOFdHFqHQEneygXRhRAIGDRuNJjCJu2ICs5UiFdwlRi02q5EZZJkZ4yrcd3Ipyc5XnR3O9nJrnHaFN9fL8m2zAa6B12IVDprN+x2h-KUTt4srMen0ios+V3PInnpM0SyQsRAtzoeQjGeIx-xqWR1F0RtWQBF16HPHk+QFOghVFcVyClAd7xHLYx2TF9J2kOQ3jNPVKT0HNrAqRxyRMZw6FePUdCuAxMxqHxDzEPgIDgNFHRPJDyHHVNVTIhAAFoSyAmTlH0fR1EcFQrg4etTXg-5nQ5cJGGYcSVSxBA6nJKtVC+eRa11fM8mcbTm1PTlFjBIzXynYoVLoRxdDqFSKg8azVJNRRHDoRR8Q-Cp1P0bxDxZHSW1deFIHc0i0i+M1YOcL4FDeSDZFLGCWNratng1d5q0ckS9LbDs3OIidJLSJx1FA2DnieRRnicXRV3cakCTxNQ9Ss+KmmPRC6twPgJSFMAhDSpqJJMy52pONiTBcDSXHJPy6FcbcNCULNiTtHivCAA */
+  id: "publicKeyVerifier",
+  initial: "idle",
+  context: ({ input }) => {
+    return {
+      ...input,
+      error: null,
+    }
+  },
+  output: ({ context }) => {
+    return context.error == null
+  },
+  states: {
+    idle: {
+      always: [
+        {
+          target: "completed",
+          guard: ({ context }) => {
+            // Don't need to check public key if it is not Near account,
+            // because public key cannot change for non-Near accounts.
+            return context.nearAccount == null
+          },
+        },
+        {
+          target: "checking",
+        },
+      ],
+    },
+
+    checking: {
+      invoke: {
+        id: "checkPubKeyRef",
+        src: "checkPubKeyActor",
+        input: ({ context }) => {
+          if (context.nearAccount == null) {
+            throw new Error("no near account")
+          }
+
+          return {
+            nearAccount: context.nearAccount,
+            nearClient: context.nearClient,
+            sendNearTransaction: context.sendNearTransaction,
+          }
+        },
+        onDone: [
+          {
+            target: "completed",
+            guard: ({ event }) => event.output,
+          },
+          {
+            target: "checked",
+          },
+        ],
+        onError: {
+          target: "completed",
+          actions: [
+            ({ event }) => console.error("Failed to check pubKey", event.error),
+            assign({
+              error: "FAILED_CHECK_PUBKEY",
+            }),
+          ],
+        },
+      },
+    },
+
+    checked: {
+      on: {
+        ADD_PUBLIC_KEY: {
+          target: "adding",
+        },
+        ABORT_ADD_PUBLIC_KEY: {
+          target: "completed",
+          actions: assign({ error: "ABORTED_ADD_PUBKEY" }),
+        },
+      },
+    },
+
+    adding: {
+      invoke: {
+        id: "addPubKeyRef",
+        src: "addPubKeyActor",
+        input: ({ context }) => {
+          if (context.nearAccount == null) {
+            throw new Error("no near account")
+          }
+
+          return {
+            pubKey: context.nearAccount.publicKey,
+            sendNearTransaction: context.sendNearTransaction,
+          }
+        },
+        onDone: [
+          { target: "completed", guard: ({ event }) => event.output != null },
+          {
+            target: "completed",
+            actions: assign({ error: "DIDNT_ADD_PUBKEY" }),
+          },
+        ],
+        onError: {
+          target: "completed",
+          actions: [
+            ({ event }) => console.error("Failed to add pubKey", event.error),
+            assign({
+              error: "FAILED_ADD_PUBKEY",
+            }),
+          ],
+        },
+      },
+    },
+
+    completed: {
+      type: "final",
+    },
+  },
+})
 
 async function checkPublicKeyOnchain({
   nearAccount,

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -1,5 +1,5 @@
 import type { providers } from "near-api-js"
-import { assign, fromPromise, log, setup } from "xstate"
+import { assign, fromPromise, setup } from "xstate"
 import { settings } from "../../config/settings"
 import {
   doesSignatureMatchUserAddress,
@@ -84,6 +84,9 @@ export const swapIntentMachine = setup({
     input: {} as Input,
     output: {} as Output,
     events: {} as Events,
+    children: {} as {
+      publicKeyVerifierRef: "publicKeyVerifierActor"
+    },
   },
   actions: {
     setError: assign({
@@ -126,7 +129,7 @@ export const swapIntentMachine = setup({
     }),
   },
   actors: {
-    publicKeyVerifier: publicKeyVerifierMachine,
+    publicKeyVerifierActor: publicKeyVerifierMachine,
     signMessage: fromPromise(
       async (_: {
         input: WalletMessage
@@ -287,7 +290,8 @@ export const swapIntentMachine = setup({
 
     "Verifying Public Key Presence": {
       invoke: {
-        src: "publicKeyVerifier",
+        id: "publicKeyVerifierRef",
+        src: "publicKeyVerifierActor",
         input: ({ context }) => {
           assert(context.signature != null, "Signature is not set")
 

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -97,6 +97,7 @@ export const swapUIMachine = setup({
 
     children: {} as {
       depositedBalanceRef: "depositedBalanceActor"
+      swapRef: "swapActor"
     },
   },
   actors: {

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -13,7 +13,7 @@ import { ModalType } from "../../../stores/modalStore"
 import type { SwappableToken } from "../../../types"
 import { isBaseToken } from "../../../utils"
 import type { depositedBalanceMachine } from "../../machines/depositedBalanceMachine"
-import { intentStatusMachine } from "../../machines/intentStatusMachine"
+import type { intentStatusMachine } from "../../machines/intentStatusMachine"
 import type { Context } from "../../machines/swapUIMachine"
 import { SwapSubmitterContext } from "./SwapSubmitter"
 import { SwapUIMachineContext } from "./SwapUIMachineProvider"
@@ -110,28 +110,6 @@ export const SwapForm = () => {
     tokenInBalance != null
       ? tokenInBalance < snapshot.context.parsedFormValues.amountIn
       : null
-
-  const intentRef = useActorRef(intentStatusMachine, {
-    input: {
-      // @ts-expect-error
-      parentRef: swapUIActorRef,
-      intentHash: "LiAqVEKaxWejXfoFe2Js8S+TygJt6hWJJ3+BVHVZ+GQ=",
-      tokenIn,
-      tokenOut,
-      quote: {
-        totalAmountIn: 13_123123n,
-        totalAmountOut: 971_231233n,
-        quoteHashes: [],
-        expirationTime: 0,
-        amountsIn: {},
-        amountsOut: {},
-      },
-    },
-  })
-
-  // useEffect(() => {
-  //   console.log(JSON.stringify(intentRef.getPersistedSnapshot()))
-  // }, [intentRef])
 
   return (
     <div className="md:max-w-[472px] rounded-[1rem] p-5 shadow-paper bg-white dark:shadow-paper-dark dark:bg-black-800">

--- a/src/features/swap/components/SwapSubmitter.tsx
+++ b/src/features/swap/components/SwapSubmitter.tsx
@@ -1,5 +1,5 @@
 import { providers } from "near-api-js"
-import { type ReactNode, createContext, useEffect } from "react"
+import { type ReactNode, createContext } from "react"
 import type { SendNearTransaction } from "../../machines/publicKeyVerifierMachine"
 import { SwapUIMachineContext } from "./SwapUIMachineProvider"
 
@@ -19,15 +19,6 @@ export function SwapSubmitterProvider({
   sendNearTransaction: SendNearTransaction
 }) {
   const actorRef = SwapUIMachineContext.useActorRef()
-
-  useEffect(() => {
-    const sub = actorRef.subscribe((state) => {
-      console.log("SwapSubmitterProvider state", state.value, state)
-    })
-    return () => {
-      sub.unsubscribe()
-    }
-  }, [actorRef])
 
   const onSubmit = () => {
     if (userAddress == null) {

--- a/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineFormSyncProvider.tsx
@@ -1,6 +1,11 @@
+import { useSelector } from "@xstate/react"
 import { type PropsWithChildren, useEffect, useRef } from "react"
 import { useFormContext } from "react-hook-form"
+import type { ModalConfirmAddPubkeyPayload } from "../../../components/Modal/ModalConfirmAddPubkey"
+import { useModalStore } from "../../../providers/ModalStoreProvider"
+import { ModalType } from "../../../stores/modalStore"
 import type { SwapWidgetProps } from "../../../types"
+import { assert } from "../../../utils/assert"
 import type { SwapFormValues } from "./SwapForm"
 import { SwapUIMachineContext } from "./SwapUIMachineProvider"
 
@@ -63,6 +68,41 @@ export function SwapUIMachineFormSyncProvider({
       sub.unsubscribe()
     }
   }, [actorRef])
+
+  const { setModalType, onCloseModal } = useModalStore((state) => state)
+
+  const swapRef = useSelector(actorRef, (state) => state.children.swapRef)
+  const publicKeyVerifierRef = useSelector(swapRef, (state) => {
+    if (state) {
+      return state.children.publicKeyVerifierRef
+    }
+  })
+
+  useEffect(() => {
+    if (!publicKeyVerifierRef) return
+
+    const sub = publicKeyVerifierRef.subscribe((snapshot) => {
+      if (snapshot.matches("checked")) {
+        assert(snapshot.context.nearAccount, "Near account is not set")
+
+        setModalType(ModalType.MODAL_CONFIRM_ADD_PUBKEY, {
+          accountId: snapshot.context.nearAccount.accountId,
+          onConfirm: () => {
+            publicKeyVerifierRef.send({ type: "ADD_PUBLIC_KEY" })
+            onCloseModal()
+          },
+          onAbort: () => {
+            console.log("send onAbort")
+            publicKeyVerifierRef.send({ type: "ABORT_ADD_PUBLIC_KEY" })
+          },
+        } satisfies ModalConfirmAddPubkeyPayload)
+      }
+    })
+
+    return () => {
+      sub.unsubscribe()
+    }
+  }, [publicKeyVerifierRef, setModalType, onCloseModal])
 
   return <>{children}</>
 }

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -7,6 +7,7 @@ export enum ModalType {
   MODAL_CONFIRM_SWAP = "modalConfirmSwap",
   MODAL_CONNECT_NETWORKS = "modalConnectNetworks",
   MODAL_STORE_NETWORK = "modalStoreNetwork",
+  MODAL_CONFIRM_ADD_PUBKEY = "modalConfirmAddPubKey",
 }
 
 export type ModalState = {


### PR DESCRIPTION
# Background

We need to send a one time transaction to add Public key to Defuse protocol for users with `foo.near` handles. We send this transaction right after signing a message. Browser don't open new windows from timeouts or other random macro tasks, they allow to open windows only on user interaction (e.g. click).

# Summary

PR adds new modal dialog that asks user to confirm their account, upon clicking Confirm we open a wallet window (and browser won't block this new window).

<details><summary>Details</summary>
<p>


<img width="633" alt="Screenshot 2024-10-29 at 18 54 10" src="https://github.com/user-attachments/assets/7343bf27-0d62-4067-a5a4-8977560a72dd">

</p>
</details> 