### PR TITLE
feat: add basic slippage functionality

### DIFF
--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -22,6 +22,7 @@ import {
   makeSwapMessage,
 } from "../../utils/messageFactory"
 import {
+  accountSlippage,
   addAmounts,
   compareAmounts,
   computeTotalDeltaDifferentDecimals,
@@ -198,8 +199,13 @@ export const swapIntentMachine = setup({
           "Operation must be swap"
         )
 
+        const slippageBasisPoints = 100 // 1% slippage
+
         const innerMessage = makeInnerSwapMessage({
-          tokenDeltas: context.intentOperationParams.quote.tokenDeltas,
+          tokenDeltas: accountSlippage(
+            context.intentOperationParams.quote.tokenDeltas,
+            slippageBasisPoints
+          ),
           signerId: context.defuseUserId,
           deadlineTimestamp: Math.min(
             Date.now() + settings.swapExpirySec * 1000,

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -89,6 +89,7 @@ type Context = {
   userChainType: ChainType
   defuseUserId: DefuseUserId
   referral?: string
+  slippageBasisPoints: number
   nearClient: providers.Provider
   sendNearTransaction: SendNearTransaction
   intentOperationParams: IntentOperationParams
@@ -125,6 +126,7 @@ type Input = {
   userChainType: ChainType
   defuseUserId: DefuseUserId
   referral?: string
+  slippageBasisPoints: number
   nearClient: providers.Provider
   sendNearTransaction: SendNearTransaction
   intentOperationParams: IntentOperationParams
@@ -199,12 +201,10 @@ export const swapIntentMachine = setup({
           "Operation must be swap"
         )
 
-        const slippageBasisPoints = 100 // 1% slippage
-
         const innerMessage = makeInnerSwapMessage({
           tokenDeltas: accountSlippageExactIn(
             context.intentOperationParams.quote.tokenDeltas,
-            slippageBasisPoints
+            context.slippageBasisPoints
           ),
           signerId: context.defuseUserId,
           deadlineTimestamp: Math.min(

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -22,7 +22,7 @@ import {
   makeSwapMessage,
 } from "../../utils/messageFactory"
 import {
-  accountSlippage,
+  accountSlippageExactIn,
   addAmounts,
   compareAmounts,
   computeTotalDeltaDifferentDecimals,
@@ -202,7 +202,7 @@ export const swapIntentMachine = setup({
         const slippageBasisPoints = 100 // 1% slippage
 
         const innerMessage = makeInnerSwapMessage({
-          tokenDeltas: accountSlippage(
+          tokenDeltas: accountSlippageExactIn(
             context.intentOperationParams.quote.tokenDeltas,
             slippageBasisPoints
           ),

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -421,6 +421,7 @@ export const swapUIMachine = setup({
               event.params.userChainType
             ),
             referral: context.referral,
+            slippageBasisPoints: 100,
             nearClient: event.params.nearClient,
             sendNearTransaction: event.params.sendNearTransaction,
             intentOperationParams: {

--- a/src/features/machines/withdrawUIMachine.ts
+++ b/src/features/machines/withdrawUIMachine.ts
@@ -545,6 +545,7 @@ export const withdrawUIMachine = setup({
               context.submitDeps.userChainType
             ),
             referral: context.referral,
+            slippageBasisPoints: 0,
             nearClient: context.submitDeps.nearClient,
             sendNearTransaction: context.submitDeps.sendNearTransaction,
             intentOperationParams: {

--- a/src/utils/tokenUtils.test.ts
+++ b/src/utils/tokenUtils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "../types/base"
 import {
   DuplicateTokenError,
-  accountSlippage,
+  accountSlippageExactIn,
   addAmounts,
   adjustDecimals,
   compareAmounts,
@@ -885,13 +885,13 @@ describe("getUnderlyingBaseTokenInfos", () => {
   })
 })
 
-describe("accountSlippage", () => {
+describe("accountSlippageExactIn", () => {
   type Delta = [string, bigint][]
 
   it("should apply slippage to positive amounts", () => {
     const delta: Delta = [["token1", 1000n]]
     const slippageBasisPoints = 100 // 1%
-    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
       ["token1", 990n],
     ])
   })
@@ -899,7 +899,7 @@ describe("accountSlippage", () => {
   it("should not apply slippage to zero amounts", () => {
     const delta: Delta = [["token1", 0n]]
     const slippageBasisPoints = 100 // 1%
-    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
       ["token1", 0n],
     ])
   })
@@ -907,7 +907,7 @@ describe("accountSlippage", () => {
   it("should not apply slippage to negative amounts", () => {
     const delta: Delta = [["token1", -1000n]]
     const slippageBasisPoints = 100 // 1%
-    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
       ["token1", -1000n],
     ])
   })
@@ -919,7 +919,7 @@ describe("accountSlippage", () => {
       ["token3", 0n],
     ]
     const slippageBasisPoints = 100 // 1%
-    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
       ["token1", 990n],
       ["token2", -500n],
       ["token3", 0n],
@@ -929,7 +929,7 @@ describe("accountSlippage", () => {
   it("should handle slippage of 0%", () => {
     const delta: Delta = [["token1", 1000n]]
     const slippageBasisPoints = 0 // 0%
-    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
       ["token1", 1000n],
     ])
   })
@@ -937,7 +937,7 @@ describe("accountSlippage", () => {
   it("should handle slippage of 100%", () => {
     const delta: Delta = [["token1", 1000n]]
     const slippageBasisPoints = 10000 // 100%
-    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
       ["token1", 0n],
     ])
   })

--- a/src/utils/tokenUtils.test.ts
+++ b/src/utils/tokenUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "../types/base"
 import {
   DuplicateTokenError,
+  accountSlippage,
   addAmounts,
   adjustDecimals,
   compareAmounts,
@@ -881,5 +882,63 @@ describe("getUnderlyingBaseTokenInfos", () => {
     expect(() => getUnderlyingBaseTokenInfos(tokensWithConflict)).toThrow(
       DuplicateTokenError
     )
+  })
+})
+
+describe("accountSlippage", () => {
+  type Delta = [string, bigint][]
+
+  it("should apply slippage to positive amounts", () => {
+    const delta: Delta = [["token1", 1000n]]
+    const slippageBasisPoints = 100 // 1%
+    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+      ["token1", 990n],
+    ])
+  })
+
+  it("should not apply slippage to zero amounts", () => {
+    const delta: Delta = [["token1", 0n]]
+    const slippageBasisPoints = 100 // 1%
+    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+      ["token1", 0n],
+    ])
+  })
+
+  it("should not apply slippage to negative amounts", () => {
+    const delta: Delta = [["token1", -1000n]]
+    const slippageBasisPoints = 100 // 1%
+    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+      ["token1", -1000n],
+    ])
+  })
+
+  it("should handle multiple tokens with mixed amounts", () => {
+    const delta: Delta = [
+      ["token1", 1000n],
+      ["token2", -500n],
+      ["token3", 0n],
+    ]
+    const slippageBasisPoints = 100 // 1%
+    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+      ["token1", 990n],
+      ["token2", -500n],
+      ["token3", 0n],
+    ])
+  })
+
+  it("should handle slippage of 0%", () => {
+    const delta: Delta = [["token1", 1000n]]
+    const slippageBasisPoints = 0 // 0%
+    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+      ["token1", 1000n],
+    ])
+  })
+
+  it("should handle slippage of 100%", () => {
+    const delta: Delta = [["token1", 1000n]]
+    const slippageBasisPoints = 10000 // 100%
+    expect(accountSlippage(delta, slippageBasisPoints)).toEqual([
+      ["token1", 0n],
+    ])
   })
 })

--- a/src/utils/tokenUtils.test.ts
+++ b/src/utils/tokenUtils.test.ts
@@ -941,4 +941,12 @@ describe("accountSlippageExactIn", () => {
       ["token1", 0n],
     ])
   })
+
+  it("should handles rounding for small numbers", () => {
+    const delta: Delta = [["token1", 99n]]
+    const slippageBasisPoints = 100 // 1%
+    expect(accountSlippageExactIn(delta, slippageBasisPoints)).toEqual([
+      ["token1", 99n],
+    ])
+  })
 })

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -273,3 +273,21 @@ export function negateTokenValue(value: TokenValue): TokenValue {
     decimals: value.decimals,
   }
 }
+
+/**
+ * Slippage can affect only positive numbers, because positive delta mean
+ * that much will receive, and user can receive a bit less than that
+ * depending on market conditions.
+ */
+export function accountSlippage(
+  delta: [string, bigint][],
+  slippageBasisPoints: number
+): [string, bigint][] {
+  return delta.map(([token, amount]) => {
+    if (amount > 0n) {
+      const slippageAmount = (amount * BigInt(slippageBasisPoints)) / 10000n
+      return [token, amount - slippageAmount]
+    }
+    return [token, amount]
+  })
+}

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -279,7 +279,7 @@ export function negateTokenValue(value: TokenValue): TokenValue {
  * that much will receive, and user can receive a bit less than that
  * depending on market conditions.
  */
-export function accountSlippage(
+export function accountSlippageExactIn(
   delta: [string, bigint][],
   slippageBasisPoints: number
 ): [string, bigint][] {


### PR DESCRIPTION
We have 2 pieces of functionailty that are affected by slippage. Swaps and withdraws (because  80% of withdraws are swap + withdraw).

## Swaps

No caveats in swaps. Users just sign a message with a little worse received amount. If there is a better quote, then the better quote will be used. Solver relay is responsible for transferring remaining amount.

## Withdraws

Here are 2 tricky things.

### 1. Withdraws of natively multichain assets. 

Swaps between natively multichain assets are 1-1. So there should not be any slippage. Eventually there will but now implementation assumes there aren't.

### 2. Withdraws to Near blockchain, and user never interacted with the token

If user never interacted with a token, then they need to pay NEP-141 storage. Which is deducted from withdraw amount, which is basically tiny (0.00125) swap to $NEAR. As it is a swap, then it's affected by slippage. This logic adds complexity: we can't receive less $NEAR than needed, because otherwise we couldn't afford storage and entire withdraw will fail. To solve it we need to account for slippage on amount in (amount of token to be withdrawn) rather than amount out (amount of $NEAR). But it adds another problem, we need know for sure how many tokens to will withdrawn. 

We decided not to account for slippage during withdrawals at all right now: 
1. natively multichain assets are 1-1
2. storage swaps are that insignificant, so solvers can increase deadline for such swaps

# Follow-up

1. Allow worse quotes that are within slippage, right now worse quotes are discarded even if user signed a message with less amount.  https://github.com/defuse-protocol/defuse-sdk/pull/277
2. Display slippage and min amount out https://github.com/defuse-protocol/defuse-sdk/pull/276
3. Add configration of slippage from settings