### PR TITLE
feat: add usd prices to token fields

### DIFF
--- a/src/components/Block/BlockMultiBalances/index.tsx
+++ b/src/components/Block/BlockMultiBalances/index.tsx
@@ -18,13 +18,8 @@ export const BlockMultiBalances = ({
   className,
 }: BlockMultiBalancesProps) => {
   const active = balance > 0n && !disabled
-
   return (
-    <Flex
-      gap="1"
-      asChild
-      className={clsx("absolute bottom-4 right-5", className)}
-    >
+    <Flex gap="1" asChild className={className}>
       <Flex asChild align="center" gap="1">
         <button type="button" onClick={handleClick} disabled={!active}>
           <div

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -102,7 +102,7 @@ export const FieldComboInput = <T extends FieldValues>({
   return (
     <div
       className={clsx(
-        "relative flex flex-col px-5 pt-5 pb-10 w-full bg-gray-50 dark:bg-black-900 dark:border-black-950",
+        "relative flex flex-col px-5 pt-5 pb-6 w-full bg-gray-50 dark:bg-black-900 dark:border-black-950",
         className
       )}
     >
@@ -119,7 +119,7 @@ export const FieldComboInput = <T extends FieldValues>({
           disabled={disabled}
           autoComplete="off"
           className={clsx(
-            "bg-gray-50 w-full text-3xl font-medium placeholder-black border-transparent focus:border-transparent focus:ring-0 dark:bg-black-900 dark:placeholder-white",
+            "bg-gray-50 w-full text-3xl font-medium placeholder-black border-transparent focus:border-transparent focus:ring-0 dark:bg-black-900 dark:placeholder-white px-0",
             disabled &&
               "text-black-200 pointer-events-none placeholder-black-200",
             {
@@ -133,23 +133,26 @@ export const FieldComboInput = <T extends FieldValues>({
         )}
       </div>
 
-      {fieldError ? (
-        <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-red-400">
-          {(fieldError as FieldError).message}
-        </span>
-      ) : usdAmount ? (
-        <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-gray-400">
-          {usdAmount}
-        </span>
-      ) : null}
-      {balance != null && (
-        <BlockMultiBalances
-          balance={balance}
-          decimals={selected?.decimals ?? 0}
-          handleClick={handleSetMaxValue}
-          disabled={disabled}
-        />
-      )}
+      <div className="flex justify-between items-center gap-2 mt-1 min-h-5 w-full max-w-[calc(100vw-106px)]">
+        {fieldError ? (
+          <span className="text-xs sm:text-sm font-medium text-red-400  whitespace-nowrap overflow-hidden">
+            {(fieldError as FieldError).message}
+          </span>
+        ) : usdAmount ? (
+          <span className="text-xs sm:text-sm font-medium text-gray-400 whitespace-nowrap overflow-hidden">
+            {usdAmount}
+          </span>
+        ) : null}
+        {balance != null && (
+          <BlockMultiBalances
+            balance={balance}
+            decimals={selected?.decimals ?? 0}
+            handleClick={handleSetMaxValue}
+            disabled={disabled}
+            className="ml-auto"
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -31,6 +31,7 @@ interface Props<T extends FieldValues>
   handleSelect?: () => void
   className?: string
   errors?: FieldErrors
+  usdAmount?: number | null
   disabled?: boolean
   isLoading?: boolean
 }
@@ -49,6 +50,7 @@ export const FieldComboInput = <T extends FieldValues>({
   handleSelect,
   className,
   errors,
+  usdAmount,
   disabled,
   isLoading,
 }: Props<T>) => {
@@ -96,7 +98,7 @@ export const FieldComboInput = <T extends FieldValues>({
   })
 
   const allInputRefs = useMergedRef(inputRef, reactHookFormRegisterProps.ref)
-
+  const fieldError = errors?.[fieldName]
   return (
     <div
       className={clsx(
@@ -131,9 +133,13 @@ export const FieldComboInput = <T extends FieldValues>({
         )}
       </div>
 
-      {errors?.[fieldName] ? (
+      {fieldError ? (
         <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-red-400">
-          {(errors[fieldName] as FieldError).message}
+          {(fieldError as FieldError).message}
+        </span>
+      ) : usdAmount ? (
+        <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-gray-400">
+          ~${usdAmount}
         </span>
       ) : null}
       {balance != null && (

--- a/src/components/Form/FieldComboInput.tsx
+++ b/src/components/Form/FieldComboInput.tsx
@@ -31,7 +31,7 @@ interface Props<T extends FieldValues>
   handleSelect?: () => void
   className?: string
   errors?: FieldErrors
-  usdAmount?: number | null
+  usdAmount?: string | null
   disabled?: boolean
   isLoading?: boolean
 }
@@ -139,7 +139,7 @@ export const FieldComboInput = <T extends FieldValues>({
         </span>
       ) : usdAmount ? (
         <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-gray-400">
-          ~${usdAmount}
+          {usdAmount}
         </span>
       ) : null}
       {balance != null && (

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,18 +1,14 @@
-import { TextField } from "@radix-ui/themes"
 import clsx from "clsx"
-import { type ReactNode, type Ref, forwardRef } from "react"
+import { type InputHTMLAttributes, type Ref, forwardRef } from "react"
 
-interface InputProps extends Omit<TextField.RootProps, "onChange"> {
+interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> {
   name: string
-  placeholder?: string
   value?: string
   fullWidth?: boolean
   disabled?: boolean
   onChange?: (value: string) => void
   className?: string
-  slotLeft?: ReactNode | null
-  slotRight?: ReactNode | null
-  type?: "text" | "number"
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -21,30 +17,22 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       name,
       value = "",
       placeholder,
-      fullWidth = false,
       disabled = false,
       onChange,
       className,
-      slotLeft = null,
-      slotRight = null,
       type = "text",
       ...rest
     }: InputProps,
     ref: Ref<HTMLInputElement>
   ) => {
     return (
-      <TextField.Root
+      <input
         {...rest}
         name={name}
         className={clsx(
-          "relative flex justify-between items-center px-5 py-[2.375rem] w-full text-lg font-base leading-6 text-black max-w-full box-border flex-shrink-0 rounded-lg bg-gray-100/60 bg-clip-border bg-none border border-gray-200/50",
-          "shadow-none outline-none",
-          "dark:bg-gray-900 dark:border-gray-950",
-          "[&>input]:flex-1 [&>input]:text-3xl [&>input]:font-medium [&>input]:bg-transparent [&>input]:border-0 [&>input:focus]:outline-none [&>input:focus]:ring-0",
-          {
-            "w-full": fullWidth,
-            "text-gray-200": disabled,
-          },
+          "bg-transparent w-full text-3xl font-medium placeholder-black border-transparent focus:border-transparent focus:ring-0 dark:bg-black-900 dark:placeholder-white px-0",
+          disabled &&
+            "text-black-200 pointer-events-none placeholder-black-200",
           className
         )}
         value={value}
@@ -53,10 +41,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         disabled={disabled}
         type={type}
         ref={ref}
-      >
-        <TextField.Slot className="p-0">{slotLeft}</TextField.Slot>
-        <TextField.Slot className="p-0">{slotRight}</TextField.Slot>
-      </TextField.Root>
+      />
     )
   }
 )

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -21,6 +21,7 @@ import {
   assetNetworkAdapter,
   reverseAssetNetworkAdapter,
 } from "src/utils/adapters"
+import { formatUsdAmount } from "src/utils/format"
 import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import { AssetComboIcon } from "../../../../components/Asset/AssetComboIcon"
 import { BlockMultiBalances } from "../../../../components/Block/BlockMultiBalances"
@@ -251,9 +252,9 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
               }}
               className="pb-16"
               slotLeft={
-                usdAmountToDeposit !== null ? (
+                usdAmountToDeposit ? (
                   <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-gray-400">
-                    ~${usdAmountToDeposit}
+                    ~{formatUsdAmount(usdAmountToDeposit)}
                   </span>
                 ) : null
               }

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -16,10 +16,12 @@ import { QRCodeSVG } from "qrcode.react"
 import { useEffect, useState } from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 import { Controller, useFormContext } from "react-hook-form"
+import { useTokensUsdPrices } from "src/hooks/useTokensUsdPrices"
 import {
   assetNetworkAdapter,
   reverseAssetNetworkAdapter,
 } from "src/utils/adapters"
+import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import { AssetComboIcon } from "../../../../components/Asset/AssetComboIcon"
 import { BlockMultiBalances } from "../../../../components/Block/BlockMultiBalances"
 import { ButtonCustom } from "../../../../components/Button/ButtonCustom"
@@ -188,7 +190,8 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
   const [isCopied, setIsCopied] = useState(false)
 
   const { accentColor } = useThemeContext()
-
+  const { data: tokensUsdPriceData } = useTokensUsdPrices()
+  const usdAmountToDeposit = getTokenUsdPrice(amount, token, tokensUsdPriceData)
   return (
     <div className="w-full max-w-[472px]">
       <div className="rounded-2xl p-5 bg-white shadow dark:bg-[#111110] dark:shadow-[0_1px_3px_0_rgb(255_255_255_/_0.1),_0_1px_2px_-1px_rgb(255_255_255_/_0.1)]">
@@ -247,6 +250,13 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
                 }
               }}
               className="pb-16"
+              slotLeft={
+                usdAmountToDeposit !== null ? (
+                  <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-gray-400">
+                    ~${usdAmountToDeposit}
+                  </span>
+                ) : null
+              }
               slotRight={
                 <div className="flex items-center gap-2 flex-row absolute right-5 bottom-5">
                   {token &&

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -16,6 +16,9 @@ import { QRCodeSVG } from "qrcode.react"
 import { useEffect, useState } from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 import { Controller, useFormContext } from "react-hook-form"
+import { BlockMultiBalances } from "src/components/Block/BlockMultiBalances"
+import { TooltipInfo } from "src/components/TooltipInfo"
+import { RESERVED_NEAR_BALANCE } from "src/features/machines/getBalanceMachine"
 import { useTokensUsdPrices } from "src/hooks/useTokensUsdPrices"
 import {
   assetNetworkAdapter,
@@ -24,7 +27,6 @@ import {
 import { formatUsdAmount } from "src/utils/format"
 import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import { AssetComboIcon } from "../../../../components/Asset/AssetComboIcon"
-import { BlockMultiBalances } from "../../../../components/Block/BlockMultiBalances"
 import { ButtonCustom } from "../../../../components/Button/ButtonCustom"
 import { EmptyIcon } from "../../../../components/EmptyIcon"
 import { Form } from "../../../../components/Form"
@@ -32,8 +34,6 @@ import { Input } from "../../../../components/Input"
 import type { ModalSelectAssetsPayload } from "../../../../components/Modal/ModalSelectAssets"
 import { NetworkIcon } from "../../../../components/Network/NetworkIcon"
 import { Select } from "../../../../components/Select/Select"
-import { TooltipInfo } from "../../../../components/TooltipInfo"
-import { RESERVED_NEAR_BALANCE } from "../../../../features/machines/getBalanceMachine"
 import { getPOABridgeInfo } from "../../../../features/machines/poaBridgeInfoActor"
 import { useModalStore } from "../../../../providers/ModalStoreProvider"
 import { getAvailableDepositRoutes } from "../../../../services/depositService"
@@ -237,64 +237,58 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
             </div>
           )}
           {isActiveDeposit && (
-            <Input
-              name="amount"
-              value={watch("amount")}
-              onChange={(value) => setValue("amount", value)}
-              type="text"
-              inputMode="decimal"
-              pattern="[0-9]*[.]?[0-9]*"
-              autoComplete="off"
-              ref={(ref) => {
-                if (ref) {
-                  ref.focus()
-                }
-              }}
-              className="pb-16"
-              slotLeft={
-                usdAmountToDeposit ? (
-                  <span className="absolute bottom-4 left-5 text-xs sm:text-sm font-medium text-gray-400">
+            <div className="flex flex-col p-5 w-full bg-gray-50 border border-gray-200/50 dark:bg-gray-900 dark:border-gray-950 rounded-lg">
+              <Input
+                name="amount"
+                value={watch("amount")}
+                onChange={(value) => setValue("amount", value)}
+                inputMode="decimal"
+                type="text"
+                pattern="[0-9]*[.]?[0-9]*"
+                autoComplete="off"
+                ref={(ref) => {
+                  if (ref) {
+                    ref.focus()
+                  }
+                }}
+              />
+              <div className="flex justify-between items-center gap-2 mt-1 min-h-5 w-full max-w-[calc(100vw-106px)]">
+                {usdAmountToDeposit ? (
+                  <span className="text-xs sm:text-sm font-medium text-gray-400 whitespace-nowrap overflow-hidden">
                     ~{formatUsdAmount(usdAmountToDeposit)}
                   </span>
-                ) : null
-              }
-              slotRight={
-                <div className="flex items-center gap-2 flex-row absolute right-5 bottom-5">
-                  {token &&
-                    isBaseToken(token) &&
-                    token.address === "wrap.near" && (
-                      <TooltipInfo
-                        icon={
-                          <Text asChild color={accentColor}>
-                            <InfoCircledIcon />
-                          </Text>
-                        }
-                      >
-                        Combined balance of NEAR and wNEAR.
-                        <br /> NEAR will be automatically wrapped to wNEAR
-                        <br /> if your wNEAR balance isn't sufficient for the
-                        swap.
-                        <br />
-                        Note that to cover network fees, we reserve
-                        {` ${formatTokenValue(
-                          RESERVED_NEAR_BALANCE,
-                          token.decimals
-                        )} NEAR`}
-                        <br /> in your wallet.
-                      </TooltipInfo>
-                    )}
+                ) : null}
+
+                <div className="flex items-center gap-2 ml-auto">
+                  {token?.symbol === "NEAR" && blockchain === "near" && (
+                    <TooltipInfo
+                      icon={
+                        <Text asChild color={accentColor}>
+                          <InfoCircledIcon />
+                        </Text>
+                      }
+                    >
+                      Combined balance of NEAR and wNEAR.
+                      <br /> NEAR will be automatically wrapped to wNEAR
+                      <br /> if your wNEAR balance isn't sufficient for the
+                      swap.
+                      <br />
+                      Note that to cover network fees, we reserve
+                      {` ${formatTokenValue(RESERVED_NEAR_BALANCE, 24)} NEAR`}
+                      <br /> in your wallet.
+                    </TooltipInfo>
+                  )}
                   {balance != null && token != null && (
                     <BlockMultiBalances
                       balance={balance}
                       decimals={token.decimals}
-                      handleClick={() => handleSetMaxValue()}
+                      handleClick={handleSetMaxValue}
                       disabled={balance === 0n}
-                      className="!static flex items-center justify-center"
                     />
                   )}
                 </div>
-              }
-            />
+              </div>
+            </div>
           )}
           {(isActiveDeposit || !network) && (
             <div className="flex flex-col gap-4 mt-4">
@@ -354,35 +348,32 @@ export const DepositForm = ({ chainType }: { chainType?: ChainType }) => {
                   )}
                 </div>
                 {depositAddress && (
-                  <Input
-                    name="generatedAddress"
-                    value={
-                      depositAddress ? truncateUserAddress(depositAddress) : ""
-                    }
-                    disabled
-                    className="min-h-14 py-0 mb-4 [&>input]:text-base"
-                    slotRight={
-                      <Button
-                        type="button"
-                        size="2"
-                        variant="soft"
-                        className="px-3"
-                        disabled={!depositAddress}
+                  <div className="flex p-5 w-full items-center justify-between gap-2 bg-gray-50 border border-gray-200/50 dark:bg-gray-900 dark:border-gray-950 rounded-lg mb-4 max-w-[calc(100vw-60px)]">
+                    {depositAddress ? (
+                      <span className="text-base font-medium text-gray-500 whitespace-nowrap overflow-hidden">
+                        {truncateUserAddress(depositAddress)}
+                      </span>
+                    ) : null}
+                    <Button
+                      type="button"
+                      size="2"
+                      variant="soft"
+                      className="px-3 cursor-copy"
+                      disabled={!depositAddress}
+                    >
+                      <CopyToClipboard
+                        text={depositAddress}
+                        onCopy={() => setIsCopied(true)}
                       >
-                        <CopyToClipboard
-                          text={depositAddress}
-                          onCopy={() => setIsCopied(true)}
-                        >
-                          <Flex gap="2" align="center">
-                            <Text>{isCopied ? "Copied" : "Copy"}</Text>
-                            <Text asChild>
-                              <CopyIcon height="14" width="14" />
-                            </Text>
-                          </Flex>
-                        </CopyToClipboard>
-                      </Button>
-                    }
-                  />
+                        <Flex gap="2" align="center">
+                          <Text>{isCopied ? "Copied" : "Copy"}</Text>
+                          <Text asChild>
+                            <CopyIcon height="14" width="14" />
+                          </Text>
+                        </Flex>
+                      </CopyToClipboard>
+                    </Button>
+                  </div>
                 )}
                 {renderDepositHint(network, minDepositAmount, token)}
               </div>

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -159,7 +159,7 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
   const showDepositButton =
     tokenInBalance != null && tokenInBalance === 0n && onNavigateDeposit != null
 
-  const usdAmountInt = getTokenUsdPrice(
+  const usdAmountIn = getTokenUsdPrice(
     getValues().amountIn,
     tokenIn,
     tokensUsdPriceData
@@ -189,7 +189,7 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
           className="border border-gray-200/50 rounded-t-xl"
           required
           errors={errors}
-          usdAmount={usdAmountInt ? `~${formatUsdAmount(usdAmountInt)}` : ""}
+          usdAmount={usdAmountIn ? `~${formatUsdAmount(usdAmountIn)}` : null}
           balance={tokenInBalance}
         />
 
@@ -207,7 +207,7 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
           errors={errors}
           disabled={true}
           isLoading={snapshot.matches({ editing: "waiting_quote" })}
-          usdAmount={usdAmountOut ? `~${formatUsdAmount(usdAmountOut)}` : ""}
+          usdAmount={usdAmountOut ? `~${formatUsdAmount(usdAmountOut)}` : null}
           balance={tokenOutBalance}
         />
 

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -9,6 +9,8 @@ import {
   useEffect,
 } from "react"
 import { useFormContext } from "react-hook-form"
+import { useTokensUsdPrices } from "src/hooks/useTokensUsdPrices"
+import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import type { ActorRefFrom, SnapshotFrom } from "xstate"
 import { ButtonCustom } from "../../../components/Button/ButtonCustom"
 import { ButtonSwitch } from "../../../components/Button/ButtonSwitch"
@@ -48,6 +50,7 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
   const swapUIActorRef = SwapUIMachineContext.useActorRef()
   const snapshot = SwapUIMachineContext.useSelector((snapshot) => snapshot)
   const intentCreationResult = snapshot.context.intentCreationResult
+  const { data: tokensUsdPriceData } = useTokensUsdPrices()
 
   const { tokenIn, tokenOut, noLiquidity } = SwapUIMachineContext.useSelector(
     (snapshot) => {
@@ -174,6 +177,11 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
           className="border border-gray-200/50 rounded-t-xl"
           required
           errors={errors}
+          usdAmount={getTokenUsdPrice(
+            getValues().amountIn,
+            tokenIn,
+            tokensUsdPriceData
+          )}
           balance={tokenInBalance}
         />
 
@@ -191,6 +199,11 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
           errors={errors}
           disabled={true}
           isLoading={snapshot.matches({ editing: "waiting_quote" })}
+          usdAmount={getTokenUsdPrice(
+            getValues().amountOut,
+            tokenOut,
+            tokensUsdPriceData
+          )}
           balance={tokenOutBalance}
         />
 

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "react"
 import { useFormContext } from "react-hook-form"
 import { useTokensUsdPrices } from "src/hooks/useTokensUsdPrices"
+import { formatUsdAmount } from "src/utils/format"
 import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import type { ActorRefFrom, SnapshotFrom } from "xstate"
 import { ButtonCustom } from "../../../components/Button/ButtonCustom"
@@ -158,6 +159,17 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
   const showDepositButton =
     tokenInBalance != null && tokenInBalance === 0n && onNavigateDeposit != null
 
+  const usdAmountInt = getTokenUsdPrice(
+    getValues().amountIn,
+    tokenIn,
+    tokensUsdPriceData
+  )
+  const usdAmountOut = getTokenUsdPrice(
+    getValues().amountOut,
+    tokenOut,
+    tokensUsdPriceData
+  )
+
   return (
     <Flex
       direction="column"
@@ -177,11 +189,7 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
           className="border border-gray-200/50 rounded-t-xl"
           required
           errors={errors}
-          usdAmount={getTokenUsdPrice(
-            getValues().amountIn,
-            tokenIn,
-            tokensUsdPriceData
-          )}
+          usdAmount={usdAmountInt ? `~${formatUsdAmount(usdAmountInt)}` : ""}
           balance={tokenInBalance}
         />
 
@@ -199,11 +207,7 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
           errors={errors}
           disabled={true}
           isLoading={snapshot.matches({ editing: "waiting_quote" })}
-          usdAmount={getTokenUsdPrice(
-            getValues().amountOut,
-            tokenOut,
-            tokensUsdPriceData
-          )}
+          usdAmount={usdAmountOut ? `~${formatUsdAmount(usdAmountOut)}` : ""}
           balance={tokenOutBalance}
         />
 

--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -338,7 +338,7 @@ export const WithdrawForm = ({
               usdAmount={
                 tokenToWithdrawUsdAmount
                   ? `~${formatUsdAmount(tokenToWithdrawUsdAmount)}`
-                  : ""
+                  : null
               }
             />
 

--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -18,6 +18,7 @@ import { providers } from "near-api-js"
 import { Fragment, type ReactNode, useEffect } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { useTokensUsdPrices } from "src/hooks/useTokensUsdPrices"
+import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import type { ActorRefFrom } from "xstate"
 import { ButtonCustom } from "../../../../components/Button/ButtonCustom"
 import { EmptyIcon } from "../../../../components/EmptyIcon"
@@ -149,6 +150,7 @@ export const WithdrawForm = ({
     watch,
     formState: { errors },
     setValue,
+    getValues,
   } = useForm<WithdrawFormNearValues>({
     mode: "onSubmit",
     reValidateMode: "onChange",
@@ -327,6 +329,11 @@ export const WithdrawForm = ({
               errors={errors}
               balance={tokenInBalance}
               register={register}
+              usdAmount={getTokenUsdPrice(
+                getValues().amountIn,
+                token,
+                tokensUsdPriceData
+              )}
             />
 
             {renderMinWithdrawalAmount(minWithdrawalAmount, tokenOut)}

--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -18,6 +18,7 @@ import { providers } from "near-api-js"
 import { Fragment, type ReactNode, useEffect } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { useTokensUsdPrices } from "src/hooks/useTokensUsdPrices"
+import { formatTokenValue, formatUsdAmount } from "src/utils/format"
 import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import type { ActorRefFrom } from "xstate"
 import { ButtonCustom } from "../../../../components/Button/ButtonCustom"
@@ -38,7 +39,6 @@ import type {
 } from "../../../../types/base"
 import { ChainType } from "../../../../types/deposit"
 import type { WithdrawWidgetProps } from "../../../../types/withdraw"
-import { formatTokenValue } from "../../../../utils/format"
 import { parseUnits } from "../../../../utils/parse"
 import { isBaseToken } from "../../../../utils/token"
 import { validateAddress } from "../../../../utils/validateAddress"
@@ -270,6 +270,12 @@ export const WithdrawForm = ({
     tokenOut.chainName
   )
 
+  const tokenToWithdrawUsdAmount = getTokenUsdPrice(
+    getValues().amountIn,
+    token,
+    tokensUsdPriceData
+  )
+
   return (
     <div className="w-full max-w-[472px]">
       <Flex
@@ -329,11 +335,11 @@ export const WithdrawForm = ({
               errors={errors}
               balance={tokenInBalance}
               register={register}
-              usdAmount={getTokenUsdPrice(
-                getValues().amountIn,
-                token,
-                tokensUsdPriceData
-              )}
+              usdAmount={
+                tokenToWithdrawUsdAmount
+                  ? `~${formatUsdAmount(tokenToWithdrawUsdAmount)}`
+                  : ""
+              }
             />
 
             {renderMinWithdrawalAmount(minWithdrawalAmount, tokenOut)}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -56,3 +56,16 @@ function trimEnd(s: string, char: string) {
 
   return pointer != null ? s.slice(0, pointer) : s
 }
+
+export function formatUsdAmount(value: number): string {
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      // Omit cents for bigger values
+      maximumFractionDigits: value >= 500 ? 0 : 2,
+    }).format(value)
+  } catch {
+    return ""
+  }
+}

--- a/src/utils/getTokenUsdPrice.ts
+++ b/src/utils/getTokenUsdPrice.ts
@@ -8,12 +8,9 @@ const getTokenUsdPrice = (
   tokensUsdPriceData?: TokenUsdPriceData
 ): number | null => {
   try {
-    if (
-      !tokensUsdPriceData ||
-      !token ||
-      !tokenAmount ||
-      Number.isNaN(+tokenAmount)
-    )
+    if (!tokensUsdPriceData || !token || !tokenAmount) return null
+    const numberTokenAmount = +tokenAmount
+    if (Number.isNaN(numberTokenAmount) || !Number.isFinite(numberTokenAmount))
       return null
     let tokenUsdPriceData = null
     if (isBaseToken(token) && tokensUsdPriceData[token.defuseAssetId]) {
@@ -30,7 +27,7 @@ const getTokenUsdPrice = (
       }
     }
     if (!tokenUsdPriceData) return null
-    return Number(tokenAmount) * tokenUsdPriceData.price
+    return numberTokenAmount * tokenUsdPriceData.price
   } catch {
     return null
   }

--- a/src/utils/getTokenUsdPrice.ts
+++ b/src/utils/getTokenUsdPrice.ts
@@ -1,0 +1,34 @@
+import type { TokenUsdPriceData } from "src/hooks/useTokensUsdPrices"
+import type { SwappableToken } from "src/types/swap"
+import { isBaseToken, isUnifiedToken } from "./token"
+
+const getTokenUsdPrice = (
+  tokenAmount: string,
+  token: SwappableToken | null,
+  tokensUsdPriceData?: TokenUsdPriceData
+): number | null => {
+  if (
+    !tokensUsdPriceData ||
+    !token ||
+    !tokenAmount ||
+    Number.isNaN(+tokenAmount)
+  )
+    return null
+  let tokenUsdPriceData = null
+  if (isBaseToken(token) && tokensUsdPriceData[token.defuseAssetId]) {
+    tokenUsdPriceData = tokensUsdPriceData[token.defuseAssetId]
+  } else if (isUnifiedToken(token)) {
+    for (const groupedToken of token.groupedTokens) {
+      if (
+        isBaseToken(groupedToken) &&
+        tokensUsdPriceData[groupedToken.defuseAssetId]
+      ) {
+        tokenUsdPriceData = tokensUsdPriceData[groupedToken.defuseAssetId]
+        break
+      }
+    }
+  }
+  if (!tokenUsdPriceData) return null
+  return Number(tokenAmount) * tokenUsdPriceData?.price
+}
+export default getTokenUsdPrice

--- a/src/utils/getTokenUsdPrice.ts
+++ b/src/utils/getTokenUsdPrice.ts
@@ -7,28 +7,32 @@ const getTokenUsdPrice = (
   token: SwappableToken | null,
   tokensUsdPriceData?: TokenUsdPriceData
 ): number | null => {
-  if (
-    !tokensUsdPriceData ||
-    !token ||
-    !tokenAmount ||
-    Number.isNaN(+tokenAmount)
-  )
-    return null
-  let tokenUsdPriceData = null
-  if (isBaseToken(token) && tokensUsdPriceData[token.defuseAssetId]) {
-    tokenUsdPriceData = tokensUsdPriceData[token.defuseAssetId]
-  } else if (isUnifiedToken(token)) {
-    for (const groupedToken of token.groupedTokens) {
-      if (
-        isBaseToken(groupedToken) &&
-        tokensUsdPriceData[groupedToken.defuseAssetId]
-      ) {
-        tokenUsdPriceData = tokensUsdPriceData[groupedToken.defuseAssetId]
-        break
+  try {
+    if (
+      !tokensUsdPriceData ||
+      !token ||
+      !tokenAmount ||
+      Number.isNaN(+tokenAmount)
+    )
+      return null
+    let tokenUsdPriceData = null
+    if (isBaseToken(token) && tokensUsdPriceData[token.defuseAssetId]) {
+      tokenUsdPriceData = tokensUsdPriceData[token.defuseAssetId]
+    } else if (isUnifiedToken(token)) {
+      for (const groupedToken of token.groupedTokens) {
+        if (
+          isBaseToken(groupedToken) &&
+          tokensUsdPriceData[groupedToken.defuseAssetId]
+        ) {
+          tokenUsdPriceData = tokensUsdPriceData[groupedToken.defuseAssetId]
+          break
+        }
       }
     }
+    if (!tokenUsdPriceData) return null
+    return Number(tokenAmount) * tokenUsdPriceData.price
+  } catch {
+    return null
   }
-  if (!tokenUsdPriceData) return null
-  return Number(tokenAmount) * tokenUsdPriceData?.price
 }
 export default getTokenUsdPrice


### PR DESCRIPTION
A demo for review of how I can add USD prices to input fields.

A few things left to add 

1. Formatting for really big USD amounts to avoid scientific notation in UI. Probably using Intl or some other way like 10mil 223th.
2. I ll add overall formatting to avoid a lot of digits after the decimal point.


<img width="569" alt="Screenshot 2025-01-08 at 15 42 35" src="https://github.com/user-attachments/assets/a5b640ad-1870-45a0-a042-3368e8b0460b" />
<img width="568" alt="Screenshot 2025-01-08 at 15 42 40" src="https://github.com/user-attachments/assets/965bf68c-f835-4318-96c3-85ff64a13f0d" />
<img width="564" alt="Screenshot 2025-01-08 at 15 43 35" src="https://github.com/user-attachments/assets/a400b5c1-7e44-4ab1-bb78-f94b07304a81" />
