### PR TITLE
feat: change NEAR balance padding from 1 to 0.1

### DIFF
--- a/src/features/machines/getBalanceMachine.ts
+++ b/src/features/machines/getBalanceMachine.ts
@@ -13,7 +13,7 @@ import type { BaseTokenInfo, UnifiedTokenInfo } from "../../types/base"
 import { Semaphore } from "../../utils/semaphore"
 import { isBaseToken, isUnifiedToken } from "../../utils/token"
 
-export const RESERVED_NEAR_BALANCE = 1n * 10n ** 24n // 1 NEAR reserved for transaction fees and storage, using yoctoNEAR precision
+export const RESERVED_NEAR_BALANCE = 100000000000000000000000n // 0.1 NEAR reserved for transaction fees and storage
 const semaphore = new Semaphore(5, 500) // 5 concurrent request, 0.5 second delay (adjust maxConcurrent and delayMs as needed)
 
 export const getNearNativeBalance = async ({


### PR DESCRIPTION
Current padding is 1 NEAR which a lot for users with small balance. MNW has a padding of 0.07 but I decided to be more cautious and set it to 0.1 in case other wallets are more strict.