### PR TITLE
feat: migrate to new version of defuse contract

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -2,7 +2,7 @@ import type { Settings } from "../types"
 
 export let settings: Settings = {
   providerIds: [],
-  defuseContractId: "defuse-alpha.near",
+  defuseContractId: "intents.near",
   swapExpirySec: 600, // 10 minutes
   /**
    * Quote query lasts 1.4 seconds in good network conditions


### PR DESCRIPTION
## BREAKING CHANGE: 
The defuse contract ID has been updated to a new version, which may affect existing integrations. 
Ensure to update your configurations accordingly.