### PR TITLE
chore(deposit): disable network for non muli-asset

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,7 +1,7 @@
 import { TextField } from "@radix-ui/themes"
 import clsx from "clsx"
 import type { ReactNode } from "react"
-import type { FieldValues, Path, UseFormRegister } from "react-hook-form"
+import type { FieldValues } from "react-hook-form"
 import styles from "./styles.module.css"
 
 type Props<T, TFieldValues extends FieldValues> = {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -21,6 +21,11 @@ type Props<T extends string, TFieldValues extends FieldValues> = {
   label?: string
   fullWidth?: boolean
   disabled?: boolean
+  value?: {
+    label: string
+    icon: React.ReactNode
+    value: string
+  }
   onChange?: (value: string) => void
   innerRef?: React.Ref<HTMLSelectElement>
 }
@@ -37,6 +42,7 @@ export const Select = forwardRef(function Select<
     label,
     fullWidth = false,
     disabled = false,
+    value,
     onChange,
   }: Props<T, TFieldValues>,
   ref: React.Ref<HTMLSelectElement>
@@ -46,7 +52,7 @@ export const Select = forwardRef(function Select<
     onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void
   }
   return (
-    <RadixSelect.Root onValueChange={onChange} {...rest}>
+    <RadixSelect.Root onValueChange={onChange} value={value?.value} {...rest}>
       <RadixSelect.Trigger
         className={clsx(styles.selectTrigger, {
           [styles.selectTriggerFullWidth || ""]: fullWidth,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -21,13 +21,7 @@ type Props<T extends string, TFieldValues extends FieldValues> = {
   label?: string
   fullWidth?: boolean
   disabled?: boolean
-  value?:
-    | {
-        label: string
-        icon: React.ReactNode
-        value: string
-      }
-    | string
+  value?: string
   onChange?: (value: string) => void
   innerRef?: React.Ref<HTMLSelectElement>
 }
@@ -54,11 +48,7 @@ export const Select = forwardRef(function Select<
     onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void
   }
   return (
-    <RadixSelect.Root
-      onValueChange={onChange}
-      value={typeof value === "string" ? value : value?.value}
-      {...rest}
-    >
+    <RadixSelect.Root onValueChange={onChange} value={value} {...rest}>
       <RadixSelect.Trigger
         className={clsx(styles.selectTrigger, {
           [styles.selectTriggerFullWidth || ""]: fullWidth,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -21,11 +21,13 @@ type Props<T extends string, TFieldValues extends FieldValues> = {
   label?: string
   fullWidth?: boolean
   disabled?: boolean
-  value?: {
-    label: string
-    icon: React.ReactNode
-    value: string
-  }
+  value?:
+    | {
+        label: string
+        icon: React.ReactNode
+        value: string
+      }
+    | string
   onChange?: (value: string) => void
   innerRef?: React.Ref<HTMLSelectElement>
 }
@@ -52,7 +54,11 @@ export const Select = forwardRef(function Select<
     onChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void
   }
   return (
-    <RadixSelect.Root onValueChange={onChange} value={value?.value} {...rest}>
+    <RadixSelect.Root
+      onValueChange={onChange}
+      value={typeof value === "string" ? value : value?.value}
+      {...rest}
+    >
       <RadixSelect.Trigger
         className={clsx(styles.selectTrigger, {
           [styles.selectTriggerFullWidth || ""]: fullWidth,

--- a/src/features/deposit/components/DepositForm/styles.module.css
+++ b/src/features/deposit/components/DepositForm/styles.module.css
@@ -34,7 +34,6 @@
   pointer-events: none;
 }
 
-
 .buttonWrapper {
   margin-bottom: 1rem;
   width: 100%;

--- a/src/features/deposit/components/DepositForm/styles.module.css
+++ b/src/features/deposit/components/DepositForm/styles.module.css
@@ -24,6 +24,16 @@
 .selectWrapper {
   margin-bottom: 1rem;
 }
+.selectWrapper > button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.selectWrapper > *[disabled] {
+  pointer-events: none;
+}
+
 
 .buttonWrapper {
   margin-bottom: 1rem;

--- a/src/features/deposit/components/DepositUIMachineFormSyncProvider.tsx
+++ b/src/features/deposit/components/DepositUIMachineFormSyncProvider.tsx
@@ -16,16 +16,12 @@ export function DepositUIMachineFormSyncProvider({
   const actorRef = DepositUIMachineContext.useActorRef()
 
   useEffect(() => {
-    // When values are set externally, they trigger "watch" callback too.
-    // In order to avoid, unnecessary state updates need to check if the form is changed by user
     const sub = watch(async (value, { type, name }) => {
-      if (type === "change" && name != null) {
-        if (name === "network") {
-          actorRef.send({
-            type: "INPUT",
-            params: { [name]: value[name] as DepositBlockchainEnum },
-          })
-        }
+      if (name === "network") {
+        actorRef.send({
+          type: "INPUT",
+          params: { [name]: value[name] as DepositBlockchainEnum },
+        })
       }
       if (name === "amount") {
         actorRef.send({

--- a/src/hooks/useNearGetTokenBalance.ts
+++ b/src/hooks/useNearGetTokenBalance.ts
@@ -8,19 +8,19 @@ import type { BaseTokenInfo, UnifiedTokenInfo } from "../types/base"
 
 const queryKey = "get-balance"
 
-export const getGetNearNativeBalanceKey = [queryKey, "get-near-native-balance"]
+export const getNearNativeBalanceKey = [queryKey, "get-near-native-balance"]
 
 export const useGetNearNativeBalance = (
   params: { accountId: string },
   options = {}
 ) =>
   useQuery({
-    queryKey: getGetNearNativeBalanceKey,
+    queryKey: getNearNativeBalanceKey,
     queryFn: () => getNearNativeBalance(params),
     ...options,
   })
 
-export const getGetNearNep141BalanceAccountKey = [
+export const getNearNep141BalanceAccountKey = [
   queryKey,
   "get-near-nep141-balance",
 ]
@@ -33,7 +33,7 @@ export const useGetNearNep141Balance = (
   options = {}
 ) =>
   useQuery({
-    queryKey: getGetNearNep141BalanceAccountKey,
+    queryKey: getNearNep141BalanceAccountKey,
     queryFn: () => getNearNep141Balance(params),
     ...options,
   })

--- a/src/hooks/usePoABridge.ts
+++ b/src/hooks/usePoABridge.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query"
+import { getSupportedTokens } from "src/services/poaBridgeClient"
+import type { DepositBlockchainEnum } from "src/types"
+
+const queryKey = "poa-bridge"
+
+export const getSupportedTokensKey = [queryKey, "get-supported-tokens"]
+
+export const useGetSupportedTokens = (
+  params: { chains?: DepositBlockchainEnum[] },
+  options = {}
+) =>
+  useQuery({
+    queryKey: getSupportedTokensKey,
+    queryFn: () => getSupportedTokens(params),
+    ...options,
+  })

--- a/src/types/deposit.ts
+++ b/src/types/deposit.ts
@@ -17,6 +17,8 @@ export enum DepositBlockchainEnum {
   NEAR = "near:mainnet",
   ETHEREUM = "eth:1",
   BASE = "eth:8453",
+  ARBITRUM = "eth:42161",
+  BITCOIN = "btc:mainnet",
 }
 
 export interface FunctionCallAction {


### PR DESCRIPTION
### Prerequisites:
When the user is handling NEAR tokens, the network is already known, so there’s no need to prompt the user to select it manually; instead, selection is disabled and handled automatically.

Changes:
- Adjust the selection behavior, as the form may be modified not only by the user