### PR TITLE
feat: add configurable referral field

### DIFF
--- a/src/features/machines/publicKeyVerifierMachine.ts
+++ b/src/features/machines/publicKeyVerifierMachine.ts
@@ -57,6 +57,14 @@ export const publicKeyVerifierMachine = setup({
       error: (_, { error }: { error: ErrorCodes }) => error,
     }),
   },
+  guards: {
+    isNonNearAccount: ({ context }) => {
+      // Don't need to check public key if it is not Near account,
+      // because public key cannot change for non-Near accounts.
+      return context.nearAccount == null
+    },
+    isTrue: (_, value: boolean) => value,
+  },
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5QAcCuAjANgSwMYGkwBPANTACdsAzbCgOmwkzAGIBtABgF1EUB7WNgAu2PgDteIAB6IAjACYArHQBsigBybZK+QE5dHWQGZ5AGhBFE62XRN7tugOwAWWbsWKVAXy-m0WPEJSCmpacgYmVjZZHiQQZAFhUQk4mQQFZTVNax19QxNzSwR5dSM6DgNdayNnZxLPHz8MHAJiMkoaelwACzBcAGtsMSgWCHEwBjEANz5+iZ6+-oAFDCCAJTAqTlj+QRFxSTSVdXly40NtFRd1WsLEPVPHDgr1FWc1N0UjRvjmwLaQp1wgsBkMRmMxBMhjM5nQQctVsQNlsYpIEntkodEJ5HipdLInrp5G4bs47ggjNZbESCSZtDVHIofv4WkF2qEur1QcMWBRyHxwshMABDIRUAUAWzhXIR6HWm22aMS+xSoDSsg4RmUJKMul1RjxzgN5KUKlUeI47y1VUMjkczL+rWCHTC0sWkBYAEEACLegD6SwAqgAhAAyAEkAMJ+-AAUQAmoq4uikgdUohHLIbCpddpHKUOEpdCpyYo3HRjOpFCUOFdHFqHQEneygXRhRAIGDRuNJjCJu2ICs5UiFdwlRi02q5EZZJkZ4yrcd3Ipyc5XnR3O9nJrnHaFN9fL8m2zAa6B12IVDprN+x2h-KUTt4srMen0ios+V3PInnpM0SyQsRAtzoeQjGeIx-xqWR1F0RtWQBF16HPHk+QFOghVFcVyClAd7xHLYx2TF9J2kOQ3jNPVKT0HNrAqRxyRMZw6FePUdCuAxMxqHxDzEPgIDgNFHRPJDyHHVNVTIhAAFoSyAmTlH0fR1EcFQrg4etTXg-5nQ5cJGGYcSVSxBA6nJKtVC+eRa11fM8mcbTm1PTlFjBIzXynYoVLoRxdDqFSKg8azVJNRRHDoRR8Q-Cp1P0bxDxZHSW1deFIHc0i0i+M1YOcL4FDeSDZFLGCWNratng1d5q0ckS9LbDs3OIidJLSJx1FA2DnieRRnicXRV3cakCTxNQ9Ss+KmmPRC6twPgJSFMAhDSpqJJMy52pONiTBcDSXHJPy6FcbcNCULNiTtHivCAA */
   id: "publicKeyVerifier",
@@ -77,11 +85,7 @@ export const publicKeyVerifierMachine = setup({
       always: [
         {
           target: "completed",
-          guard: ({ context }) => {
-            // Don't need to check public key if it is not Near account,
-            // because public key cannot change for non-Near accounts.
-            return context.nearAccount == null
-          },
+          guard: "isNonNearAccount",
         },
         {
           target: "checking",
@@ -107,7 +111,10 @@ export const publicKeyVerifierMachine = setup({
         onDone: [
           {
             target: "completed",
-            guard: ({ event }) => event.output,
+            guard: {
+              type: "isTrue",
+              params: ({ event }) => event.output,
+            },
           },
           {
             target: "checked",

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -76,6 +76,7 @@ type Context = {
   userAddress: string
   userChainType: ChainType
   defuseUserId: DefuseUserId
+  referral?: string
   nearClient: providers.Provider
   sendNearTransaction: SendNearTransaction
   intentOperationParams: IntentOperationParams
@@ -111,6 +112,7 @@ type Input = {
   userAddress: string
   userChainType: ChainType
   defuseUserId: DefuseUserId
+  referral?: string
   nearClient: providers.Provider
   sendNearTransaction: SendNearTransaction
   intentOperationParams: IntentOperationParams
@@ -193,6 +195,7 @@ export const swapIntentMachine = setup({
               context.intentOperationParams.quote.expirationTime
             ).getTime()
           ),
+          referral: context.referral,
         })
 
         return {

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -48,6 +48,7 @@ export type Context = {
   intentCreationResult: SwapIntentMachineOutput | null
   intentRefs: ActorRefFrom<typeof intentStatusMachine>[]
   tokenList: SwappableToken[]
+  referral?: string
 }
 
 type PassthroughEvent = {
@@ -68,6 +69,7 @@ export const swapUIMachine = setup({
       tokenIn: SwappableToken
       tokenOut: SwappableToken
       tokenList: SwappableToken[]
+      referral?: string
     },
     context: {} as Context,
     events: {} as
@@ -283,6 +285,7 @@ export const swapUIMachine = setup({
     intentCreationResult: null,
     intentRefs: [],
     tokenList: input.tokenList,
+    referral: input.referral,
   }),
 
   entry: ["spawnBackgroundQuoterRef", "spawnDepositedBalanceRef"],
@@ -405,6 +408,7 @@ export const swapUIMachine = setup({
               event.params.userAddress,
               event.params.userChainType
             ),
+            referral: context.referral,
             nearClient: event.params.nearClient,
             sendNearTransaction: event.params.sendNearTransaction,
             intentOperationParams: {

--- a/src/features/machines/withdrawUIMachine.ts
+++ b/src/features/machines/withdrawUIMachine.ts
@@ -61,6 +61,7 @@ export type Context = {
     ) => Promise<{ txHash: string } | null>
   } | null
   preparationOutput: PreparationOutput | null
+  referral?: string
 }
 
 type PassthroughEvent = {
@@ -85,6 +86,7 @@ export const withdrawUIMachine = setup({
       tokenIn: BaseTokenInfo | UnifiedTokenInfo
       tokenOut: BaseTokenInfo
       tokenList: (BaseTokenInfo | UnifiedTokenInfo)[]
+      referral?: string
     },
     context: {} as Context,
     events: {} as
@@ -367,6 +369,7 @@ export const withdrawUIMachine = setup({
     nep141StorageOutput: null,
     nep141StorageQuote: null,
     preparationOutput: null,
+    referral: input.referral,
   }),
 
   entry: ["spawnBackgroundQuoterRef", "fetchPOABridgeInfo"],
@@ -561,6 +564,7 @@ export const withdrawUIMachine = setup({
               context.submitDeps.userAddress,
               context.submitDeps.userChainType
             ),
+            referral: context.referral,
             nearClient: context.submitDeps.nearClient,
             sendNearTransaction: context.submitDeps.sendNearTransaction,
             intentOperationParams: {

--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -53,6 +53,7 @@ interface SwapUIMachineProviderProps extends PropsWithChildren {
   initialTokenOut?: SwappableToken
   tokenList: SwappableToken[]
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
+  referral?: string
 }
 
 export function SwapUIMachineProvider({
@@ -61,6 +62,7 @@ export function SwapUIMachineProvider({
   initialTokenOut,
   tokenList,
   signMessage,
+  referral,
 }: SwapUIMachineProviderProps) {
   const { setValue, resetField } = useFormContext<SwapFormValues>()
   const tokenIn = initialTokenIn || tokenList[0]
@@ -74,6 +76,7 @@ export function SwapUIMachineProvider({
           tokenIn,
           tokenOut,
           tokenList,
+          referral,
         },
       }}
       logic={swapUIMachine.provide({

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -19,6 +19,7 @@ export const SwapWidget = ({
   onNavigateDeposit,
   initialTokenIn,
   initialTokenOut,
+  referral,
 }: SwapWidgetProps) => {
   return (
     <WidgetRoot>
@@ -30,6 +31,7 @@ export const SwapWidget = ({
             initialTokenOut={initialTokenOut}
             tokenList={tokenList}
             signMessage={signMessage}
+            referral={referral}
           >
             <SwapUIMachineFormSyncProvider
               userAddress={userAddress}

--- a/src/features/withdraw/components/WithdrawWidget.tsx
+++ b/src/features/withdraw/components/WithdrawWidget.tsx
@@ -40,6 +40,7 @@ export const WithdrawWidget = (props: WithdrawWidgetProps) => {
               tokenIn: initialTokenIn,
               tokenOut: initialTokenOut,
               tokenList: props.tokenList,
+              referral: props.referral,
             },
           }}
           logic={withdrawUIMachine.provide({

--- a/src/features/withdraw/components/WithdrawWidget.tsx
+++ b/src/features/withdraw/components/WithdrawWidget.tsx
@@ -124,6 +124,7 @@ export const WithdrawWidget = (props: WithdrawWidgetProps) => {
                         deadlineTimestamp:
                           // Expiry time maybe zero if nothing to swap, so let's just fallback to the default
                           Date.now() + 10 * 60 * 1000,
+                        referral: context.referral,
                       })
 
                       return {

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -97,4 +97,10 @@ export type SwapWidgetProps = {
   onNavigateDeposit?: () => void
   initialTokenIn?: SwappableToken
   initialTokenOut?: SwappableToken
+
+  /**
+   * Optional referral code, used for tracking purposes.
+   * Prop is not reactive, set it once when the component is created.
+   */
+  referral?: string
 }

--- a/src/types/withdraw.ts
+++ b/src/types/withdraw.ts
@@ -7,4 +7,9 @@ export type WithdrawWidgetProps = UserInfo & {
   tokenList: (BaseTokenInfo | UnifiedTokenInfo)[]
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
   sendNearTransaction: SendNearTransaction
+  /**
+   * Optional referral code, used for tracking purposes.
+   * Prop is not reactive, set it once when the component is created.
+   */
+  referral?: string
 }

--- a/src/utils/messageFactory.test.ts
+++ b/src/utils/messageFactory.test.ts
@@ -73,6 +73,35 @@ describe("makeSwapMessage()", () => {
     expect(msg1.NEP413.nonce).not.toEqual(msg2.NEP413.nonce)
   })
 
+  it("should include referral in token_diff intent", () => {
+    const innerMessage = makeInnerSwapMessage({
+      tokenDeltas: [
+        ["foo.near", -100n],
+        ["bar.near", 200n],
+      ],
+      signerId: userAddressToDefuseUserId("user.near", "near"),
+      deadlineTimestamp: 1704110400000,
+      referral: "referrer.near",
+    })
+
+    expect(innerMessage).toMatchInlineSnapshot(`
+      {
+        "deadline": "2024-01-01T12:00:00.000Z",
+        "intents": [
+          {
+            "diff": {
+              "bar.near": "200",
+              "foo.near": "-100",
+            },
+            "intent": "token_diff",
+            "referral": "referrer.near",
+          },
+        ],
+        "signer_id": "user.near",
+      }
+    `)
+  })
+
   it("should merge amounts in/out with same token", () => {
     const innerMessage = makeInnerSwapMessage({
       tokenDeltas: [
@@ -95,6 +124,7 @@ describe("makeSwapMessage()", () => {
               "foo.near": "-50",
             },
             "intent": "token_diff",
+            "referral": undefined,
           },
         ],
         "signer_id": "user.near",
@@ -133,6 +163,7 @@ describe("makeInnerSwapAndWithdrawMessage()", () => {
               "foo.near": "-100",
             },
             "intent": "token_diff",
+            "referral": undefined,
           },
           {
             "amount": "200",
@@ -264,6 +295,49 @@ describe("makeInnerSwapAndWithdrawMessage()", () => {
             "msg": "deadbeef00000000000000000000000000000001",
             "receiver_id": "foo.cloud.aurora",
             "token": "usdt.near",
+          },
+        ],
+        "signer_id": "user.near",
+      }
+    `)
+  })
+
+  it("should include referral in token_diff intent when swapping and withdrawing", () => {
+    const innerMessage = makeInnerSwapAndWithdrawMessage({
+      tokenDeltas: [
+        ["foo.near", -100n],
+        ["bar.near", 200n],
+      ],
+      withdrawParams: {
+        type: "to_near",
+        amount: 200n,
+        tokenAccountId: "bar.near",
+        receiverId: "receiver.near",
+        storageDeposit: 0n,
+      },
+      signerId: userAddressToDefuseUserId("user.near", "near"),
+      deadlineTimestamp: DEADLINE,
+      referral: "referrer.near",
+    })
+
+    expect(innerMessage).toMatchInlineSnapshot(`
+      {
+        "deadline": "2024-01-01T12:00:00.000Z",
+        "intents": [
+          {
+            "diff": {
+              "bar.near": "200",
+              "foo.near": "-100",
+            },
+            "intent": "token_diff",
+            "referral": "referrer.near",
+          },
+          {
+            "amount": "200",
+            "intent": "ft_withdraw",
+            "receiver_id": "receiver.near",
+            "storage_deposit": undefined,
+            "token": "bar.near",
           },
         ],
         "signer_id": "user.near",

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -14,15 +14,18 @@ import type { DefuseUserId } from "./defuse"
  * @param tokenDeltas
  * @param signerId
  * @param deadlineTimestamp Unix timestamp in milliseconds
+ * @param referral
  */
 export function makeInnerSwapMessage({
   tokenDeltas,
   signerId,
   deadlineTimestamp,
+  referral,
 }: {
   tokenDeltas: [string, bigint][]
   signerId: DefuseUserId
   deadlineTimestamp: number
+  referral?: string
 }): Nep413DefuseMessageFor_DefuseIntents {
   const tokenDiff: Record<string, string> = {}
   const tokenDiffNum: Record<string, bigint> = {}
@@ -49,6 +52,7 @@ export function makeInnerSwapMessage({
       {
         intent: "token_diff",
         diff: tokenDiff,
+        referral,
       },
     ],
     signer_id: signerId,
@@ -60,17 +64,20 @@ export function makeInnerSwapMessage({
  * @param withdrawParams
  * @param signerId
  * @param deadlineTimestamp Unix timestamp in seconds
+ * @param referral
  */
 export function makeInnerSwapAndWithdrawMessage({
   tokenDeltas,
   withdrawParams,
   signerId,
   deadlineTimestamp,
+  referral,
 }: {
   tokenDeltas: [string, bigint][] | null
   withdrawParams: WithdrawParams
   signerId: DefuseUserId
   deadlineTimestamp: number
+  referral?: string
 }): Nep413DefuseMessageFor_DefuseIntents {
   const intents: NonNullable<Nep413DefuseMessageFor_DefuseIntents["intents"]> =
     []
@@ -80,6 +87,7 @@ export function makeInnerSwapAndWithdrawMessage({
       tokenDeltas,
       signerId,
       deadlineTimestamp,
+      referral,
     })
     assert(swapIntents, "swapIntents must be defined")
     intents.push(...swapIntents)


### PR DESCRIPTION
PR also includes small refactoring of `publicKeyVerifierMachine`, otherwise sdk couldn't compile because of bloated types:

```
src/features/machines/withdrawUIMachine.ts(83,14): error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
```