### PR TITLE
fix: don't switch amounts when token selected from dialog

### DIFF
--- a/src/components/Modal/ModalDialog/index.tsx
+++ b/src/components/Modal/ModalDialog/index.tsx
@@ -60,6 +60,11 @@ export const ModalDialog = ({
               : defaultMaxWidth
             : defaultMaxWidth
         }
+        onOpenAutoFocus={(e) => {
+          // This is a workaround for focusing the first input in the modal
+          // Focusing first input is annoying for mobile users
+          e.preventDefault()
+        }}
       >
         <VisuallyHidden>
           <Dialog.Title>null</Dialog.Title>

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -87,17 +87,28 @@ export const SwapForm = () => {
     }
     const { modalType, fieldName, token } = payload as ModalSelectAssetsPayload
     if (modalType === ModalType.MODAL_SELECT_ASSETS && fieldName && token) {
+      const { tokenIn, tokenOut } =
+        swapUIActorRef.getSnapshot().context.formValues
+
       switch (fieldName) {
         case "tokenIn":
           if (tokenOut === token) {
-            switchTokens()
+            // Don't need to switch amounts, when token selected from dialog
+            swapUIActorRef.send({
+              type: "input",
+              params: { tokenIn: tokenOut, tokenOut: tokenIn },
+            })
           } else {
             swapUIActorRef.send({ type: "input", params: { tokenIn: token } })
           }
           break
         case "tokenOut":
           if (tokenIn === token) {
-            switchTokens()
+            // Don't need to switch amounts, when token selected from dialog
+            swapUIActorRef.send({
+              type: "input",
+              params: { tokenIn: tokenOut, tokenOut: tokenIn },
+            })
           } else {
             swapUIActorRef.send({ type: "input", params: { tokenOut: token } })
           }
@@ -105,7 +116,7 @@ export const SwapForm = () => {
       }
       onCloseModal(undefined)
     }
-  }, [payload, onCloseModal, swapUIActorRef, tokenIn, tokenOut, switchTokens])
+  }, [payload, onCloseModal, swapUIActorRef])
 
   const { onSubmit } = useContext(SwapSubmitterContext)
 


### PR DESCRIPTION
Two fixes:
- don't switch amounts when token selected from dialog
- remove focusing the first input in dialog
