### PR TITLE
fix: add warning if fetch balance is failed

### DIFF
--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -411,6 +411,7 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
             depositSolanaResult,
             depositTurboResult,
             generatedAddressResult,
+            snapshot: snapshot.context,
           })}
         {network !== BlockchainEnum.NEAR && isDepositReceived && (
           <DepositSuccess />
@@ -577,6 +578,7 @@ function renderDepositWarning(
     depositSolanaResult: Context["depositSolanaResult"]
     depositTurboResult: Context["depositTurboResult"]
     generatedAddressResult: Context["generatedAddressResult"]
+    snapshot: Context
   }
 ) {
   let content: ReactNode = null
@@ -591,6 +593,7 @@ function renderDepositWarning(
     depositResults.depositSolanaResult,
     depositResults.depositTurboResult,
     depositResults.generatedAddressResult,
+    depositResults.snapshot.error,
   ]
 
   const errorResult = results.find(
@@ -612,6 +615,9 @@ function renderDepositWarning(
       case "ERR_GENERATING_ADDRESS":
         content =
           "It seems the deposit address was not generated. Please try re-selecting the token and network."
+        break
+      case "ERR_GET_BALANCE":
+        content = "It seems the balance is not available. Please try again."
         break
       default:
         content = "An error occurred. Please try again."


### PR DESCRIPTION
If `backgroundBalanceActor` crashes due to PRC then show an error message to the user.

<details>
<summary>Example:</summary>
<img width="579" alt="Screenshot 2024-12-14 at 03 06 19" src="https://github.com/user-attachments/assets/c196d634-3103-4530-b8eb-984400e5d7cd" />
</details>
