### PR TITLE
chore: enhance success and failure handling

### DIFF
--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -21,6 +21,7 @@ import { BlockchainEnum, type SwappableToken } from "../../../../types"
 import { formatTokenValue } from "../../../../utils/format"
 import { isBaseToken, isUnifiedToken } from "../../../../utils/token"
 import { DepositUIMachineContext } from "../DepositUIMachineProvider"
+import { Deposits } from "../Deposits"
 import styles from "./styles.module.css"
 
 export type DepositFormValues = {
@@ -43,21 +44,22 @@ export const DepositForm = () => {
   const depositUIActorRef = DepositUIMachineContext.useActorRef()
   const snapshot = DepositUIMachineContext.useSelector((snapshot) => snapshot)
   const generatedAddressResult = snapshot.context.generatedAddressResult
-  const depositNearResult = snapshot.context.depositNearResult
 
-  const { token, network, amount, balance, nativeBalance } =
+  const { token, network, amount, balance, nativeBalance, userAddress } =
     DepositUIMachineContext.useSelector((snapshot) => {
       const token = snapshot.context.formValues.token
       const network = snapshot.context.formValues.network
       const amount = snapshot.context.formValues.amount
       const balance = snapshot.context.balance
       const nativeBalance = snapshot.context.nativeBalance
+      const userAddress = snapshot.context.userAddress
       return {
         token,
         network,
         amount,
         balance,
         nativeBalance,
+        userAddress,
       }
     })
 
@@ -310,30 +312,14 @@ export const DepositForm = () => {
             </div>
           )}
         </Form>
-        {depositNearResult && (
-          <Box>
-            <Text size={"1"} color={"gray"}>
-              Transaction:
-            </Text>{" "}
-            <TransactionLink
-              txHash={
-                depositNearResult.status === "SUCCESSFUL"
-                  ? depositNearResult.txHash
-                  : ""
-              }
-            />
-          </Box>
-        )}
+        <Deposits
+          amount={amount}
+          asset={token}
+          userAddressId={userAddress}
+          depositNearResult={snapshot.context.depositNearResult}
+        />
       </div>
     </div>
-  )
-}
-
-const TransactionLink = ({ txHash }: { txHash: string }) => {
-  return (
-    <Link href={`https://nearblocks.io/txns/${txHash}`} target={"_blank"}>
-      {shortenTxHash(txHash)}
-    </Link>
   )
 }
 

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -312,12 +312,7 @@ export const DepositForm = () => {
             </div>
           )}
         </Form>
-        <Deposits
-          amount={amount}
-          asset={token}
-          userAddressId={userAddress}
-          depositNearResult={snapshot.context.depositNearResult}
-        />
+        <Deposits depositNearResult={snapshot.context.depositNearResult} />
       </div>
     </div>
   )

--- a/src/features/deposit/components/Deposits/index.tsx
+++ b/src/features/deposit/components/Deposits/index.tsx
@@ -1,0 +1,86 @@
+import { Box, Flex, Link, Text } from "@radix-ui/themes"
+import { AssetComboIcon } from "src/components/Asset/AssetComboIcon"
+import type { SwappableToken } from "src/types"
+import type { Context } from "../../../machines/depositUIMachine"
+
+const NEAR_EXPLORER = "https://nearblocks.io"
+
+export const Deposits = ({
+  amount,
+  asset,
+  userAddressId,
+  depositNearResult,
+}: {
+  amount: string
+  asset: SwappableToken | null
+  userAddressId: string
+  depositNearResult: Context["depositNearResult"]
+}) => {
+  if (
+    depositNearResult?.status !== "DEPOSIT_COMPLETED" ||
+    depositNearResult?.txHash == null ||
+    asset == null
+  ) {
+    return null
+  }
+
+  const txUrl =
+    depositNearResult.txHash != null
+      ? `${NEAR_EXPLORER}/txns/${depositNearResult.txHash}`
+      : null
+
+  return (
+    <Flex p={"2"} gap={"3"}>
+      <Box pt={"2"}>
+        <AssetComboIcon icon={asset.icon} name={asset.name} />
+      </Box>
+
+      <Flex direction={"column"} flexGrow={"1"}>
+        <Flex>
+          <Box flexGrow={"1"}>
+            <Text size={"2"} weight={"medium"}>
+              Deposit
+            </Text>
+          </Box>
+
+          <Flex gap={"1"} align={"center"}>
+            <Text size={"1"} weight={"medium"}>
+              Completed
+            </Text>
+          </Flex>
+        </Flex>
+
+        <Flex align={"center"}>
+          <Box flexGrow={"1"}>
+            <Text size={"1"} weight={"medium"} color={"gray"}>
+              From {shortenText(userAddressId)}
+            </Text>
+          </Box>
+
+          <Box>
+            <Text size={"1"} weight={"medium"} color={"green"}>
+              +{amount.toString()} {asset?.symbol}
+            </Text>
+          </Box>
+        </Flex>
+
+        {depositNearResult.txHash != null && txUrl != null && (
+          <Box>
+            <Text size={"1"} color={"gray"}>
+              Transaction:
+            </Text>{" "}
+            <Text size={"1"}>
+              <Link href={txUrl} target={"_blank"}>
+                {shortenText(depositNearResult.txHash)}
+              </Link>
+            </Text>
+          </Box>
+        )}
+      </Flex>
+    </Flex>
+  )
+}
+
+function shortenText(text: string) {
+  return `${text.slice(0, 5)}...${text.slice(-5)}`
+}

--- a/src/features/deposit/components/Deposits/index.tsx
+++ b/src/features/deposit/components/Deposits/index.tsx
@@ -1,26 +1,16 @@
 import { Box, Flex, Link, Text } from "@radix-ui/themes"
 import { AssetComboIcon } from "src/components/Asset/AssetComboIcon"
-import type { SwappableToken } from "src/types"
+import { formatTokenValue } from "src/utils/format"
 import type { Context } from "../../../machines/depositUIMachine"
 
 const NEAR_EXPLORER = "https://nearblocks.io"
 
 export const Deposits = ({
-  amount,
-  asset,
-  userAddressId,
   depositNearResult,
 }: {
-  amount: string
-  asset: SwappableToken | null
-  userAddressId: string
   depositNearResult: Context["depositNearResult"]
 }) => {
-  if (
-    depositNearResult?.status !== "DEPOSIT_COMPLETED" ||
-    depositNearResult?.txHash == null ||
-    asset == null
-  ) {
+  if (depositNearResult?.status !== "DEPOSIT_COMPLETED") {
     return null
   }
 
@@ -32,7 +22,10 @@ export const Deposits = ({
   return (
     <Flex p={"2"} gap={"3"}>
       <Box pt={"2"}>
-        <AssetComboIcon icon={asset.icon} name={asset.name} />
+        <AssetComboIcon
+          icon={depositNearResult.asset.icon}
+          name={depositNearResult.asset.name}
+        />
       </Box>
 
       <Flex direction={"column"} flexGrow={"1"}>
@@ -53,13 +46,22 @@ export const Deposits = ({
         <Flex align={"center"}>
           <Box flexGrow={"1"}>
             <Text size={"1"} weight={"medium"} color={"gray"}>
-              From {shortenText(userAddressId)}
+              From {shortenText(depositNearResult.userAddressId)}
             </Text>
           </Box>
 
           <Box>
             <Text size={"1"} weight={"medium"} color={"green"}>
-              +{amount.toString()} {asset?.symbol}
+              +
+              {formatTokenValue(
+                depositNearResult.amount,
+                depositNearResult.asset.decimals,
+                {
+                  min: 0.0001,
+                  fractionDigits: 4,
+                }
+              )}{" "}
+              {depositNearResult.asset.symbol}
             </Text>
           </Box>
         </Flex>

--- a/src/features/machines/depositNearMachine.ts
+++ b/src/features/machines/depositNearMachine.ts
@@ -8,8 +8,16 @@ export type Context = {
   accountId: string | null
   txHash: string | null
   balance: bigint | null
-  error: string | undefined
-  outcome: unknown | null
+  error:
+    | null
+    | {
+        status: "ERR_SUBMITTING_TRANSACTION"
+        error: Error
+      }
+    | {
+        status: "ERR_VERIFYING_TRANSACTION"
+        error: Error | null
+      }
 }
 
 type Events = {
@@ -28,13 +36,10 @@ type Input = {
 }
 
 export type Output =
+  | NonNullable<Context["error"]>
   | {
-      status: "SUCCESSFUL"
+      status: "DEPOSIT_COMPLETED"
       txHash: string
-    }
-  | {
-      status: "FAILED"
-      error: string
     }
 
 export const depositNearMachine = setup({
@@ -61,6 +66,12 @@ export const depositNearMachine = setup({
     ),
   },
   actions: {
+    setError: assign({
+      error: (_, error: NonNullable<Context["error"]>) => error,
+    }),
+    logError: (_, params: { error: unknown }) => {
+      console.error(params.error)
+    },
     emitSuccessfulDeposit: emit(({ context }) => ({
       type: "SUCCESSFUL_DEPOSIT",
       data: context.txHash,
@@ -76,7 +87,7 @@ export const depositNearMachine = setup({
     },
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0AdmAIYBOAdNlAVgVAMQTpHm0Bu6A1mOShtviJlKWarSgJ26AMbEcWZgG0ADAF0VqxKH64FBLSAAeiAOwAOACzkAbNYBMAVhPWnATguuAzAEYANCABPRDxvC2VyVxMHHzsTT1c7O2VvawBfVP8+TFxCEgoqGjp6MFJSdApUABs5ADNygFteNGzBPJExOkkCDll5JTUNAx0+-SQjUzMHck9PZWjXB0nlM3N-IIQ8B1cbewXvFIszbzMzdMzmgVzhNhKsGoDxRmYeKW4m4auKG9I7h86pXp6DSDMbDPQGYwIbyeOzWGwpZLKOwLCyeBx2NbBfYmCKuFYOZQWEzeWI+U4ZEBZS5CL63e6PEplCrVHB1UiNKk5Gnkb6-cRdHpyIEDNRDFrgsaQ6GxGxmSKuawWawmMKeMyYjaTcjKGb7TwWBz7OyTTxnSkXLltABGZWIEFksHkRRB2nFzAhiG8eLs5EsBNscWR3miGpC3hxrjxUUJxNJdm86QpBHQKHgY05rTIYoEEtAkNRVhMga8tg8qOsocSZnIROiXsc+rMaIcZozn3ahSg2d07sliEOPqLMJLivcngrgSxXvIwaS9eJy31rlbFsztJ+9Lo3ZGHqhyms2y8JIDJmUKuUrlD+3COp8PnRhOsTbsK4+3Jt6DtDqdXdBbtGeaek+OJmDGJJHIsRLqpOGz7Ns9ZJHYnhFgWDgWK+LTtgAcugOAAAQAGLoAArgQEB4eUeEAJLdMQlRYBA265uMUIwjiYReK43iEqEtieFeOJ2AOcQONEBb7hh1JtAAwug9RVGAOCQExvaAQgSRyuQomRnMcZzA4V5JOQKr4osxLEsc6EUm23IAIJWuUSmMX+OaqSxJh4tMRw+O45hqiYGIwWh5BCRYFhetp9hNomqRAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0AdmAIYBOAdNlAVgVAMQTpHm0Bu6A1mOShtviJlKWarSgJ26AMbEcWZgG0ADAF0VqxKH64FBLSAAeiAOwAOACzkAbNYBMAVhPWnATguuAzAEYANCABPRDxvC2VyVxMHHzsTT1c7O2VvawBfVP8+TFxCEgoqGjp6MFJSdApUABs5ADNygFteNGzBPJExOkkCDll5JTUNAx0+-SQjUzMHck9PZWjXB0nlM3N-IIQ8B1cbewXvFIszbzMzdMzmgVzhNhKsGoDxRmYeKW4m4auKG9I7h86pXp6DSDMbDPQGYwIbyeOzWGwpZLKOwLCyeBx2NbBfYmCKuFYOZQWEzeWI+U4ZEBZS5CL63e6PEplCrVHB1UiNKk5Gnkb6-cRdHpyIEDNRDFrgsaQ6GxGxmSKuawWawmMKeMyYjaTcjKGb7TwWBz7OyTTxnSkXLltABGZWIEFksHkRRB2nFzAhiG8eLs5EsBNscWR3miGpC3hxrjxUUJxNJdm86QpBHQKHgY05rTIYoEEtAkNRVhMga8tg8qOsocSZnIRPRhx1K0JJzNGc+7UKUGzundksQhx9RZhJcV7k8FcCWK95GDSS9sW8y31rhbFsztJ+9LoXZGHqhyms2y8JIDJmUKuUrlD+3COp8PnRhOsZhhK4+3Jt6DtDqdndBbtGeaek+OJmDGJJHIsRLqhOGz7Nsc5JHYnhFgWDgWK+LRtgAcugOAAAQAGLoAArgQEB4eUeEAJLdMQlRYBA265uMUIwt4vo6he+r7geaIakqNZosqHjRDqXoOGkFKttyADC6D1FUYA4JATE9oBCBJHK5AOFsrhzHGcwOFeSTkCq+KLMSxLHOhUmrm2ACCVrlMpjF-jmaksSYeLTEcMISbE9johqC7sZptgIQ2diJqkQA */
   id: "deposit-near",
 
   initial: "signing",
@@ -84,15 +95,13 @@ export const depositNearMachine = setup({
   output: ({ context }): Output => {
     if (context.txHash != null) {
       return {
-        status: "SUCCESSFUL",
+        status: "DEPOSIT_COMPLETED",
         txHash: context.txHash,
       }
     }
+
     if (context.error != null) {
-      return {
-        status: "FAILED",
-        error: context.error,
-      }
+      return context.error
     }
 
     throw new Error("Unexpected output")
@@ -105,8 +114,7 @@ export const depositNearMachine = setup({
       asset: input.asset,
       accountId: input.accountId,
       txHash: null,
-      error: undefined,
-      outcome: null,
+      error: null,
       tokenAddress: null,
     }
   },
@@ -131,10 +139,19 @@ export const depositNearMachine = setup({
         },
         onError: {
           target: "Aborted",
-          actions: assign((context) => ({
-            ...context,
-            error: "Signing error",
-          })),
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => ({
+                status: "ERR_SUBMITTING_TRANSACTION",
+                error: toError(event.error),
+              }),
+            },
+          ],
         },
         src: "signAndSendTransactions",
       },
@@ -156,6 +173,13 @@ export const depositNearMachine = setup({
         },
         onError: {
           target: "Not Found or Invalid",
+          actions: {
+            type: "setError",
+            params: {
+              status: "ERR_VERIFYING_TRANSACTION",
+              error: null,
+            },
+          },
         },
         src: "validateTransaction",
       },
@@ -188,3 +212,7 @@ export const depositNearMachine = setup({
     },
   },
 })
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error("unknown error")
+}

--- a/src/features/machines/depositNearMachine.ts
+++ b/src/features/machines/depositNearMachine.ts
@@ -40,6 +40,9 @@ export type Output =
   | {
       status: "DEPOSIT_COMPLETED"
       txHash: string
+      userAddressId: string
+      amount: bigint
+      asset: SwappableToken
     }
 
 export const depositNearMachine = setup({
@@ -93,10 +96,18 @@ export const depositNearMachine = setup({
   initial: "signing",
 
   output: ({ context }): Output => {
-    if (context.txHash != null) {
+    if (
+      context.txHash != null &&
+      context.accountId != null &&
+      context.amount != null &&
+      context.asset != null
+    ) {
       return {
         status: "DEPOSIT_COMPLETED",
         txHash: context.txHash,
+        userAddressId: context.accountId,
+        amount: context.amount,
+        asset: context.asset,
       }
     }
 

--- a/src/features/machines/depositUIMachine.ts
+++ b/src/features/machines/depositUIMachine.ts
@@ -113,7 +113,7 @@ export const depositUIMachine = setup({
     clearError: assign({ error: null }),
     setDepositNearResult: assign({
       depositNearResult: (_, value: DepositNearMachineOutput) =>
-        value.status === "SUCCESSFUL" ? value : null,
+        value.status === "DEPOSIT_COMPLETED" ? value : null,
     }),
     setDepositGenerateAddressResult: assign({
       generatedAddressResult: (_, value: DepositGenerateAddressMachineOutput) =>


### PR DESCRIPTION
- Update `depositNearMachine` outputs
- Add Deposits component for rendering deposit result with `txHash`

Example:
<img width="537" alt="Screenshot 2024-11-03 at 16 27 01" src="https://github.com/user-attachments/assets/03a3c072-5a60-4798-a537-26f4f3c76edd">
