### PR TITLE
feat(deposit): allow direct deposit through evm wallet

### DIFF
--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -325,7 +325,9 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
                 </div>
                 <Input
                   name="generatedAddress"
-                  value={depositAddress}
+                  value={
+                    depositAddress ? truncateUserAddress(depositAddress) : ""
+                  }
                   disabled
                   className={styles.inputGeneratedAddress}
                   slotRight={
@@ -435,7 +437,6 @@ function filterBlockchainsOptions(
   token: SwappableToken,
   chainType?: ChainType
 ): Record<string, { label: string; icon: React.ReactNode; value: string }> {
-  // TODO: use supportedTokensList
   if (isUnifiedToken(token)) {
     return token.groupedTokens.reduce(
       (
@@ -614,4 +615,8 @@ function renderDepositHint(
       )}
     </Callout.Root>
   )
+}
+
+function truncateUserAddress(hash: string) {
+  return `${hash.slice(0, 12)}...${hash.slice(-12)}`
 }

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -29,7 +29,7 @@ import { ModalType } from "../../../../stores/modalStore"
 import {
   type BaseTokenInfo,
   BlockchainEnum,
-  ChainType,
+  type ChainType,
   type SwappableToken,
 } from "../../../../types"
 import { formatTokenValue } from "../../../../utils/format"
@@ -452,9 +452,6 @@ function getBlockchainsOptions(
       value: BlockchainEnum.BITCOIN,
     },
   }
-  if (chainType !== ChainType.Near) {
-    delete (options as Partial<typeof options>)[BlockchainEnum.NEAR]
-  }
   return options
 }
 
@@ -490,7 +487,7 @@ function getDefaultBlockchainOptionValue(
   token: SwappableToken,
   chainType?: ChainType
 ): string | undefined {
-  if (!isUnifiedToken(token)) {
+  if (isBaseToken(token)) {
     const key = assetNetworkAdapter[token.chainName]
     return key ? getBlockchainsOptions(chainType)[key]?.value : undefined
   }
@@ -590,7 +587,8 @@ function NotSupportedDepositRoute() {
         <ExclamationTriangleIcon />
       </Callout.Icon>
       <Callout.Text>
-        Deposit is not supported for this network, please try another network
+        Deposit is not supported for this wallet connection, please try another
+        token or network
       </Callout.Text>
     </Callout.Root>
   )

--- a/src/features/deposit/components/DepositForm/styles.module.css
+++ b/src/features/deposit/components/DepositForm/styles.module.css
@@ -137,6 +137,7 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  margin-top: 1rem;
 }
 
 .title {

--- a/src/features/deposit/components/DepositUIMachineFormSyncProvider.tsx
+++ b/src/features/deposit/components/DepositUIMachineFormSyncProvider.tsx
@@ -6,11 +6,13 @@ import { DepositUIMachineContext } from "./DepositUIMachineProvider"
 
 type DepositUIMachineFormSyncProviderProps = PropsWithChildren<{
   userAddress?: string
+  rpcUrl?: string
 }>
 
 export function DepositUIMachineFormSyncProvider({
   children,
   userAddress,
+  rpcUrl,
 }: DepositUIMachineFormSyncProviderProps) {
   const { watch } = useFormContext<DepositFormValues>()
   const actorRef = DepositUIMachineContext.useActorRef()
@@ -37,11 +39,17 @@ export function DepositUIMachineFormSyncProvider({
 
   useEffect(() => {
     if (!userAddress) {
-      actorRef.send({ type: "LOGIN", params: { userAddress: "" } })
+      actorRef.send({
+        type: "LOGIN",
+        params: { userAddress: "", rpcUrl: undefined },
+      })
     } else {
-      actorRef.send({ type: "LOGIN", params: { userAddress } })
+      actorRef.send({
+        type: "LOGIN",
+        params: { userAddress, rpcUrl },
+      })
     }
-  }, [actorRef, userAddress])
+  }, [actorRef, userAddress, rpcUrl])
 
   return <>{children}</>
 }

--- a/src/features/deposit/components/DepositUIMachineFormSyncProvider.tsx
+++ b/src/features/deposit/components/DepositUIMachineFormSyncProvider.tsx
@@ -40,8 +40,7 @@ export function DepositUIMachineFormSyncProvider({
   useEffect(() => {
     if (!userAddress) {
       actorRef.send({
-        type: "LOGIN",
-        params: { userAddress: "", rpcUrl: undefined },
+        type: "LOGOUT",
       })
     } else {
       actorRef.send({

--- a/src/features/deposit/components/DepositUIMachineProvider.tsx
+++ b/src/features/deposit/components/DepositUIMachineProvider.tsx
@@ -167,26 +167,20 @@ export function DepositUIMachineProvider({
           depositEVMActor: depositEVMMachine.provide({
             actors: {
               sendTransaction: fromPromise(async ({ input }) => {
-                const { asset, amount, balance, tokenAddress } = input
+                const { asset, amount, tokenAddress, depositAddress } = input
 
-                const generatedAddress =
-                  "0xeF2EEC3F26A05c68AA4b25740477F3E998C10b55"
-
-                assert(
-                  generatedAddress != null,
-                  "Generated address is not defined"
-                )
+                assert(depositAddress != null, "Deposit address is not defined")
 
                 let calldata: { to?: string; data?: string } = {}
                 if (isUnifiedToken(asset) && asset.unifiedAssetId === "eth") {
                   calldata = createDepositEVMNativeCalldata(
-                    generatedAddress,
+                    depositAddress,
                     amount
                   )
                 } else {
                   calldata = createDepositEVMERC20Calldata(
                     tokenAddress,
-                    generatedAddress,
+                    depositAddress,
                     amount
                   )
                 }
@@ -195,6 +189,12 @@ export function DepositUIMachineProvider({
 
                 return txHash ?? "unknown"
               }),
+            },
+            guards: {
+              isDepositValid: ({ context }) => {
+                if (!context.txHash) return false
+                return true
+              },
             },
           }),
         },

--- a/src/features/deposit/components/DepositWidget.tsx
+++ b/src/features/deposit/components/DepositWidget.tsx
@@ -13,6 +13,7 @@ export const DepositWidget = ({
   userAddress,
   chainType,
   sendTransactionNear,
+  sendTransactionEVM,
   rpcUrl,
 }: DepositWidgetProps) => {
   return (
@@ -22,6 +23,7 @@ export const DepositWidget = ({
         <DepositUIMachineProvider
           tokenList={tokenList}
           sendTransactionNear={sendTransactionNear}
+          sendTransactionEVM={sendTransactionEVM}
         >
           <DepositUIMachineFormSyncProvider
             userAddress={userAddress}

--- a/src/features/deposit/components/DepositWidget.tsx
+++ b/src/features/deposit/components/DepositWidget.tsx
@@ -13,7 +13,7 @@ export const DepositWidget = ({
   userAddress,
   chainType,
   sendTransactionNear,
-  onEmit,
+  rpcUrl,
 }: DepositWidgetProps) => {
   return (
     <DepositWidgetProvider>
@@ -23,7 +23,10 @@ export const DepositWidget = ({
           tokenList={tokenList}
           sendTransactionNear={sendTransactionNear}
         >
-          <DepositUIMachineFormSyncProvider userAddress={userAddress}>
+          <DepositUIMachineFormSyncProvider
+            userAddress={userAddress}
+            rpcUrl={rpcUrl}
+          >
             <DepositForm chainType={chainType} />
           </DepositUIMachineFormSyncProvider>
         </DepositUIMachineProvider>

--- a/src/features/deposit/components/Deposits/index.tsx
+++ b/src/features/deposit/components/Deposits/index.tsx
@@ -13,7 +13,6 @@ export const Deposits = ({
   if (depositNearResult?.tag !== "ok") {
     return null
   }
-
   const txUrl =
     depositNearResult.value.txHash != null
       ? `${NEAR_EXPLORER}/txns/${depositNearResult.value.txHash}`

--- a/src/features/machines/depositEVMMachine.ts
+++ b/src/features/machines/depositEVMMachine.ts
@@ -15,7 +15,7 @@ export type Context = {
   accountId: string
   tokenAddress: string
   txHash: string | null
-  generatedAddress: string | null
+  depositAddress: string
   error: null | {
     tag: "err"
     value: {
@@ -31,6 +31,7 @@ type Input = {
   asset: SwappableToken
   accountId: string
   tokenAddress: string
+  depositAddress: string
 }
 
 export type Output =
@@ -61,7 +62,8 @@ export const depositEVMMachine = setup({
       }: {
         input: { txHash: string; accountId: string; amount: bigint }
       }): Promise<boolean> => {
-        throw new Error("not implemented")
+        // TODO: implement
+        return true
       }
     ),
   },
@@ -125,7 +127,7 @@ export const depositEVMMachine = setup({
       asset: input.asset,
       accountId: input.accountId,
       tokenAddress: input.tokenAddress,
-      generatedAddress: null,
+      depositAddress: input.depositAddress,
       txHash: null,
       error: null,
     }
@@ -143,6 +145,7 @@ export const depositEVMMachine = setup({
             accountId: context.accountId,
             asset: context.asset,
             tokenAddress: context.tokenAddress,
+            depositAddress: context.depositAddress,
           }
         },
         onDone: {

--- a/src/features/machines/depositEVMMachine.ts
+++ b/src/features/machines/depositEVMMachine.ts
@@ -1,0 +1,235 @@
+import { assign, emit, fromPromise, setup } from "xstate"
+import type { SwappableToken } from "../../types"
+
+export type DepositDescription = {
+  type: "depositEVM"
+  userAddressId: string
+  amount: bigint
+  asset: SwappableToken
+}
+
+export type Context = {
+  balance: bigint
+  amount: bigint
+  asset: SwappableToken
+  accountId: string
+  tokenAddress: string
+  txHash: string | null
+  generatedAddress: string | null
+  error: null | {
+    tag: "err"
+    value: {
+      reason: "ERR_SUBMITTING_TRANSACTION" | "ERR_VERIFYING_TRANSACTION"
+      error: Error | null
+    }
+  }
+}
+
+type Input = {
+  balance: bigint
+  amount: bigint
+  asset: SwappableToken
+  accountId: string
+  tokenAddress: string
+}
+
+export type Output =
+  | NonNullable<Context["error"]>
+  | {
+      tag: "ok"
+      value: {
+        txHash: string
+        depositDescription: DepositDescription
+      }
+    }
+
+export const depositEVMMachine = setup({
+  types: {} as {
+    context: Context
+    input: Input
+    output: Output
+  },
+  actors: {
+    sendTransaction: fromPromise(
+      async ({ input }: { input: Input }): Promise<string> => {
+        throw new Error("not implemented")
+      }
+    ),
+    validateTransaction: fromPromise(
+      async ({
+        input,
+      }: {
+        input: { txHash: string; accountId: string; amount: bigint }
+      }): Promise<boolean> => {
+        throw new Error("not implemented")
+      }
+    ),
+  },
+  actions: {
+    setError: assign({
+      error: (_, error: NonNullable<Context["error"]>["value"]) => ({
+        tag: "err" as const,
+        value: error,
+      }),
+    }),
+    logError: (_, params: { error: unknown }) => {
+      console.error(params.error)
+    },
+    emitSuccessfulDeposit: emit(({ context }) => ({
+      type: "SUCCESSFUL_DEPOSIT",
+      data: context.txHash,
+    })),
+    emitFailedDeposit: emit(({ context }) => ({
+      type: "FAILED_DEPOSIT",
+      error: context.error,
+    })),
+  },
+  guards: {
+    isDepositValid: () => {
+      throw new Error("not implemented")
+    },
+  },
+}).createMachine({
+  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0YAbgLYB02UAdlpVAMQTqVik2HoDWLKG2+RZCtVoI26AMYBDHFiYBtAAwBdRUsSheuWZXUgAHogDMhgBykALIYBshgIwB2BeYUL75gEzmANCACeRp1ITd1t3BU8TAE4beysAXzifHkxcAhJyLCoaejAAJ1z0XNJUABtpADNCsmS+NMFM4ShRSnYpGXllVV1Ndp0kfSNDSNJbJ3cTAFZ7SJc3ax9-BFNhyMMPcwnIh1HzVYSktBT+dMI8rHLfbIYmFjEuUhrUgVJT3PPLkTE27VUu-p7tLoDAhIhMrKQXJEoiYTEMNpMFkZ3PZSNN7LFdlEYvFEiBHscyK93lc8gUiqUKlUHodas8iRdss1WtIfp1lN0joD+sDQRMggoJrZImFPOZ0YillZzCNhVZkeZRvY1pF9niaU90gAjAqSCBSWAyWh0P4aTlMIGIWxWey2UgTCYeWz2qxYwzuCVulFojFQ6KGWIJXGUdAoeD9fF1Dl8LmgYF4cwmCUhFFu0IKOUO5Ho1UR55CbJRrTm7mIBQe6w59UEl5nBm0Qu9C0IKwTdykGyRcyWaLjJxWcs4g49OqkbXoXX6w1QBsxgYIWxrMwt9zWcYeG2GCYe2xmLZbKJbVzKyvD54AOXQOAABAAxdAAV0oECvhSvAEkWpISlgIDPi7HEE7FYdzFT0u3FPxEAmcJUQdZxhShdxVlsE8jhHABhdBiFKMAcEgP8+gA+cTBcCFbC7MIoXRYxDA9dw+ScdEpV9bFUNpdIAEFNUKPDf3+M1CLnTc2ydaDrScWZLH7SCEHtNtrFCKZbFEyx7EDOIgA */
+  id: "deposit-evm",
+
+  initial: "signing",
+
+  output: ({ context }): Output => {
+    if (context.txHash != null) {
+      return {
+        tag: "ok",
+        value: {
+          txHash: context.txHash,
+          depositDescription: {
+            type: "depositEVM",
+            userAddressId: context.accountId,
+            amount: context.amount,
+            asset: context.asset,
+          },
+        },
+      }
+    }
+
+    if (context.error != null) {
+      return context.error
+    }
+
+    throw new Error("Unexpected output")
+  },
+
+  context: ({ input }) => {
+    return {
+      balance: input.balance,
+      amount: input.amount,
+      asset: input.asset,
+      accountId: input.accountId,
+      tokenAddress: input.tokenAddress,
+      generatedAddress: null,
+      txHash: null,
+      error: null,
+    }
+  },
+
+  states: {
+    signing: {
+      invoke: {
+        id: "deposit-evm.signing:invocation[0]",
+
+        input: ({ context }) => {
+          return {
+            balance: context.balance,
+            amount: context.amount,
+            accountId: context.accountId,
+            asset: context.asset,
+            tokenAddress: context.tokenAddress,
+          }
+        },
+        onDone: {
+          target: "verifying",
+          actions: assign({
+            txHash: ({ event }) => event.output,
+          }),
+        },
+        onError: {
+          target: "Aborted",
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => {
+                console.log("onError type: setError", event)
+                return {
+                  reason: "ERR_SUBMITTING_TRANSACTION",
+                  error: toError(event.error),
+                }
+              },
+            },
+          ],
+        },
+        src: "sendTransaction",
+      },
+    },
+
+    verifying: {
+      invoke: {
+        id: "deposit-evm.verifying:invocation[0]",
+        input: ({ context }) => ({
+          txHash: context.txHash || "",
+          accountId: context.accountId || "",
+          amount: context.amount || 0n,
+        }),
+        onDone: {
+          target: "broadcasting",
+          guard: {
+            type: "isDepositValid",
+          },
+        },
+        onError: {
+          target: "Not Found or Invalid",
+          actions: {
+            type: "setError",
+            params: ({ event }) => ({
+              reason: "ERR_VERIFYING_TRANSACTION",
+              error: null,
+            }),
+          },
+        },
+        src: "validateTransaction",
+      },
+    },
+
+    broadcasting: {
+      entry: {
+        type: "emitSuccessfulDeposit",
+      },
+
+      description:
+        "Configure the payload for ft_transfer_call,\n\nwhich triggers the EVM wallet and\n\nbroadcasts the transaction",
+
+      always: {
+        target: "Completed",
+      },
+    },
+
+    "Not Found or Invalid": {
+      type: "final",
+    },
+
+    Completed: {
+      type: "final",
+    },
+
+    Aborted: {
+      type: "final",
+      entry: ["emitFailedDeposit"],
+    },
+  },
+})
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error("unknown error")
+}

--- a/src/features/machines/depositUIMachine.ts
+++ b/src/features/machines/depositUIMachine.ts
@@ -254,6 +254,11 @@ export const depositUIMachine = setup({
     LOGOUT: {
       actions: assign({
         userAddress: () => "",
+        formValues: {
+          token: null,
+          network: null,
+          amount: "",
+        },
       }),
     },
   },

--- a/src/features/machines/depositUIMachine.ts
+++ b/src/features/machines/depositUIMachine.ts
@@ -41,8 +41,10 @@ export type Context = {
   tokenList: SwappableToken[]
   userAddress: string
   defuseAssetId: string | null
+  tokenAddress: string | null
   generatedAddressResult: DepositGenerateAddressMachineOutput | null
   depositNearResult: DepositNearMachineOutput | null
+  rpcUrl: string | undefined
 }
 
 export const depositUIMachine = setup({
@@ -70,6 +72,7 @@ export const depositUIMachine = setup({
           type: "LOGIN"
           params: {
             userAddress: string
+            rpcUrl: string | undefined
           }
         }
       | {
@@ -133,7 +136,7 @@ export const depositUIMachine = setup({
     }),
     clearDepositResult: assign({ depositNearResult: null }),
 
-    extractDefuseAssetId: assign({
+    extractAssetIds: assign({
       defuseAssetId: ({ context }) => {
         if (context.formValues.token == null) {
           return null
@@ -147,6 +150,21 @@ export const depositUIMachine = setup({
               assetNetworkAdapter[token.chainName] ===
               context.formValues.network
           )?.defuseAssetId ?? null
+        )
+      },
+      tokenAddress: ({ context }) => {
+        if (context.formValues.token == null) {
+          return null
+        }
+        if (isBaseToken(context.formValues.token)) {
+          return context.formValues.token.address
+        }
+        return (
+          context.formValues.token.groupedTokens.find(
+            (token) =>
+              assetNetworkAdapter[token.chainName] ===
+              context.formValues.network
+          )?.address ?? null
         )
       },
     }),
@@ -193,7 +211,7 @@ export const depositUIMachine = setup({
     isOk: (_, a: { tag: "err" | "ok" }) => a.tag === "ok",
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0ArlgMQAyA8gOICSAcgNoAMAuoqBtjlugHZsgAPRIwB0ATjEAOAEwA2RtMYBGWQHZpAVmnSALABoQAT0R4ZGkUskqxSgMyqdSxo0kBfVwZQdchEhUrkAKoAKkysSCDeXLz8Qgh40rZK4hqykmKqsho6aUmyBsbxZhZWsjb2js5uHiBemD5EIpC4WDxQxADKgQBCALLUoSz8Udx8EXGytiVKStk2mRKSqgUmcqJqNjpiSduS2e6eaPX4jc1cbcR0AAohYcPHo7EmllO2GuqJSjrSStupK-E3qpxDNbLZvjMypYDrUjpxfE0IC02iIAG4AQwANlgIOjzu0ILwwCJWqj0ABrYl1eGnJH4tFYnF41pQBCk9AAY2ZvDCdwiIxi4xMsh0OhEOg0S2yYLUshUALwWmBjgcOwyWVUShh1IaWERyKgDOxuPxxEJPGJ7MpIh1Jz1ZxZRqZ+LZPDJXOiPF5SnC7AegtAcVMXxEaSUiW+MlUGnBCp09hE0jEGi+YkUQNUb21cN1IlgBAARgBbXCm82Wt0Uqk5nC0MDogBOACUwAAzPl+ziPIUIHR7ESa0VqWZSSSTfRGZ6yaQiSTxpaZ7KMb7L7NRBH54ullnEMANhvoBsiVCYvGtw9Fm01uuNlvtob8-1jQOIPvAmzyRhiFUyOX5SfxBo5g2JISQ5BIOTfKoa7HAiMAWg2zIXOWJKVtatqUGACF4mAACCEAQA2cCwHeHaRE+Ty9n2Ihgs4OguEkqjLrYcY5CIGgSEBMZlFkOgwTSerwXuSHtHuB5HieZ4XleUSYdhOB4QRRGwCRbZkQKz6CK+1ESKokgyL83FpP+hR4LYWSJr8qgOJofYvPxuYEKgJpgN0WLojwHJgMQAiwDgOEiOirYKQ2AAUijOAAlGaNYIk5LluaenlgOpFE9hZ35Jj8tn0dOJnPHINFiIwDiSqB2jOBo7g1Dw6AoPAES2r49xdgGWnxN+Yq-N88YlbI8iZAqTFTPMtjfsmqiLFqNRNbSBotS0bVBuksgWJlvWZAN+XxH+4pKA41iSpYYiyA5dr6vSOKYmAC2epRpjUd1ui2H1W0Klokggqq6SSrYVjTYc65zfSGLGiJt3di+8RJmK6TSJkK1-GBCojgOXwvZNmTvFIZ0boWJY4PiENLa+dgiC4zgzDMyaJMsAEJHKiYKEdjhWDGti440QmIUTj6tZpcR-WIoYldIY7OJNpTbYqDizmkk2pCdjBAZzerxThiUeV5xMC4g2gzlk5knSuDiTdL4bAukJVbJq1n2GI1WuEAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0ArlgMQAyA8gOICSAcgNoAMAuoqBtjlugHZsgAPRIwB0ATjEAOAEwA2RtMYBGWQHZpAVmnSALABoQAT0R4ZGkUskqxSgMyqdSxo0kBfVwZQdchEhUrkAKoAKkysSCDeXLz8Qgh40rZK4hqykmKqsho6aUmyBsbxZhZWsjb2js5uHiBemD5EIpC4WDxQxADKgQBCALLUoSz8Udx8EXGytiVKStk2mRKSqgUmcqJqNjpiSduS2e6eaPX4jc1cbcR0AAohYcPHo7EmllO2GuqJSjrSStupK-E3qpxDNbLZvjMypYDrUjpxfE0IC02iIAG4AQwANlgIOjzu0ILwwCJWqj0ABrYl1eGnJH4tFYnF41pQBCk9AAY2ZvDCdwiIxi4xMkmUFlUGjs2kkSVs0kkALwSnUIlkXyV7w0jFl0hsMOpDSwiORUAZ2Nx+OIfPYD0FoDieC0YhEWx0WzB0nFs3yRmeIpVEvKc0YYneerhBpEsAIACMALa4C2EnjE9mUkT6nC0MDogBOACUwAAzK2RG1jO2IHR7ESqL45WsaKSSSb6H3xFTSESSHS2JaqN46RjfIdhqIIqNxhMs4hJlM8MlpjNZ3MF4tKcLWziPCKFBKqkSKTRWRxWDRggxxPZOlSNquqkOJaqHMeNGDJnPMi6zknzilU8M4JQYDvniYAAIIQBAOZwLAq4lgK5aCJWVYiGCziDtKSpDrYCqurIIiNiGGhnmUWQ6KOxwIm+YAfhaNE5ugOYiKgmJ4oWjGxumAFASBODgZB0GwLBRbwWWTwIK6kjiBkkgyL8JFpN6u62FkB6-KoDiaFWLwUTShoEKg5pgN0WLojwHJgMQAiwDgoEiOihZ8TmAAUijOAAlDOAEIgZRkmax5lgKJW62khCCqWI3xiD8WmDrIcgKkocioWIjAOBosnas4GjuDUPDoCg8ARBmvj3CFiH2pFOgWJFui2GlsjyJkCriqI8xbJFQ5LLKukRmcLJlS0oX2uk+G-N8PYNU1SkmKq+GOA4jVglkEhKL1JyGv1KI4piYCDdEFXCih411VNDUKloUntb2IbSlYa01CVtLGqaTL4vt24VvEOrVekHppGIZRvEkra7rMTq1pNqgZFk0NPrCL6GhO8Y4O9-JiUKEl2CILjODMMwPvYCpyMkh4ZWqp5gutVHATRn5QB9w2IDdKppXK8hpVIKgzfE7y-Wk0OpIDjDEdTjS+aB-lmRZjOHQg2idlkKmA8ODjQzzioel2qUOBkSr9tDuWuEAA */
   id: "deposit-ui",
 
   context: ({ input, spawn }) => ({
@@ -213,10 +231,12 @@ export const depositUIMachine = setup({
     tokenList: input.tokenList,
     userAddress: "",
     defuseAssetId: null,
+    tokenAddress: null,
     generatedAddressResult: null,
     poaBridgeInfoRef: spawn("poaBridgeInfoActor", {
       id: "poaBridgeInfoRef",
     }),
+    rpcUrl: undefined,
   }),
 
   entry: ["fetchPOABridgeInfo"],
@@ -226,6 +246,7 @@ export const depositUIMachine = setup({
       actions: [
         assign({
           userAddress: ({ event }) => event.params.userAddress,
+          rpcUrl: ({ event }) => event.params.rpcUrl,
         }),
       ],
     },
@@ -250,7 +271,6 @@ export const depositUIMachine = setup({
           target: ".validating",
           actions: [
             "clearError",
-            // "sendToDepositNearRefClearError",
             {
               type: "setFormValues",
               params: ({ event }) => ({ data: event.params }),
@@ -264,7 +284,7 @@ export const depositUIMachine = setup({
         idle: {},
 
         validating: {
-          entry: "extractDefuseAssetId",
+          entry: "extractAssetIds",
 
           invoke: {
             src: "formValidationBalanceActor",
@@ -272,14 +292,21 @@ export const depositUIMachine = setup({
             input: ({ context }) => {
               return {
                 defuseAssetId: context.defuseAssetId,
+                tokenAddress: context.tokenAddress,
                 userAddress: context.userAddress,
                 network: context.formValues.network,
+                rpcUrl: context.rpcUrl,
               }
             },
 
             onDone: [
               {
                 target: "#deposit-ui.generating",
+
+                actions: assign({
+                  balance: ({ event }) => event.output.balance,
+                  nativeBalance: ({ event }) => event.output.nativeBalance,
+                }),
 
                 reenter: true,
                 guard: "isDepositNonNearRelevant",

--- a/src/features/machines/depositUIMachine.ts
+++ b/src/features/machines/depositUIMachine.ts
@@ -146,6 +146,7 @@ export const depositUIMachine = setup({
         value,
     }),
     clearDepositResult: assign({ depositNearResult: null }),
+    clearDepositEVMResult: assign({ depositEVMResult: null }),
 
     extractAssetIds: assign({
       defuseAssetId: ({ context }) => {
@@ -233,7 +234,7 @@ export const depositUIMachine = setup({
     isOk: (_, a: { tag: "err" | "ok" }) => a.tag === "ok",
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0ArlgMQAyA8gOICSAcgNoAMAuoqBtjlugHZsgAPRHgCMAZgDsAOgAsANgCsEuQA4FMsSoBMYuWIA0IAJ7CVKgJxTx2xWK0WVIlQF9nhlB1yESFSuQCqACpMrEggnly8-EIIMlJqKnIichISCuYKKhI6hiYIeGaW1lq29uaOLm4gHpheRFKQuFg8UMQAyv4AQgCy1MEs-BHcfGExclpS6mJKEnZi86mJucIlcrKMuloSjAqZ5jIiru5otfj1jVwt7V29wSKh7KfD0Yhya8mpIvZy+yq6Est8loFFJpuY5IxzGIRKlMocqjVON4GhAmlc6AAFIIhQZPKKjYROMSgpRaHQiGRaERQhRyQF4abScwicRiSksn5OI7VE5I86oy5QKQANwAhgAbLAQUWC4gQXhgKTNYXoADWisRdSwKLRQrFkulgoQyvQAGMZcMQjiwkN8aAYngUhM1Iw5BpyuZmV96QpoVJGIxxDIdl8xPsZNzNWdtRdmnqJVKLVd5TxFSb1VIo8jYy0RQnDXHjTwVebIjwrfdcZxngT8o4QTIDjCkj99iz6ZI4skLFoDsGJOZUpHeVqpLACAAjAC2uEFtDAooAToEBHKFUri2qNSOcPOlwAlMAAM2tj2rdsEiF2IPMOyUSR2zMU9OSzvdjBKGxblWOEWRMFTRck1aFM003DMo0oMBAJlMAAEEIAgRc4FgQ8TwGG08RGe1EGDEEPyhERGDUdJdAUekZChKQknvFlPVdSixGHP96gIVBDTAToJVFHhTTAYgBFgHBYKkUUjxwMBFwACi0ANGAASjlHdkTYjiuPFHi+NPcIsJeBAyS7QiYWheYiK0F8SlBW8JBkTI-jJAMfx5FjtXHadZzjABRAA1boVzXVMNxVCCdx87o0O021sOMFYQW2MwDgUYiNBkNJyMvBAiNdKQbMYGRtCDcZmVcKoeHQFB4DCLMiCrJoLwdcMrH2XsxEYZQIWUek0mJeRG3s1LMg2ZjTmzAU41qss9IKcEmspDQ2reBb6RbWQYQUXsNAkLJiOGvkYzG3MpXFMAJprHC63y2aWoWjq6Ri-J1pUKRmRszQMj+Rx4V-Eb+V1PMDWA076pWfZ4nMLZVHBGloRkF90hyilWoHZQlHKXbRzcmccDnBdlxiM86uimIkqe2k1HKdbEt9Ax7rwVZnq2NryjeeYMgkdHoykADJMBzDzyJxBJDWSlNBKCQnCI7rlqcZ63Xy-KCLyjmVPY2D1M0k6+cJvTdDWSQ2Xo5Q2umCzpAsNrfVSWTHFdZX6kxjyWjClcgYFhBaTiSkBwKtkipEelgRy4iVES5K2TSkrnCAA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0ArlgMQAyA8gOICSAcgNoAMAuoqBtjlugHZsgAPRHgCMAZgDsAOgAsANgCsEuQA4FMsSoBMYuWIA0IAJ7CVKgJxTx2xWK0WVIlQF9nhlB1yESFSuQCqACpMrEggnly8-EIIMlJqKnIichISCuYKKhI6hiYIeGaW1lq29uaOLm4gHpheRFKQuFg8UMQAyv4AQgCy1MEs-BHcfGExclpS6mJKEnZi86mJucIlcrKMuloSjAqZ5jIiru5otfj1jVwt7V29wSKh7KfD0YhyjFLmjNpaTm9bIhJ9st8iIZAp1hkJFlGCUtLsZEdqidON4GhAmlc6AAFIIhQZPKKjYROMRSabZHSgn7maZyYF4ckfETiMQyH7JcxORE1FHndGXKBSABuAEMADZYCAigXECC8MBSZpC9AAawVPLqWDRGMFoolUoFCCV6AAxtLhiE8WEhoTQDE8CkJmpGHINOVzJyRFp6QoxCIpIxGOIZDsvWJ9giqhqzlqLs1deLJearnKeArjWqpNHUXGWsLEwb40aeMqzZEeJb7vjOM8iflHOCZAcAUk5B7m-TJHFkhYtAcQ4DUtzkZqpLACAAjAC2uAFtDAIoAToEBLL5YqS6r1SOcPOlwAlMAAMytjxrtsEiAs7xk2h2jEBOlZdOMKyhZJUQbbvpZCmHEVRGA00XZNWlTdNN0zaNKDAYDpTAABBCAIEXOBYEPE8BmtAkRjtRAQ3BGEaREL5dhpRR6RkGkpCSJQkhED0XSosR-1OVECFQA0wE6cURR4E0wGIARYBweCpBFI8cDARcAAotEDRgAEpZR3djOPgnixT4gTT3CHCXgQLZpE-dQzHkSRMhkTtMg+WiXRKcwJAY1jeS1cdp1neMAFEADVuhXNc0w3ZUoJ3Xzugw3SbVwy8EAsf0nAUBinB+GRshEekRCSmjEnJB82TS8RXCqHh0BQeAwmzIhqyaC97QjKx9j7MQHzkN5lHpNJSXkJtXTBLKVF0FzR1zKAavLAyCnMNYGIKlrlHal88gdZJZABNKfhUKivUqY4AL5HVFQgMUwHG2s8PrW9Grm1rFp9ewmQkDQLEyTRmWGmNtQFfN9VAs66pWfZ4nMLZVGmmkfys18QXSKQnI0B9HMUQFdqRfa3MnGccDnBdlxiM9apimIFC+SZVHSNQ+yy30DGhvBVg+LZEcSPRwyUD7ANg6S-uw88icQSQ1jZTQSicxwH19ekkhUWymy2z8tE+SM9rY+oOK4zTtNO3nCYMmlLAUV1GA9dIoUyb06d0G8klvB8SJbFio1U+p3KxgVwpXf7+YQEnLCcv1A0HNq4UykMpCfVLVDZBi-2KoA */
   id: "deposit-ui",
 
   context: ({ input, spawn }) => ({
@@ -385,7 +386,6 @@ export const depositUIMachine = setup({
 
         onDone: {
           target: "updateBalance",
-          guard: { type: "isOk", params: ({ event }) => event.output },
 
           actions: [
             {
@@ -446,7 +446,13 @@ export const depositUIMachine = setup({
 
         input: ({ context, event }) => {
           assertEvent(event, "SUBMIT")
-
+          const depositAddress =
+            context.generatedAddressResult?.tag === "ok"
+              ? context.generatedAddressResult.value.depositAddress
+              : null
+          if (!depositAddress) {
+            throw new Error("Deposit address is missing")
+          }
           if (
             context.formValues.token == null ||
             !context.userAddress ||
@@ -460,12 +466,12 @@ export const depositUIMachine = setup({
             asset: context.formValues.token,
             accountId: context.userAddress,
             tokenAddress: context.tokenAddress,
+            depositAddress,
           }
         },
 
         onDone: {
-          target: "editing.validating",
-          guard: { type: "isOk", params: ({ event }) => event.output },
+          target: "updateBalance",
 
           actions: [
             {

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -236,6 +236,11 @@ export function getAvailableDepositRoutes(
             activeDeposit: true,
             passiveDeposit: true,
           }
+        case BlockchainEnum.BITCOIN:
+          return {
+            activeDeposit: false,
+            passiveDeposit: true,
+          }
         default:
           return null
       }

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -1,3 +1,5 @@
+import { Interface } from "ethers"
+import { type Abi, erc20Abi } from "viem"
 import { settings } from "../config/settings"
 import {
   getNearNep141MinStorageBalance,
@@ -117,6 +119,30 @@ export function createBatchDepositNearNativeTransaction(
   ]
 }
 
+export function createDepositEVMERC20Calldata(
+  assetAccountId: string,
+  generatedAddress: string,
+  amount: bigint
+): { to: string; data: string } {
+  const iface = new Interface(erc20Abi)
+  const data = iface.encodeFunctionData("transfer", [generatedAddress, amount])
+  return {
+    to: assetAccountId,
+    data,
+  }
+}
+
+export function createDepositEVMNativeCalldata(
+  generatedAddress: string,
+  amount: bigint
+): { to: string; value: bigint; data: string } {
+  return {
+    to: generatedAddress,
+    value: amount,
+    data: "0x",
+  }
+}
+
 /**
  * Generate a deposit address for the specified blockchain and asset through the POA bridge API call.
  *
@@ -234,7 +260,7 @@ export function getAvailableDepositRoutes(
         case BlockchainEnum.BASE:
         case BlockchainEnum.ARBITRUM:
           return {
-            activeDeposit: false,
+            activeDeposit: true,
             passiveDeposit: true,
           }
         case BlockchainEnum.BITCOIN:

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -242,11 +242,6 @@ export function getAvailableDepositRoutes(
             activeDeposit: false,
             passiveDeposit: true,
           }
-        case BlockchainEnum.BITCOIN:
-          return {
-            activeDeposit: false,
-            passiveDeposit: true,
-          }
         default:
           network satisfies never
           throw new Error("exhaustive check failed")

--- a/src/types/deposit.ts
+++ b/src/types/deposit.ts
@@ -10,7 +10,9 @@ export type DepositWidgetProps = {
   userAddress?: string
   chainType: ChainType
   sendTransactionNear: (transactions: Transaction[]) => Promise<string>
+  sendTransactionEVM: (transactions: Transaction[]) => Promise<string>
   onEmit?: (event: DepositEvent) => void
+  rpcUrl?: string
 }
 
 export type DepositEvent = {

--- a/src/types/deposit.ts
+++ b/src/types/deposit.ts
@@ -1,3 +1,4 @@
+import type { Abi } from "viem"
 import type { SwappableToken } from "../types"
 
 export type ChainType = "near" | "evm"
@@ -15,8 +16,10 @@ export type UserInfo = {
 export type DepositWidgetProps = UserInfo & {
   tokenList: SwappableToken[]
   sendTransactionNear: (transactions: Transaction[]) => Promise<string>
-  sendTransactionEVM: (transactions: Transaction[]) => Promise<string>
-  onEmit?: (event: DepositEvent) => void
+  sendTransactionEVM: (calldata: {
+    to?: string
+    data?: string
+  }) => Promise<string | null>
   rpcUrl?: string
 }
 


### PR DESCRIPTION
This PR enables direct deposits using an EVM-connected wallet.

# Changes include:
- The Deposit UI machine is now responsible for routing between NEAR and EVM submissions
- A separate deposit EVM machine has been added
- The deposit balance machine can now fetch balances for ERC20 tokens or native balances using the RPC URL provided to the SDK
- The background balance machine is now responsible for fetching EVM tokens based on the network
- The deposit service has been extended with two functions needed for fetching balances

# Example:
<img width="563" alt="Screenshot 2024-11-13 at 02 40 38" src="https://github.com/user-attachments/assets/10d0209e-e650-411e-8fc1-a2adc997d11f">
<img width="391" alt="Screenshot 2024-11-14 at 09 29 26" src="https://github.com/user-attachments/assets/1f25c831-e9da-4f1c-92a1-de801bd4cfd8">

