### PR TITLE
fix: disable deposits on solana

### DIFF
--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -303,6 +303,10 @@ export function getAvailableDepositRoutes(
     case ChainType.Solana:
       switch (network) {
         case BlockchainEnum.NEAR:
+          return {
+            activeDeposit: false,
+            passiveDeposit: false,
+          }
         case BlockchainEnum.ETHEREUM:
         case BlockchainEnum.BASE:
         case BlockchainEnum.ARBITRUM:


### PR DESCRIPTION
Due to issues reported by our users with deposits using the Phantom wallet on the Solana network, we have decided to disable it.