### PR TITLE
chore: change eth rpc url

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -29,7 +29,7 @@ export let settings: Settings = {
    */
   rpcUrls: {
     near: "https://nearrpc.aurora.dev",
-    eth: "https://cloudflare-eth.com",
+    eth: "https://eth.drpc.org",
     base: "https://mainnet.base.org",
     arbitrum: "https://arb1.arbitrum.io/rpc",
     bitcoin: "https://mainnet.bitcoin.org",


### PR DESCRIPTION
The reason for switching to another is that this RPS is unstable, 
Score | Privacy are negative at Chainlist:
<img width="1013" alt="Screenshot 2024-12-14 at 01 47 31" src="https://github.com/user-attachments/assets/fdd6cf19-7546-46c3-8e36-1eb27a0d14be" />
