### PR TITLE
feat: enabled deposit to turbochain

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -36,7 +36,13 @@ export let settings: Settings = {
     solana:
       "https://quiet-solemn-asphalt.solana-mainnet.quiknode.pro/91aa5918df65520d47a54d88590f1503a4e804b1",
     dogecoin: "https://go.getblock.io/5f7f5fba970e4f7a907fcd2c5f4c38a2",
-    turbochain: "https://rpc-0x4e45415f.aurora-cloud.dev ",
+    turbochain: "https://rpc-0x4e45415f.aurora-cloud.dev",
+  },
+  /**
+   * SiloToSilo addresses on blockchains within Aurora Engine
+   */
+  silo: {
+    turbochain: "", // TODO: add address to deployed contract at turbochain
   },
 }
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -38,12 +38,6 @@ export let settings: Settings = {
     dogecoin: "https://go.getblock.io/5f7f5fba970e4f7a907fcd2c5f4c38a2",
     turbochain: "https://rpc-0x4e45415f.aurora-cloud.dev",
   },
-  /**
-   * SiloToSilo addresses on blockchains within Aurora Engine
-   */
-  silo: {
-    turbochain: "", // TODO: add address to deployed contract at turbochain
-  },
 }
 
 export const getSettings = (): Settings => settings

--- a/src/constants/aurora.ts
+++ b/src/constants/aurora.ts
@@ -1,0 +1,6 @@
+/**
+ * SiloToSilo addresses on blockchains within Aurora Engine
+ */
+export const siloToSiloAddress = {
+  turbochain: "0x8a4Bf14C51e1092581F1392810eE38c5A20f83da",
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from "./swap"
 export * from "./tokens"
+export * from "./aurora"

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -377,20 +377,16 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
             depositSolanaResult,
             depositTurboResult
           )}
-        {userAddress &&
-          (network === BlockchainEnum.NEAR ||
-            network === BlockchainEnum.TURBOCHAIN) && (
-            <Deposits
-              chainName={
-                network === BlockchainEnum.NEAR
-                  ? "near"
-                  : network === BlockchainEnum.TURBOCHAIN
-                    ? "turbochain"
-                    : null
-              }
-              depositResult={depositNearResult ?? depositTurboResult}
-            />
-          )}
+        <Deposits
+          chainName={
+            network === BlockchainEnum.NEAR
+              ? "near"
+              : network === BlockchainEnum.TURBOCHAIN
+                ? "turbochain"
+                : null
+          }
+          depositResult={depositNearResult ?? depositTurboResult}
+        />
         {network !== BlockchainEnum.NEAR && isDepositReceived && (
           <DepositSuccess />
         )}

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -73,6 +73,7 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
   const depositNearResult = snapshot.context.depositNearResult
   const depositEVMResult = snapshot.context.depositEVMResult
   const depositSolanaResult = snapshot.context.depositSolanaResult
+  const depositTurboResult = snapshot.context.depositTurboResult
 
   const depositAddress =
     generatedAddressResult?.tag === "ok"
@@ -157,11 +158,11 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
   }
 
   useEffect(() => {
-    if (token && getDefaultBlockchainOptionValue(token, chainType)) {
-      const networkOption = getDefaultBlockchainOptionValue(token, chainType)
+    if (token && getDefaultBlockchainOptionValue(token)) {
+      const networkOption = getDefaultBlockchainOptionValue(token)
       setValue("network", networkOption)
     }
-  }, [token, setValue, chainType])
+  }, [token, setValue])
 
   const balanceInsufficient = isInsufficientBalance(
     amount,
@@ -223,16 +224,14 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
                 control={control}
                 render={({ field }) => (
                   <Select
-                    options={filterBlockchainsOptions(token, chainType)}
+                    options={filterBlockchainsOptions(token)}
                     placeholder={{
                       label: "Select network",
                       icon: <EmptyIcon />,
                     }}
                     fullWidth
                     value={
-                      getDefaultBlockchainOptionValue(token, chainType) ||
-                      network ||
-                      ""
+                      getDefaultBlockchainOptionValue(token) || network || ""
                     }
                     disabled={!isUnifiedToken(token)}
                     onChange={field.onChange}
@@ -375,11 +374,23 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
             userAddress,
             depositNearResult,
             depositEVMResult,
-            depositSolanaResult
+            depositSolanaResult,
+            depositTurboResult
           )}
-        {userAddress && network === BlockchainEnum.NEAR && (
-          <Deposits depositNearResult={snapshot.context.depositNearResult} />
-        )}
+        {userAddress &&
+          (network === BlockchainEnum.NEAR ||
+            network === BlockchainEnum.TURBOCHAIN) && (
+            <Deposits
+              chainName={
+                network === BlockchainEnum.NEAR
+                  ? "near"
+                  : network === BlockchainEnum.TURBOCHAIN
+                    ? "turbochain"
+                    : null
+              }
+              depositResult={depositNearResult ?? depositTurboResult}
+            />
+          )}
         {network !== BlockchainEnum.NEAR && isDepositReceived && (
           <DepositSuccess />
         )}
@@ -481,8 +492,7 @@ function getBlockchainsOptions(): Record<
 }
 
 function filterBlockchainsOptions(
-  token: SwappableToken,
-  chainType?: ChainType
+  token: SwappableToken
 ): Record<string, { label: string; icon: React.ReactNode; value: string }> {
   if (isUnifiedToken(token)) {
     return token.groupedTokens.reduce(
@@ -509,8 +519,7 @@ function filterBlockchainsOptions(
 }
 
 function getDefaultBlockchainOptionValue(
-  token: SwappableToken,
-  chainType?: ChainType
+  token: SwappableToken
 ): BlockchainEnum | null {
   if (isBaseToken(token)) {
     const key = assetNetworkAdapter[token.chainName]
@@ -553,7 +562,8 @@ function renderDepositWarning(
   userAddress: string | null,
   depositNearResult: Context["depositNearResult"],
   depositEVMResult: Context["depositEVMResult"],
-  depositSolanaResult: Context["depositSolanaResult"]
+  depositSolanaResult: Context["depositSolanaResult"],
+  depositTurboResult: Context["depositTurboResult"]
 ) {
   let content: ReactNode = null
   if (!userAddress) {
@@ -566,12 +576,14 @@ function renderDepositWarning(
   const r1 = depositNearResult !== null && depositNearResult.tag === "err"
   const r2 = depositEVMResult !== null && depositEVMResult.tag === "err"
   const r3 = depositSolanaResult !== null && depositSolanaResult.tag === "err"
+  const r4 = depositTurboResult !== null && depositTurboResult.tag === "err"
 
-  if (r1 || r2 || r3) {
+  if (r1 || r2 || r3 || r4) {
     const status =
       (r1 && depositNearResult.value.reason) ||
       (r2 && depositEVMResult.value.reason) ||
-      (r3 && depositSolanaResult.value.reason)
+      (r3 && depositSolanaResult.value.reason) ||
+      (r4 && depositTurboResult.value.reason)
     switch (status) {
       case "ERR_SUBMITTING_TRANSACTION":
         content =

--- a/src/features/deposit/components/DepositWidget.tsx
+++ b/src/features/deposit/components/DepositWidget.tsx
@@ -25,6 +25,7 @@ export const DepositWidget = ({
           sendTransactionNear={sendTransactionNear}
           sendTransactionEVM={sendTransactionEVM}
           sendTransactionSolana={sendTransactionSolana}
+          chainType={chainType}
         >
           <DepositUIMachineFormSyncProvider
             userAddress={userAddress}

--- a/src/features/deposit/components/Deposits/index.tsx
+++ b/src/features/deposit/components/Deposits/index.tsx
@@ -1,29 +1,31 @@
 import { Box, Flex, Link, Text } from "@radix-ui/themes"
 import { AssetComboIcon } from "src/components/Asset/AssetComboIcon"
+import type { SupportedChainName } from "src/types"
+import { chainTxExplorer } from "src/utils/chainTxExplorer"
 import { formatTokenValue } from "src/utils/format"
 import type { Context } from "../../../machines/depositUIMachine"
 
-const NEAR_EXPLORER = "https://nearblocks.io"
-
 export const Deposits = ({
-  depositNearResult,
+  chainName,
+  depositResult,
 }: {
-  depositNearResult: Context["depositNearResult"]
+  chainName: SupportedChainName | null
+  depositResult: Context["depositNearResult"] | Context["depositTurboResult"]
 }) => {
-  if (depositNearResult?.tag !== "ok") {
+  if (depositResult?.tag !== "ok") {
     return null
   }
   const txUrl =
-    depositNearResult.value.txHash != null
-      ? `${NEAR_EXPLORER}/txns/${depositNearResult.value.txHash}`
+    chainName != null && depositResult.value.txHash != null
+      ? chainTxExplorer(chainName) + depositResult.value.txHash
       : null
 
   return (
     <Flex p={"2"} gap={"3"}>
       <Box pt={"2"}>
         <AssetComboIcon
-          icon={depositNearResult.value.depositDescription.asset.icon}
-          name={depositNearResult.value.depositDescription.asset.name}
+          icon={depositResult.value.depositDescription.asset.icon}
+          name={depositResult.value.depositDescription.asset.name}
         />
       </Box>
 
@@ -47,7 +49,7 @@ export const Deposits = ({
             <Text size={"1"} weight={"medium"} color={"gray"}>
               From{" "}
               {shortenText(
-                depositNearResult.value.depositDescription.userAddressId
+                depositResult.value.depositDescription.userAddressId
               )}
             </Text>
           </Box>
@@ -56,26 +58,26 @@ export const Deposits = ({
             <Text size={"1"} weight={"medium"} color={"green"}>
               +
               {formatTokenValue(
-                depositNearResult.value.depositDescription.amount,
-                depositNearResult.value.depositDescription.asset.decimals,
+                depositResult.value.depositDescription.amount,
+                depositResult.value.depositDescription.asset.decimals,
                 {
                   min: 0.0001,
                   fractionDigits: 4,
                 }
               )}{" "}
-              {depositNearResult.value.depositDescription.asset.symbol}
+              {depositResult.value.depositDescription.asset.symbol}
             </Text>
           </Box>
         </Flex>
 
-        {depositNearResult.value.txHash != null && txUrl != null && (
+        {depositResult.value.txHash != null && txUrl != null && (
           <Box>
             <Text size={"1"} color={"gray"}>
               Transaction:
             </Text>{" "}
             <Text size={"1"}>
               <Link href={txUrl} target={"_blank"}>
-                {shortenText(depositNearResult.value.txHash)}
+                {shortenText(depositResult.value.txHash)}
               </Link>
             </Text>
           </Box>

--- a/src/features/deposit/components/Deposits/index.tsx
+++ b/src/features/deposit/components/Deposits/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Link, Text } from "@radix-ui/themes"
 import { AssetComboIcon } from "src/components/Asset/AssetComboIcon"
 import type { SupportedChainName } from "src/types"
+import { assert } from "src/utils/assert"
 import { chainTxExplorer } from "src/utils/chainTxExplorer"
 import { formatTokenValue } from "src/utils/format"
 import type { Context } from "../../../machines/depositUIMachine"
@@ -15,10 +16,13 @@ export const Deposits = ({
   if (depositResult?.tag !== "ok") {
     return null
   }
-  const txUrl =
-    chainName != null && depositResult.value.txHash != null
-      ? chainTxExplorer(chainName) + depositResult.value.txHash
-      : null
+  const explorerUrl = chainName != null && chainTxExplorer(chainName)
+  const txHash = depositResult.value.txHash
+
+  assert(txHash != null, "txHash should not be null")
+  assert(explorerUrl != null, "explorerUrl should not be null")
+
+  const txUrl = explorerUrl + txHash
 
   return (
     <Flex p={"2"} gap={"3"}>

--- a/src/features/machines/depositTurboMachine.ts
+++ b/src/features/machines/depositTurboMachine.ts
@@ -1,0 +1,238 @@
+import { assign, emit, fromPromise, setup } from "xstate"
+import type { SwappableToken } from "../../types"
+
+export type DepositDescription = {
+  type: "depositTurbo"
+  userAddressId: string
+  amount: bigint
+  asset: SwappableToken
+}
+
+export type Context = {
+  balance: bigint
+  amount: bigint
+  asset: SwappableToken
+  accountId: string
+  tokenAddress: string
+  txHash: string | null
+  depositAddress: string
+  error: null | {
+    tag: "err"
+    value: {
+      reason: "ERR_SUBMITTING_TRANSACTION" | "ERR_VERIFYING_TRANSACTION"
+      error: Error | null
+    }
+  }
+}
+
+type Input = {
+  balance: bigint
+  amount: bigint
+  asset: SwappableToken
+  accountId: string
+  tokenAddress: string
+  depositAddress: string
+}
+
+export type Output =
+  | NonNullable<Context["error"]>
+  | {
+      tag: "ok"
+      value: {
+        txHash: string
+        depositDescription: DepositDescription
+      }
+    }
+
+export const depositTurboMachine = setup({
+  types: {} as {
+    context: Context
+    input: Input
+    output: Output
+  },
+  actors: {
+    signAndSendTransactions: fromPromise(
+      async ({ input }: { input: Input }): Promise<string> => {
+        throw new Error("not implemented")
+      }
+    ),
+    validateTransaction: fromPromise(
+      async ({
+        input,
+      }: {
+        input: { txHash: string; accountId: string; amount: bigint }
+      }): Promise<boolean> => {
+        // TODO: implement
+        return true
+      }
+    ),
+  },
+  actions: {
+    setError: assign({
+      error: (_, error: NonNullable<Context["error"]>["value"]) => ({
+        tag: "err" as const,
+        value: error,
+      }),
+    }),
+    logError: (_, params: { error: unknown }) => {
+      console.error(params.error)
+    },
+    emitSuccessfulDeposit: emit(({ context }) => ({
+      type: "SUCCESSFUL_DEPOSIT",
+      data: context.txHash,
+    })),
+    emitFailedDeposit: emit(({ context }) => ({
+      type: "FAILED_DEPOSIT",
+      error: context.error,
+    })),
+  },
+  guards: {
+    isDepositValid: () => {
+      throw new Error("not implemented")
+    },
+  },
+}).createMachine({
+  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBcC0YAbgLYB02UAdlpVAMQTqVik2HoDWLKG2+RZCtVoI26AMYBDHFiYBtAAwBdRUsSheuWZXUgAHogDMhgBykALIYBshgIwB2BeYUL75gEzmANCACeRp1ITd1t3BU8TAE4beysAXzifHkxcAhJyLCoaejAAJ1z0XNJUABtpADNCsmS+NMFM4ShRSnYpGXllVV1Ndp0kfSNDSNJbJ3cTAFZ7SJc3ax9-BFNhyMMPcwnIh1HzVYSktBT+dMI8rHLfbIYmFjEuUhrUgVJT3PPLkTE27VUu-p7tLoDAhIhMrKQXJEoiYTEMNpMFkZ3PZSNN7LFdlEYvFEiBHscyK93lc8gUiqUKlUHodas8iRdss1WtIfp1lN0joD+sDQRMggoJrZImFPOZ0YillZzCNhVZkeZRvY1pF9niaU90gAjAqSCBSWAyWh0P4aTlMIGIWxWey2UgTCYeWz2qxYwzuCVulFojFQ6KGWIJXGUdAoeD9fF1Dl8LmgYF4cwmCUhFFu0IKOUO5Ho1UR55CbJRrTm7mIBQe6w59UEl5nBm0Qu9C0IKwTdykGyRcyWaLjJxWcs4g49OqkbXoXX6w1QBsxgYIWxrMwt9zWcYeG2GCYe2xmLZbKJbVzKyvD54AOXQOAABAAxdAAV0oECvhSvAEkWpISlgIDPi7HEE7FYdzFT0u3FPxEAmcJUQdZxhShdxVlsE8jhHABhdBiFKMAcEgP8+gA+cTBcCFbC7MIoXRYxDA9dw+ScdEpV9bFUNpdIAEFNUKPDf3+M1CLnTc2ydaDrScWZLH7SCEHtNtrFCKZbFEyx7EDOIgA */
+  id: "deposit-turbo",
+
+  initial: "signing",
+
+  output: ({ context }): Output => {
+    if (context.txHash != null) {
+      return {
+        tag: "ok",
+        value: {
+          txHash: context.txHash,
+          depositDescription: {
+            type: "depositTurbo",
+            userAddressId: context.accountId,
+            amount: context.amount,
+            asset: context.asset,
+          },
+        },
+      }
+    }
+
+    if (context.error != null) {
+      return context.error
+    }
+
+    throw new Error("Unexpected output")
+  },
+
+  context: ({ input }) => {
+    return {
+      balance: input.balance,
+      amount: input.amount,
+      asset: input.asset,
+      accountId: input.accountId,
+      tokenAddress: input.tokenAddress,
+      depositAddress: input.depositAddress,
+      txHash: null,
+      error: null,
+    }
+  },
+
+  states: {
+    signing: {
+      invoke: {
+        id: "deposit-turbo.signing:invocation[0]",
+
+        input: ({ context }) => {
+          return {
+            balance: context.balance,
+            amount: context.amount,
+            accountId: context.accountId,
+            asset: context.asset,
+            tokenAddress: context.tokenAddress,
+            depositAddress: context.depositAddress,
+          }
+        },
+        onDone: {
+          target: "verifying",
+          actions: assign({
+            txHash: ({ event }) => event.output,
+          }),
+        },
+        onError: {
+          target: "Aborted",
+          actions: [
+            {
+              type: "logError",
+              params: ({ event }) => event,
+            },
+            {
+              type: "setError",
+              params: ({ event }) => {
+                console.log("onError type: setError", event)
+                return {
+                  reason: "ERR_SUBMITTING_TRANSACTION",
+                  error: toError(event.error),
+                }
+              },
+            },
+          ],
+        },
+        src: "signAndSendTransactions",
+      },
+    },
+
+    verifying: {
+      invoke: {
+        id: "deposit-turbo.verifying:invocation[0]",
+        input: ({ context }) => ({
+          txHash: context.txHash || "",
+          accountId: context.accountId || "",
+          amount: context.amount || 0n,
+        }),
+        onDone: {
+          target: "broadcasting",
+          guard: {
+            type: "isDepositValid",
+          },
+        },
+        onError: {
+          target: "Not Found or Invalid",
+          actions: {
+            type: "setError",
+            params: ({ event }) => ({
+              reason: "ERR_VERIFYING_TRANSACTION",
+              error: null,
+            }),
+          },
+        },
+        src: "validateTransaction",
+      },
+    },
+
+    broadcasting: {
+      entry: {
+        type: "emitSuccessfulDeposit",
+      },
+
+      description:
+        "Configure the payload for ft_transfer_call,\n\nwhich triggers the Turbo wallet and\n\nbroadcasts the transaction",
+
+      always: {
+        target: "Completed",
+      },
+    },
+
+    "Not Found or Invalid": {
+      type: "final",
+    },
+
+    Completed: {
+      type: "final",
+    },
+
+    Aborted: {
+      type: "final",
+      entry: ["emitFailedDeposit"],
+    },
+  },
+})
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error("unknown error")
+}

--- a/src/features/machines/depositUIMachine.ts
+++ b/src/features/machines/depositUIMachine.ts
@@ -246,34 +246,20 @@ export const depositUIMachine = setup({
       return !!context.userAddress
     },
     isDepositNearRelevant: ({ context }) => {
-      return (
-        context.balance + context.nativeBalance >=
-          context.parsedFormValues.amount &&
-        context.formValues.network === BlockchainEnum.NEAR
-      )
+      return context.formValues.network === BlockchainEnum.NEAR
     },
     isDepositEVMRelevant: ({ context }) => {
       return (
-        context.balance + context.nativeBalance >=
-          context.parsedFormValues.amount &&
-        (context.formValues.network === BlockchainEnum.ETHEREUM ||
-          context.formValues.network === BlockchainEnum.BASE ||
-          context.formValues.network === BlockchainEnum.ARBITRUM)
+        context.formValues.network === BlockchainEnum.ETHEREUM ||
+        context.formValues.network === BlockchainEnum.BASE ||
+        context.formValues.network === BlockchainEnum.ARBITRUM
       )
     },
     isDepositSolanaRelevant: ({ context }) => {
-      return (
-        context.balance + context.nativeBalance >=
-          context.parsedFormValues.amount &&
-        context.formValues.network === BlockchainEnum.SOLANA
-      )
+      return context.formValues.network === BlockchainEnum.SOLANA
     },
     isDepositTurbochainRelevant: ({ context }) => {
-      return (
-        context.balance + context.nativeBalance >=
-          context.parsedFormValues.amount &&
-        context.formValues.network === BlockchainEnum.TURBOCHAIN
-      )
+      return context.formValues.network === BlockchainEnum.TURBOCHAIN
     },
     isBalanceSufficientForEstimate: ({ context }) => {
       if (context.formValues.token == null) {

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -141,6 +141,30 @@ export function createDepositEVMERC20Transaction(
   }
 }
 
+export function createDepositSiloToSiloTransaction(
+  assetAccountId: string,
+  userAddress: string,
+  amount: bigint,
+  depositAddress: string,
+  siloAddress: string
+): { to: Address; data: Hash } {
+  // TODO check chain type for userAddress as a rule, pass through the user chainType
+  const data = encodeFunctionData({
+    abi: siloAbi,
+    functionName: "safeFtTransferCallToNear",
+    args: [
+      assetAccountId as Address,
+      amount,
+      depositAddress,
+      userAddressToDefuseUserId(userAddress, ChainType.EVM),
+    ],
+  })
+  return {
+    to: siloAddress as Address,
+    data,
+  }
+}
+
 export function createDepositEVMNativeTransaction(
   generatedAddress: string,
   amount: bigint
@@ -362,3 +386,34 @@ export function getWalletRpcUrl(network: BlockchainEnum): string {
       throw new Error("exhaustive check failed")
   }
 }
+
+const siloAbi = [
+  {
+    inputs: [
+      {
+        internalType: "contract IEvmErc20",
+        name: "token",
+        type: "address",
+      },
+      {
+        internalType: "uint128",
+        name: "amount",
+        type: "uint128",
+      },
+      {
+        internalType: "string",
+        name: "receiverId",
+        type: "string",
+      },
+      {
+        internalType: "string",
+        name: "message",
+        type: "string",
+      },
+    ],
+    name: "safeFtTransferCallToNear",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+]

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -4,7 +4,14 @@ import {
   SystemProgram,
   Transaction as TransactionSolana,
 } from "@solana/web3.js"
-import { type Address, type Hash, encodeFunctionData, erc20Abi } from "viem"
+import { assert } from "src/utils/assert"
+import {
+  type Address,
+  type Hash,
+  encodeFunctionData,
+  erc20Abi,
+  getAddress,
+} from "viem"
 import { settings } from "../config/settings"
 import {
   getNearNep141MinStorageBalance,
@@ -140,19 +147,21 @@ export function createDepositEVMERC20Transaction(
   }
 }
 
-export function createDepositSiloToSiloTransaction(
-  assetAccountId: string,
+export function createDepositFromSiloTransaction(
+  tokenAddress: string,
   userAddress: string,
   amount: bigint,
   depositAddress: string,
-  siloAddress: string
+  siloAddress: string,
+  chainType: ChainType
 ): { to: Address; data: Hash } {
-  // TODO check chain type for userAddress as a rule, pass through the user chainType
+  assert(chainType === ChainType.EVM, "chainType should be EVM")
+
   const data = encodeFunctionData({
-    abi: siloAbi,
+    abi: siloToSiloABI,
     functionName: "safeFtTransferCallToNear",
     args: [
-      assetAccountId as Address,
+      getAddress(tokenAddress),
       amount,
       depositAddress,
       userAddressToDefuseUserId(userAddress, ChainType.EVM),
@@ -390,7 +399,7 @@ export function getWalletRpcUrl(network: BlockchainEnum): string {
   }
 }
 
-const siloAbi = [
+const siloToSiloABI = [
   {
     inputs: [
       {

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -14,8 +14,7 @@ import { getNearTxSuccessValue } from "../features/machines/getTxMachine"
 import { BlockchainEnum } from "../types"
 import { ChainType } from "../types"
 import type { Transaction } from "../types/deposit"
-import type { DefuseUserId } from "../utils/defuse"
-import { estimateSolanaTransferCost } from "./estimateService"
+import { type DefuseUserId, userAddressToDefuseUserId } from "../utils/defuse"
 import { getDepositAddress, getSupportedTokens } from "./poaBridgeClient"
 
 const FT_DEPOSIT_GAS = `30${"0".repeat(12)}` // 30 TGAS
@@ -307,9 +306,13 @@ export function getAvailableDepositRoutes(
     case ChainType.EVM:
       switch (network) {
         case BlockchainEnum.NEAR:
-        case BlockchainEnum.TURBOCHAIN:
           return {
             activeDeposit: false,
+            passiveDeposit: false,
+          }
+        case BlockchainEnum.TURBOCHAIN:
+          return {
+            activeDeposit: true,
             passiveDeposit: false,
           }
         case BlockchainEnum.ETHEREUM:

--- a/src/types/deposit.ts
+++ b/src/types/deposit.ts
@@ -20,6 +20,7 @@ export type DepositWidgetProps = UserInfo & {
   sendTransactionNear: (tx: Transaction["NEAR"][]) => Promise<string | null>
   sendTransactionEVM: (tx: Transaction["EVM"]) => Promise<Hash | null>
   sendTransactionSolana: (tx: Transaction["Solana"]) => Promise<string | null>
+  chainType: ChainType
 }
 
 export type Transaction = {

--- a/src/types/quoting.ts
+++ b/src/types/quoting.ts
@@ -36,4 +36,7 @@ export interface Settings {
   rpcUrls: {
     [key in SupportedChainName]: string
   }
+  silo: {
+    turbochain: string
+  }
 }

--- a/src/types/quoting.ts
+++ b/src/types/quoting.ts
@@ -36,7 +36,4 @@ export interface Settings {
   rpcUrls: {
     [key in SupportedChainName]: string
   }
-  silo: {
-    turbochain: string
-  }
 }

--- a/src/utils/chainTxExplorer.ts
+++ b/src/utils/chainTxExplorer.ts
@@ -1,0 +1,25 @@
+import type { SupportedChainName } from "src/types"
+
+export function chainTxExplorer(blockchain: SupportedChainName): string {
+  switch (blockchain) {
+    case "near":
+      return "https://nearblocks.io/txns/"
+    case "eth":
+      return "https://etherscan.io/tx/"
+    case "base":
+      return "https://basescan.org/tx/"
+    case "arbitrum":
+      return "https://arbiscan.io/tx/"
+    case "turbochain":
+      return "https://explorer.turbo.aurora.dev/tx/"
+    case "bitcoin":
+      return "https://blockchain.info/tx/"
+    case "solana":
+      return "https://solscan.io/tx/"
+    case "dogecoin":
+      return "https://dogechain.info/tx/"
+    default:
+      blockchain satisfies never
+      return ""
+  }
+}

--- a/src/utils/chainTxExplorer.ts
+++ b/src/utils/chainTxExplorer.ts
@@ -1,6 +1,6 @@
 import type { SupportedChainName } from "src/types"
 
-export function chainTxExplorer(blockchain: SupportedChainName): string {
+export function chainTxExplorer(blockchain: SupportedChainName): string | null {
   switch (blockchain) {
     case "near":
       return "https://nearblocks.io/txns/"
@@ -20,6 +20,6 @@ export function chainTxExplorer(blockchain: SupportedChainName): string {
       return "https://dogechain.info/tx/"
     default:
       blockchain satisfies never
-      return ""
+      return null
   }
 }


### PR DESCRIPTION
This update enables users to make direct deposits on Turbochain using EVM wallets such as MetaMask.

For the completion of this PR, the following updates are required:
- Add the `siloToSilo` contract to `silo.turbochain` at settings.

Example:
---
<img width="349" alt="Screenshot 2024-12-05 at 19 26 09" src="https://github.com/user-attachments/assets/0df8b742-1b87-43e4-93dc-0aa7ded1717a">
<img width="503" alt="Screenshot 2024-12-05 at 19 26 32" src="https://github.com/user-attachments/assets/022235de-5406-42a8-b1e8-1bceabe6b95f">

