### PR TITLE
feat: track No liquidity event

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
       "import": "./dist/index.esm.js",
       "types": "./dist/index.d.ts"
     },
+    "./logger": {
+      "import": "./dist/logger.esm.js",
+      "types": "./dist/logger.d.ts"
+    },
     "./styles.css": "./dist/index.css"
   },
   "module": "./dist/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,12 +9,13 @@ import packageJson from "./package.json" assert { type: "json" }
 
 const config = [
   {
-    input: "src/index.ts",
+    input: ["src/index.ts", "src/logger.ts"],
     output: [
       {
-        file: "dist/index.esm.js",
+        dir: "dist",
         format: "es",
         sourcemap: true,
+        entryFileNames: "[name].esm.js",
       },
     ],
     plugins: [
@@ -40,6 +41,11 @@ const config = [
   {
     input: "src/index.ts",
     output: [{ file: "dist/index.d.ts", format: "es" }],
+    plugins: [dts()],
+  },
+  {
+    input: "src/logger.ts",
+    output: [{ file: "dist/logger.d.ts", format: "es" }],
     plugins: [dts()],
   },
   {

--- a/src/features/machines/backgroundQuoterMachine.ts
+++ b/src/features/machines/backgroundQuoterMachine.ts
@@ -67,15 +67,6 @@ export const backgroundQuoterMachine = fromCallback<
       case "NEW_QUOTE_INPUT": {
         const quoteInput = event.params
 
-        // todo: `NEW_QUOTE_INPUT` should not be emitted for 0 amounts, this is temporary fix
-        if (
-          quoteInput.amountIn === 0n ||
-          ("tokensIn" in quoteInput && !quoteInput.tokensIn.length)
-        ) {
-          console.warn("Ignoring quote input with empty input")
-          return
-        }
-
         pollQuote(
           abortController.signal,
           quoteInput,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,35 @@
+/**
+ * This should be a separate file, so SDK logging could be set up without loading all other modules
+ */
+
+export type Context = Record<string, unknown>
+export type Contexts = Record<string, Context | undefined>
+
+export interface ILogger {
+  /**
+   * Use verbose for detailed execution flow tracking
+   * Example: verbose('Preparing transaction', { amount: 100 })
+   */
+  verbose: (message: string, data?: Record<string, unknown>) => void
+
+  /**
+   * Use info for significant operations
+   * Example: info('Transaction sent successfully')
+   */
+  info: (message: string, context?: Contexts) => void
+  warn: (message: string, context?: Contexts) => void
+  error: (message: string | Error | unknown, context?: Contexts) => void
+}
+
+const noopLogger: ILogger = {
+  verbose: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+export let logger: ILogger = { ...noopLogger }
+
+export function setLogger(newLogger: ILogger) {
+  logger = newLogger
+}

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -1,4 +1,5 @@
 import { settings } from "../config/settings"
+import { logger } from "../logger"
 import type { BaseTokenInfo } from "../types"
 import { computeTotalBalance } from "../utils/tokenUtils"
 import { quote } from "./solverRelayHttpClient"
@@ -55,7 +56,7 @@ export async function queryQuote(
 
   // If total available is less than requested, just quote the full amount from one token
   if (totalAvailableIn == null || totalAvailableIn < input.amountIn) {
-    const q = await quote(
+    const q = await quoteWithLog(
       {
         defuse_asset_identifier_in: tokenIn,
         defuse_asset_identifier_out: tokenOut,
@@ -98,7 +99,7 @@ export async function queryQuoteExactOut(
   },
   { signal }: { signal?: AbortSignal } = {}
 ): Promise<AggregatedQuote> {
-  const quotes = await quote(
+  const quotes = await quoteWithLog(
     {
       defuse_asset_identifier_in: input.tokenIn,
       defuse_asset_identifier_out: input.tokenOut,
@@ -240,7 +241,7 @@ export async function fetchQuotesForTokens(
 ): Promise<null | NonNullable<QuoteResults>[]> {
   const quotes = await Promise.all(
     Object.entries(amountsToQuote).map(async ([tokenIn, amountIn]) => {
-      return quote(
+      return quoteWithLog(
         {
           defuse_asset_identifier_in: tokenIn,
           defuse_asset_identifier_out: tokenOut,
@@ -263,3 +264,11 @@ function ensureAllNonNull<T>(array: (T | null)[]): T[] | null {
   const filtered = array.filter((x): x is T => x !== null)
   return filtered.length === array.length ? filtered : null
 }
+
+const quoteWithLog = (async (params, config) => {
+  const result = await quote(params, config)
+  if (result == null) {
+    logger.warn("No liquidity", { quoteParams: params })
+  }
+  return result
+}) satisfies typeof quote


### PR DESCRIPTION
PR introduces `logger` which is global configurable object. Logger lives in a separate file and treated as an entry point. It's need for better tree-shaking, so user who want to configure it don't end up loading entire library:
```js
function someGlobalInitFn() {
   const {setLogger} = await import("@defuse-protocol/defuse-sdk/logger")
   setLogger(...)
}
```

Logger has conventional method like error, info, etc. Also it has verbose, which will be used as a breadcrumb for an event. In follow up PR I will update all usage of console.log in the code.