### PR TITLE
fix: double vertical scroll on select assets

### DIFF
--- a/src/components/Modal/ModalDialog/styles.module.css
+++ b/src/components/Modal/ModalDialog/styles.module.css
@@ -29,9 +29,10 @@
     top: auto;
     max-width: 100%;
     width: 100%;
-    max-height: 80vh;
+    max-height: 70vh;
     transform: none;
     border-radius: 16px 16px 0 0;
+    padding: 0 25px;
     animation: mobileContentShow 300ms cubic-bezier(0.16, 1, 0.3, 1);
   }
 }

--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -118,15 +118,15 @@ export const ModalSelectAssets = () => {
 
   return (
     <ModalDialog>
-      <div className="flex flex-col min-h-[680px] max-h-[680px] h-full">
-        <div className="flex-none p-5 border-b border-gray-100 dark:border-black-950">
+      <div className="flex flex-col min-h-[680px] md:max-h-[680px] h-full">
+        <div className="z-20 h-auto flex-none p-5 border-b border-gray-100 dark:border-black-950 sticky top-0 bg-white dark:bg-black-800 z-10">
           <SearchBar
             query={searchValue}
             setQuery={setSearchValue}
             handleOverrideCancel={onCloseModal}
           />
         </div>
-        <div className="flex-1 flex flex-col justify-between border-b border-gray-100 px-2.5 overflow-y-auto dark:border-black-950">
+        <div className="z-10 flex-1 overflow-y-auto border-b border-gray-100 px-2.5 dark:border-black-950">
           {assetList.length ? (
             <AssetList
               assets={


### PR DESCRIPTION
<details>
<summary>Example:</summary>
Before:
<img width="407" alt="Screenshot 2024-12-12 at 23 06 42" src="https://github.com/user-attachments/assets/21c4419a-b635-45b8-b645-8a3012ce9e0b" />

After:
![IMG_2271](https://github.com/user-attachments/assets/2a8f6332-ac7a-455d-82da-197280a71bcc)
</details>