### PR TITLE
feat: publish intent retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "uuid": "^10.0.0",
     "viem": "^2.18.1",
     "xstate": "^5.18.2",
-    "zustand": "^5.0.0-rc.2"
+    "zustand": "^5.0.0-rc.2",
+    "@lifeomic/attempt" : "3.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "husky && ./scripts/gen-defuse-types.sh"
   },
   "dependencies": {
+    "@lifeomic/attempt": "^3.1.0",
     "@noble/curves": "1.4.0",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "1.1.1",
@@ -52,8 +53,7 @@
     "uuid": "^10.0.0",
     "viem": "^2.18.1",
     "xstate": "^5.18.2",
-    "zustand": "^5.0.0-rc.2",
-    "@lifeomic/attempt" : "3.1.0"
+    "zustand": "^5.0.0-rc.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",

--- a/src/services/intentService.ts
+++ b/src/services/intentService.ts
@@ -1,3 +1,4 @@
+import { retry } from "@lifeomic/attempt"
 import type { ChainType, WalletSignatureResult } from "../types"
 import { prepareSwapSignedData } from "../utils/prepareBroadcastRequest"
 import * as solverRelayClient from "./solverRelayHttpClient"
@@ -16,15 +17,26 @@ export async function publishIntent(
   userInfo: { userAddress: string; userChainType: ChainType },
   quoteHashes: string[]
 ): Promise<PublishIntentResult> {
-  // todo: retry on network error
-  const result = await solverRelayClient.publishIntent({
-    signed_data: prepareSwapSignedData(signatureData, userInfo),
-    quote_hashes: quoteHashes,
-  })
-
-  if (result.status === "OK") return { tag: "ok", value: result.intent_hash }
-
-  return { tag: "err", value: { reason: result.status } }
+  return retry<PublishIntentResult>(
+    async () => {
+      const result = await solverRelayClient.publishIntent({
+        signed_data: prepareSwapSignedData(signatureData, userInfo),
+        quote_hashes: quoteHashes,
+      })
+      if (result.status === "OK")
+        return { tag: "ok", value: result.intent_hash }
+      if (result.status === "FAILED" && result.reason === "already processed")
+        return { tag: "ok", value: result.intent_hash }
+      return { tag: "err", value: { reason: result.status } }
+    },
+    {
+      delay: 1000,
+      factor: 1.5,
+      maxAttempts: 7,
+      jitter: true,
+      minDelay: 1000,
+    }
+  )
 }
 
 export type IntentSettlementResult = Awaited<

--- a/src/services/intentService.ts
+++ b/src/services/intentService.ts
@@ -18,7 +18,7 @@ export async function publishIntent(
   quoteHashes: string[]
 ): Promise<PublishIntentResult> {
   const result = await retry<types.PublishIntentResponse["result"]>(
-    () =>
+    async () =>
       solverRelayClient.publishIntent({
         signed_data: prepareSwapSignedData(signatureData, userInfo),
         quote_hashes: quoteHashes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,6 +497,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lifeomic/attempt@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.1.0.tgz#7fc703559177b81a008b9d263e3d9a001d11d08a"
+  integrity sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==
+
 "@near-wallet-selector/core@^7.0.0":
   version "7.9.3"
   resolved "https://registry.yarnpkg.com/@near-wallet-selector/core/-/core-7.9.3.tgz#5a51b72064c9e018c0f0eb97db06b70cd58b8358"

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,7 +497,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lifeomic/attempt@3.1.0":
+"@lifeomic/attempt@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.1.0.tgz#7fc703559177b81a008b9d263e3d9a001d11d08a"
   integrity sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw==


### PR DESCRIPTION
Adding retires for intent publishing.

This library is used - https://github.com/lifeomic/attempt
It has 0 deps

Some context for params usage - https://encore.dev/blog/retries


Some example of timing I get for retries


<img width="519" alt="Screenshot 2024-12-12 at 18 39 08" src="https://github.com/user-attachments/assets/1c959450-1988-4817-9594-4f0e547f7edf" />


a small code sample to try it locally

```
import { retry } from "@lifeomic/attempt"

let counter = 0
async function main() {
  await retry(
    async () => {
      const a = new Date()
      console.log(
        counter,
        `${a.getHours()}:${a.getMinutes()}:${a.getSeconds()}:${a.getMilliseconds()}`
      )

      if (counter > 123) {
        return
      }
      counter++
      throw new Error()
    },
    {
      delay: 1000,
      factor: 1.5,
      maxAttempts: 7,
      jitter: true,
      minDelay: 1000,
    }
  )
}

main()
```

