### PR TITLE
fix: balance block layout shift

### DIFF
--- a/src/components/Block/BlockMultiBalances/index.tsx
+++ b/src/components/Block/BlockMultiBalances/index.tsx
@@ -3,7 +3,6 @@ import { InfoCircledIcon } from "@radix-ui/react-icons"
 import {
   Checkbox,
   Flex,
-  Skeleton,
   Text,
   Tooltip,
   useThemeContext,
@@ -13,7 +12,7 @@ import { formatTokenValue } from "../../../utils/format"
 import styles from "./styles.module.css"
 
 export interface BlockMultiBalancesProps {
-  balance?: bigint
+  balance: bigint
   decimals: number
   withNativeSupport?: boolean
   nativeSupportChecked?: CheckedState
@@ -33,8 +32,7 @@ export const BlockMultiBalances = ({
   disabled,
   className,
 }: BlockMultiBalancesProps) => {
-  const isBalanceBigInt = typeof balance === "bigint"
-  const active = isBalanceBigInt && balance > 0n && !disabled
+  const active = balance > 0n && !disabled
   const { accentColor } = useThemeContext()
 
   return (
@@ -46,24 +44,19 @@ export const BlockMultiBalances = ({
       <Flex asChild align={"center"} gap={"1"}>
         <button type={"button"} onClick={handleClick} disabled={!active}>
           <div className={clsx(styles.icon, active && styles.activeIcon)} />
-          {isBalanceBigInt ? (
-            <Text
-              size={"1"}
-              className={clsx(
-                styles.balanceValue,
-                active ? styles.balanceValueActive : styles.balanceValueInactive
-              )}
-            >
-              {formatTokenValue(balance, decimals, {
-                min: 0.0001,
-                fractionDigits: 4,
-              })}
-            </Text>
-          ) : (
-            <Skeleton className={clsx(styles.balanceValue)}>
-              <Text size={"1"}>0</Text>
-            </Skeleton>
-          )}
+
+          <Text
+            size={"1"}
+            className={clsx(
+              styles.balanceValue,
+              active ? styles.balanceValueActive : styles.balanceValueInactive
+            )}
+          >
+            {formatTokenValue(balance, decimals, {
+              min: 0.0001,
+              fractionDigits: 4,
+            })}
+          </Text>
           {withNativeSupport && (
             <div className={styles.nativeSupport}>
               <Checkbox

--- a/src/components/Block/BlockMultiBalances/index.tsx
+++ b/src/components/Block/BlockMultiBalances/index.tsx
@@ -3,6 +3,7 @@ import { InfoCircledIcon } from "@radix-ui/react-icons"
 import {
   Checkbox,
   Flex,
+  Skeleton,
   Text,
   Tooltip,
   useThemeContext,
@@ -12,7 +13,7 @@ import { formatTokenValue } from "../../../utils/format"
 import styles from "./styles.module.css"
 
 export interface BlockMultiBalancesProps {
-  balance: bigint
+  balance?: bigint
   decimals: number
   withNativeSupport?: boolean
   nativeSupportChecked?: CheckedState
@@ -32,7 +33,8 @@ export const BlockMultiBalances = ({
   disabled,
   className,
 }: BlockMultiBalancesProps) => {
-  const active = balance > 0n && !disabled
+  const isBalanceBigInt = typeof balance === "bigint"
+  const active = isBalanceBigInt && balance > 0n && !disabled
   const { accentColor } = useThemeContext()
 
   return (
@@ -44,18 +46,24 @@ export const BlockMultiBalances = ({
       <Flex asChild align={"center"} gap={"1"}>
         <button type={"button"} onClick={handleClick} disabled={!active}>
           <div className={clsx(styles.icon, active && styles.activeIcon)} />
-          <Text
-            size={"1"}
-            className={clsx(
-              styles.balanceValue,
-              active ? styles.balanceValueActive : styles.balanceValueInactive
-            )}
-          >
-            {formatTokenValue(balance, decimals, {
-              min: 0.0001,
-              fractionDigits: 4,
-            })}
-          </Text>
+          {isBalanceBigInt ? (
+            <Text
+              size={"1"}
+              className={clsx(
+                styles.balanceValue,
+                active ? styles.balanceValueActive : styles.balanceValueInactive
+              )}
+            >
+              {formatTokenValue(balance, decimals, {
+                min: 0.0001,
+                fractionDigits: 4,
+              })}
+            </Text>
+          ) : (
+            <Skeleton className={clsx(styles.balanceValue)}>
+              <Text size={"1"}>0</Text>
+            </Skeleton>
+          )}
           {withNativeSupport && (
             <div className={styles.nativeSupport}>
               <Checkbox

--- a/src/components/Block/BlockMultiBalances/index.tsx
+++ b/src/components/Block/BlockMultiBalances/index.tsx
@@ -44,7 +44,6 @@ export const BlockMultiBalances = ({
       <Flex asChild align={"center"} gap={"1"}>
         <button type={"button"} onClick={handleClick} disabled={!active}>
           <div className={clsx(styles.icon, active && styles.activeIcon)} />
-
           <Text
             size={"1"}
             className={clsx(

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -151,17 +151,19 @@ export const FieldComboInput = <T extends FieldValues>({
         </span>
       ) : null}
 
-      <BlockMultiBalances
-        balance={balance}
-        decimals={selected?.decimals ?? 0}
-        withNativeSupport={withNativeSupport ?? false}
-        handleIncludeNativeToSwap={
-          handleIncludeNativeToSwap ? handleIncludeNativeToSwap : () => {}
-        }
-        nativeSupportChecked={nativeSupportChecked ?? false}
-        handleClick={handleSetMaxValue}
-        disabled={disabled}
-      />
+      {balance != null && (
+        <BlockMultiBalances
+          balance={balance}
+          decimals={selected?.decimals ?? 0}
+          withNativeSupport={withNativeSupport ?? false}
+          handleIncludeNativeToSwap={
+            handleIncludeNativeToSwap ? handleIncludeNativeToSwap : () => {}
+          }
+          nativeSupportChecked={nativeSupportChecked ?? false}
+          handleClick={handleSetMaxValue}
+          disabled={disabled}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -150,7 +150,6 @@ export const FieldComboInput = <T extends FieldValues>({
           {label && label}
         </span>
       ) : null}
-
       {balance != null && (
         <BlockMultiBalances
           balance={balance}

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -108,9 +108,7 @@ export const FieldComboInput = <T extends FieldValues>({
   return (
     <div
       className={clsx(
-        "relative flex flex-col px-5 py-[2.375rem] w-full bg-gray-50 dark:bg-black-900 dark:border-black-950",
-        !label && "pt-5",
-        !price && balance == null && errors && !errors[fieldName] && "pb-5",
+        "relative flex flex-col px-5 pt-5 pb-10 w-full bg-gray-50 dark:bg-black-900 dark:border-black-950",
         className
       )}
     >
@@ -152,19 +150,18 @@ export const FieldComboInput = <T extends FieldValues>({
           {label && label}
         </span>
       ) : null}
-      {balance != null && (
-        <BlockMultiBalances
-          balance={balance}
-          decimals={selected?.decimals ?? 0}
-          withNativeSupport={withNativeSupport ?? false}
-          handleIncludeNativeToSwap={
-            handleIncludeNativeToSwap ? handleIncludeNativeToSwap : () => {}
-          }
-          nativeSupportChecked={nativeSupportChecked ?? false}
-          handleClick={handleSetMaxValue}
-          disabled={disabled}
-        />
-      )}
+
+      <BlockMultiBalances
+        balance={balance || 0n}
+        decimals={selected?.decimals ?? 0}
+        withNativeSupport={withNativeSupport ?? false}
+        handleIncludeNativeToSwap={
+          handleIncludeNativeToSwap ? handleIncludeNativeToSwap : () => {}
+        }
+        nativeSupportChecked={nativeSupportChecked ?? false}
+        handleClick={handleSetMaxValue}
+        disabled={disabled}
+      />
     </div>
   )
 }

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -152,7 +152,7 @@ export const FieldComboInput = <T extends FieldValues>({
       ) : null}
 
       <BlockMultiBalances
-        balance={balance || 0n}
+        balance={balance}
         decimals={selected?.decimals ?? 0}
         withNativeSupport={withNativeSupport ?? false}
         handleIncludeNativeToSwap={


### PR DESCRIPTION
Set a default padding for the Input and remove layout shif

Before
https://github.com/user-attachments/assets/cf72487d-690f-4403-a156-fbbb960cfedd


After
https://github.com/user-attachments/assets/eb041030-688b-478d-95b8-d4959d11d07c


I also think this stuff on screenshot is legacy
<img width="422" alt="Screenshot 2024-12-09 at 16 43 12" src="https://github.com/user-attachments/assets/826e5235-1a4e-4904-8d30-c1668ecf31c2">
<img width="1190" alt="Screenshot 2024-12-09 at 16 45 35" src="https://github.com/user-attachments/assets/9c3bbb88-a97f-466d-b182-211f256a858e">


