### PR TITLE
feat: consider slippage when choosing the best quote

### DIFF
--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -78,7 +78,6 @@ export type IntentDescription =
       type: "swap"
       totalAmountIn: TokenValue
       totalAmountOut: TokenValue
-      quote: AggregatedQuote
     }
   | {
       type: "withdraw"
@@ -313,7 +312,6 @@ export const swapIntentMachine = setup({
               intentHash: context.intentHash,
               intentDescription: {
                 type: "swap",
-                quote: context.intentOperationParams.quote,
                 totalAmountIn: negateTokenValue(
                   computeTotalDeltaDifferentDecimals(
                     context.intentOperationParams.tokensIn,

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -165,47 +165,17 @@ export const swapIntentMachine = setup({
     logError: (_, params: { error: unknown }) => {
       logger.error(params.error)
     },
-    proposeQuote: assign({
-      intentOperationParams: ({ context }, proposedQuote: AggregatedQuote) => {
-        if (context.intentOperationParams.quote) {
-          enqueueBetterQuote(
-            context.quotes,
-            context.intentOperationParams.quote,
-            proposedQuote,
-            context.intentOperationParams.tokenOut,
-            context.slippageBasisPoints
-          )
-        }
-
-        if (context.intentOperationParams.type === "swap") {
-          return {
-            ...context.intentOperationParams,
-            quote: determineNewestValidQuote(
-              context.intentOperationParams.tokenOut,
-              context.intentOperationParams.quote,
-              proposedQuote
-            ),
-          }
-        }
-
-        // Quote needs to be updated for withdraw only in case of crosschain withdrawal
-        if (
-          context.intentOperationParams.type === "withdraw" &&
-          context.intentOperationParams.quote !== null
-        ) {
-          return {
-            ...context.intentOperationParams,
-            quote: determineNewestValidQuote(
-              context.intentOperationParams.tokenOut,
-              context.intentOperationParams.quote,
-              proposedQuote
-            ),
-          }
-        }
-
-        return context.intentOperationParams
-      },
-    }),
+    proposeQuote: ({ context }, proposedQuote: AggregatedQuote) => {
+      if (context.intentOperationParams.quote) {
+        enqueueBetterQuote(
+          context.quotes,
+          context.intentOperationParams.quote,
+          proposedQuote,
+          context.intentOperationParams.tokenOut,
+          context.slippageBasisPoints
+        )
+      }
+    },
     assembleSignMessages: assign({
       messageToSign: ({ context }) => {
         assert(
@@ -727,29 +697,6 @@ function peekBestQuote(
   }
 
   return null
-}
-
-function determineNewestValidQuote(
-  tokenOut: BaseTokenInfo,
-  originalQuote: AggregatedQuote,
-  proposedQuote: AggregatedQuote
-): AggregatedQuote {
-  const out1 = computeTotalDeltaDifferentDecimals(
-    [tokenOut],
-    originalQuote.tokenDeltas
-  )
-  const out2 = computeTotalDeltaDifferentDecimals(
-    [tokenOut],
-    proposedQuote.tokenDeltas
-  )
-  if (
-    compareAmounts(out1, out2) <= 0 &&
-    originalQuote.expirationTime <= proposedQuote.expirationTime
-  ) {
-    return proposedQuote
-  }
-
-  return originalQuote
 }
 
 async function verifyWalletSignature(

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -267,7 +267,7 @@ export const swapIntentMachine = setup({
       return status === "SETTLED"
     },
     isIntentRelevant: ({ context }) => {
-      const hadQuote = context.intentOperationParams.quote == null
+      const hadQuote = context.intentOperationParams.quote != null
       const hasQuote = context.quoteToPublish != null
       return hadQuote === hasQuote
     },

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -167,7 +167,15 @@ export const swapIntentMachine = setup({
     },
     proposeQuote: assign({
       intentOperationParams: ({ context }, proposedQuote: AggregatedQuote) => {
-        context.quotes.enqueue(proposedQuote)
+        if (context.intentOperationParams.quote) {
+          enqueueBetterQuote(
+            context.quotes,
+            context.intentOperationParams.quote,
+            proposedQuote,
+            context.intentOperationParams.tokenOut,
+            context.slippageBasisPoints
+          )
+        }
 
         if (context.intentOperationParams.type === "swap") {
           return {
@@ -678,6 +686,28 @@ export const swapIntentMachine = setup({
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error("unknown error")
+}
+
+function enqueueBetterQuote(
+  quotes: PriorityQueue<AggregatedQuote>,
+  originalQuote: AggregatedQuote,
+  proposedQuote: AggregatedQuote,
+  tokenOut: BaseTokenInfo,
+  slippageBasisPoints: number
+) {
+  const outOriginal = computeTotalDeltaDifferentDecimals(
+    [tokenOut],
+    accountSlippageExactIn(originalQuote.tokenDeltas, slippageBasisPoints)
+  )
+
+  const outProposed = computeTotalDeltaDifferentDecimals(
+    [tokenOut],
+    proposedQuote.tokenDeltas
+  )
+
+  if (compareAmounts(outOriginal, outProposed) <= 0) {
+    quotes.enqueue(proposedQuote)
+  }
 }
 
 function peekBestQuote(

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -21,6 +21,7 @@ import {
   makeInnerSwapMessage,
   makeSwapMessage,
 } from "../../utils/messageFactory"
+import { PriorityQueue } from "../../utils/priorityQueue"
 import {
   accountSlippageExactIn,
   addAmounts,
@@ -93,6 +94,7 @@ type Context = {
   nearClient: providers.Provider
   sendNearTransaction: SendNearTransaction
   intentOperationParams: IntentOperationParams
+  quotes: PriorityQueue<AggregatedQuote>
   messageToSign: null | {
     walletMessage: WalletMessage
     innerMessage: Nep413DefuseMessageFor_DefuseIntents
@@ -165,6 +167,8 @@ export const swapIntentMachine = setup({
     },
     proposeQuote: assign({
       intentOperationParams: ({ context }, proposedQuote: AggregatedQuote) => {
+        context.quotes.enqueue(proposedQuote)
+
         if (context.intentOperationParams.type === "swap") {
           return {
             ...context.intentOperationParams,
@@ -301,11 +305,17 @@ export const swapIntentMachine = setup({
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5SwO4EMAOBaAlgOwBcxCBiAOQFEB1AfQEUBVAeQBUKBtABgF1FQMA9rBwEcAvHxAAPRACYAnAFYAdPIAcigGyKA7It0BGTcYDMAGhABPRAZOzlJxfJNqdmnTs7zOsgCwBffwtUTFxCYgJlHAgAGzASLl4kEEFhUXFJGQRbNWUfTgNfRVk1eU01Ut8LawQTdWVNP05HfU9fY0Dg9Gx8IkJlAGUcKDx8KBIIcTAovAA3AQBraeERgFk4WDQYRMlUkTEJZKzvZRLdV0bfWVkdAwNqxEaDVSKTO18dK7cTTpAQnvC-SGIzGJDAACdwQJwcoMDE0AQAGbQgC2yhWeHWsE22x4uyE+wyR0QWFkmk4ygqmhM1OMBm8dweCF8vnkyicrLKei0JVsv3+YT6kQAahCcIjLGMAAQABQArgAjGI4ADGUoA0mBLLLwXBiCr4pM8NN8PMlrDFcqVZrLKLweKcBCAEpgRE7ZJ7dKHUBZWQmVT09qFbxvLwGHRMgycHT2WRGErucn0-T87qCiLKO3iyV4KCyy2qjVanV6vAGiZTGZm6YYAvWrVZxGO8Eut0GJL8AlezJyMqUv1qO5RpxqD6aSN3XyqckKTjlQfRn5BP5p3oZxs5vPypWFm0l2D6+IQqEwuEI5HgtG1nf121ipvO13uztpA49hCkk5XeSfZzFOMFFUVg2JwnAqJoUYuDog6KEYHipqEa79AAQlCaAQCqaCwKIuZSgAkoCBAVsaVaLMsq6EcoqECOhmHYdKBFCggpoCJhXqJM+KRdm+xIILclKgS4fqKEU+gFJGHwqIojjRtc8gGBUnABMuApIZE1G0VhOF5oxERgpC0KwvCSKouiFFClRaEYVpDGEcxcysQiBwcXiHrcUSPokiU9g5B4+ilAY+juJGJhRqctxKaUajznoCEAhZG62UKCSuS+hLetIiDReyGiskpCkiWS47Adk1w+Y03yiWoSmKHF6b9IluG6aQ7Dtvir4eZltR+MoLKfBoZLSZo8iyCFPWhm8ziTbIxR1Wpmb3puUrAngCJyrqxEmg55qqZRjV5ita26vZ8xsc5PCcZ6PGed1yjfPksEiSyaijSVGgUmJnh1KB1LOHNe2LdKh0EOthqVixO3meugO4cDoMnY57EXW1bkdRlWRYCYvjPApZJhj+bweEyg72NGOgmHocafM0S5dIhAP2hKQPDKtIMbcehlniZl5mfTCUwwdLNHWACNneILkdlxaPvpjzSnGSFTyKyL2OPcJXGLkmjYxBSuFLY1yBMueACBAcCSLtQrtelMsuGyuPkvJBMUxGJV+myXhuPISgwUUyl0-FGbRHEVvdrxhQUpUrIxl7cbOK9NR2JovWyHOfjtErNxqP9FkrWMIfXV1Ci9VGvkU+Gui+OYJW+C9DhQUUhRlSNfsrnz0OM0t25WkW2oyrqB5lmA+edRjKheBULKBbB4blPITJx6csHDToShlNotOtwHKFWXR2n4YRw-o4guiqHU2gr3oHjlC7NT61O8kQU4dyKGobyaNn7fZklESH++Ub328UcHwTDRgqFoCcbxTguC0OUBQ2gfAf36AAYQECiOEYAiAQF-rxJQDh5xOH6iUGMxVb7Uh0A0cMoUp4iWjIgyIABxYgYo1QUAMuCbBN1SRawaJJCedx5JExKkYCmFDybP30L4WhKkoYNQFstIWbMh6o2trxaSd1mhuEUKBUchUgI1HJvYQcdRX5Y3UB4ZSgQgA */
   context: ({ input }) => {
+    const quotes = makeQuotePriorityQueue(input.intentOperationParams.tokenOut)
+    if (input.intentOperationParams.quote != null) {
+      quotes.enqueue(input.intentOperationParams.quote)
+    }
+
     return {
       messageToSign: null,
       signature: null,
       error: null,
       intentHash: null,
+      quotes,
       ...input,
     }
   },
@@ -777,4 +787,18 @@ export function calcWithdrawAmount(
     addAmounts(directWithdrawalAmount, gotFromSwap),
     spentOnStorage
   )
+}
+
+function makeQuotePriorityQueue(tokenOut: BaseTokenInfo) {
+  return new PriorityQueue<AggregatedQuote>((quoteA, quoteB) => {
+    const amountOutA = computeTotalDeltaDifferentDecimals(
+      [tokenOut],
+      quoteA.tokenDeltas
+    )
+    const amountOutB = computeTotalDeltaDifferentDecimals(
+      [tokenOut],
+      quoteB.tokenDeltas
+    )
+    return compareAmounts(amountOutA, amountOutB)
+  })
 }

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -191,12 +191,7 @@ export const swapIntentMachine = setup({
             context.slippageBasisPoints
           ),
           signerId: context.defuseUserId,
-          deadlineTimestamp: Math.min(
-            Date.now() + settings.swapExpirySec * 1000,
-            new Date(
-              context.intentOperationParams.quote.expirationTime
-            ).getTime()
-          ),
+          deadlineTimestamp: Date.now() + settings.swapExpirySec * 1000,
           referral: context.referral,
         })
 

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -215,8 +215,8 @@ export const swapIntentMachine = setup({
     setIntentHash: assign({
       intentHash: (_, intentHash: string) => intentHash,
     }),
-    peekBestQuote: assign({
-      quoteToPublish: ({ context }) => peekBestQuote(context.quotes),
+    dequeueValidQuote: assign({
+      quoteToPublish: ({ context }) => dequeueValidQuote(context.quotes),
     }),
   },
   actors: {
@@ -617,7 +617,7 @@ export const swapIntentMachine = setup({
     },
 
     "Verifying Intent": {
-      entry: "peekBestQuote",
+      entry: "dequeueValidQuote",
       always: [
         {
           target: "Broadcasting Intent",
@@ -676,7 +676,7 @@ function enqueueBetterQuote(
   }
 }
 
-function peekBestQuote(
+function dequeueValidQuote(
   quotes: PriorityQueue<AggregatedQuote>
 ): AggregatedQuote | null {
   const MIN_BUFFER_TIME_MS = 10_000 // 10 seconds

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -562,15 +562,23 @@ export const swapIntentMachine = setup({
 
           let quoteHashes: string[] = []
           if (context.intentOperationParams.quote) {
-            quoteHashes = context.intentOperationParams.quote.quoteHashes
+            const quote = peekBestQuote(context.quotes)
+
+            if (quote == null) {
+              // todo: this should be checked in advance (before entering input fn)? Throwing here might cause issues
+              throw new Error("No valid quotes found")
+            }
+
+            quoteHashes = quoteHashes.concat(quote.quoteHashes)
           }
+
           if (
             context.intentOperationParams.type === "withdraw" &&
             context.intentOperationParams.nep141Storage &&
             context.intentOperationParams.nep141Storage.quote
           ) {
-            quoteHashes.push(
-              ...context.intentOperationParams.nep141Storage.quote.quoteHashes
+            quoteHashes = quoteHashes.concat(
+              context.intentOperationParams.nep141Storage.quote.quoteHashes
             )
           }
 
@@ -670,6 +678,25 @@ export const swapIntentMachine = setup({
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error("unknown error")
+}
+
+function peekBestQuote(
+  quotes: PriorityQueue<AggregatedQuote>
+): AggregatedQuote | null {
+  const MIN_BUFFER_TIME_MS = 10_000 // 10 seconds
+
+  while (!quotes.isEmpty()) {
+    const quote = quotes.dequeue()
+    if (
+      // We take a quote that won't expire in the next 10 seconds, so we have time to broadcast the intent
+      Date.now() + MIN_BUFFER_TIME_MS <
+      new Date(quote.expirationTime).getTime()
+    ) {
+      return quote
+    }
+  }
+
+  return null
 }
 
 function determineNewestValidQuote(

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -93,6 +93,9 @@ type Context = {
   nearClient: providers.Provider
   sendNearTransaction: SendNearTransaction
   intentOperationParams: IntentOperationParams
+  // The best quote that was actually published or will be published
+  quoteToPublish: AggregatedQuote | null
+  // Queue stores all quotes coming from the background quoter
   quotes: PriorityQueue<AggregatedQuote>
   messageToSign: null | {
     walletMessage: WalletMessage
@@ -212,6 +215,9 @@ export const swapIntentMachine = setup({
     setIntentHash: assign({
       intentHash: (_, intentHash: string) => intentHash,
     }),
+    peekBestQuote: assign({
+      quoteToPublish: ({ context }) => peekBestQuote(context.quotes),
+    }),
   },
   actors: {
     verifySignatureActor: fromPromise(
@@ -261,16 +267,9 @@ export const swapIntentMachine = setup({
       return status === "SETTLED"
     },
     isIntentRelevant: ({ context }) => {
-      if (context.intentOperationParams.quote != null) {
-        // Naively assume that the quote is still relevant if the expiration time is in the future
-        return (
-          new Date(
-            context.intentOperationParams.quote.expirationTime
-          ).getTime() > Date.now()
-        )
-      }
-
-      return true
+      const hadQuote = context.intentOperationParams.quote == null
+      const hasQuote = context.quoteToPublish != null
+      return hadQuote === hasQuote
     },
     isSigned: (_, params: WalletSignatureResult | null) => params != null,
     isTrue: (_, params: boolean) => params,
@@ -293,6 +292,7 @@ export const swapIntentMachine = setup({
       error: null,
       intentHash: null,
       quotes,
+      quoteToPublish: null,
       ...input,
     }
   },
@@ -306,6 +306,9 @@ export const swapIntentMachine = setup({
       const intentType = context.intentOperationParams.type
       switch (intentType) {
         case "swap": {
+          const quote = context.quoteToPublish
+          assert(quote != null, "Quote must be set for swap intent")
+
           return {
             tag: "ok",
             value: {
@@ -315,12 +318,12 @@ export const swapIntentMachine = setup({
                 totalAmountIn: negateTokenValue(
                   computeTotalDeltaDifferentDecimals(
                     context.intentOperationParams.tokensIn,
-                    context.intentOperationParams.quote.tokenDeltas
+                    quote.tokenDeltas
                   )
                 ),
                 totalAmountOut: computeTotalDeltaDifferentDecimals(
                   [context.intentOperationParams.tokenOut],
-                  context.intentOperationParams.quote.tokenDeltas
+                  quote.tokenDeltas
                 ),
               },
             },
@@ -334,7 +337,8 @@ export const swapIntentMachine = setup({
               intentDescription: {
                 type: "withdraw",
                 amountWithdrawn: calcOperationAmountOut(
-                  context.intentOperationParams
+                  context.intentOperationParams,
+                  context.quoteToPublish
                 ),
               },
             },
@@ -537,15 +541,8 @@ export const swapIntentMachine = setup({
           assert(context.messageToSign != null, "Sign message is not set")
 
           let quoteHashes: string[] = []
-          if (context.intentOperationParams.quote) {
-            const quote = peekBestQuote(context.quotes)
-
-            if (quote == null) {
-              // todo: this should be checked in advance (before entering input fn)? Throwing here might cause issues
-              throw new Error("No valid quotes found")
-            }
-
-            quoteHashes = quoteHashes.concat(quote.quoteHashes)
+          if (context.quoteToPublish) {
+            quoteHashes = quoteHashes.concat(context.quoteToPublish.quoteHashes)
           }
 
           if (
@@ -620,6 +617,7 @@ export const swapIntentMachine = setup({
     },
 
     "Verifying Intent": {
+      entry: "peekBestQuote",
       always: [
         {
           target: "Broadcasting Intent",
@@ -731,20 +729,23 @@ async function verifyWalletSignature(
 }
 
 export function calcOperationAmountOut(
-  operation: IntentOperationParams
+  operation: IntentOperationParams,
+  quoteToPublish: AggregatedQuote | null
 ): TokenValue {
   const operationType = operation.type
   switch (operationType) {
-    case "swap":
+    case "swap": {
+      assert(quoteToPublish != null, "Quote must be set for swap operation")
       return computeTotalDeltaDifferentDecimals(
         [operation.tokenOut],
-        operation.quote.tokenDeltas
+        quoteToPublish.tokenDeltas
       )
+    }
 
     case "withdraw":
       return calcWithdrawAmount(
         operation.tokenOut,
-        operation.quote,
+        quoteToPublish,
         operation.nep141Storage,
         operation.directWithdrawalAmount
       )

--- a/src/features/withdraw/components/WithdrawWidget.tsx
+++ b/src/features/withdraw/components/WithdrawWidget.tsx
@@ -65,9 +65,8 @@ export const WithdrawWidget = (props: WithdrawWidgetProps) => {
                         nep141Storage,
                         recipient,
                         destinationMemo,
+                        quote,
                       } = context.intentOperationParams
-
-                      const quote = context.quoteToPublish
 
                       const totalAmountWithdrawn = calcOperationAmountOut(
                         context.intentOperationParams,

--- a/src/features/withdraw/components/WithdrawWidget.tsx
+++ b/src/features/withdraw/components/WithdrawWidget.tsx
@@ -62,14 +62,16 @@ export const WithdrawWidget = (props: WithdrawWidgetProps) => {
 
                       const {
                         tokenOut,
-                        quote,
                         nep141Storage,
                         recipient,
                         destinationMemo,
                       } = context.intentOperationParams
 
+                      const quote = context.quoteToPublish
+
                       const totalAmountWithdrawn = calcOperationAmountOut(
-                        context.intentOperationParams
+                        context.intentOperationParams,
+                        quote
                       )
 
                       const tokenOutAccountId =

--- a/src/utils/priorityQueue.test.ts
+++ b/src/utils/priorityQueue.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import { PriorityQueue } from "./priorityQueue"
+
+describe("PriorityQueue", () => {
+  // Helper to create a min heap number queue
+  const createNumberQueue = () => {
+    return new PriorityQueue<number>((a, b) => a - b)
+  }
+
+  it("should initialize empty", () => {
+    const queue = createNumberQueue()
+    expect(queue.isEmpty()).toBe(true)
+  })
+
+  it("should enqueue items correctly", () => {
+    const queue = createNumberQueue()
+    queue.enqueue(3)
+    queue.enqueue(1)
+    queue.enqueue(2)
+    expect(queue.peek()).toBe(1)
+  })
+
+  it("should dequeue items in correct order", () => {
+    const queue = createNumberQueue()
+    queue.enqueue(3)
+    queue.enqueue(1)
+    queue.enqueue(4)
+    queue.enqueue(2)
+
+    expect(queue.dequeue()).toBe(1)
+    expect(queue.dequeue()).toBe(2)
+    expect(queue.dequeue()).toBe(3)
+    expect(queue.dequeue()).toBe(4)
+    expect(queue.isEmpty()).toBe(true)
+  })
+
+  it("should work with custom comparator", () => {
+    const maxHeap = new PriorityQueue<number>((a, b) => b - a)
+    maxHeap.enqueue(1)
+    maxHeap.enqueue(3)
+    maxHeap.enqueue(2)
+
+    expect(maxHeap.dequeue()).toBe(3)
+    expect(maxHeap.dequeue()).toBe(2)
+    expect(maxHeap.dequeue()).toBe(1)
+  })
+
+  it("should throw error when peeking empty queue", () => {
+    const queue = createNumberQueue()
+    expect(() => queue.peek()).toThrow("PriorityQueue is empty")
+  })
+
+  it("should throw error when dequeuing empty queue", () => {
+    const queue = createNumberQueue()
+    expect(() => queue.dequeue()).toThrow("PriorityQueue is empty")
+  })
+
+  it("should handle objects with custom comparator", () => {
+    interface Task {
+      priority: number
+      name: string
+    }
+
+    const taskQueue = new PriorityQueue<Task>((a, b) => a.priority - b.priority)
+
+    taskQueue.enqueue({ priority: 3, name: "Low" })
+    taskQueue.enqueue({ priority: 1, name: "High" })
+    taskQueue.enqueue({ priority: 2, name: "Medium" })
+
+    expect(taskQueue.dequeue().name).toBe("High")
+    expect(taskQueue.dequeue().name).toBe("Medium")
+    expect(taskQueue.dequeue().name).toBe("Low")
+  })
+
+  it("should maintain heap property after multiple operations", () => {
+    const queue = createNumberQueue()
+    const numbers = [5, 2, 8, 1, 9, 3, 7, 4, 6]
+
+    for (const n of numbers) {
+      queue.enqueue(n)
+    }
+    const sorted = []
+    while (!queue.isEmpty()) {
+      sorted.push(queue.dequeue())
+    }
+
+    expect(sorted).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+})

--- a/src/utils/priorityQueue.ts
+++ b/src/utils/priorityQueue.ts
@@ -1,0 +1,118 @@
+import { assert } from "./assert"
+
+type Comparator<T> = (a: T, b: T) => number
+
+export class PriorityQueue<T> {
+  private heap: T[]
+  private comparator: Comparator<T>
+
+  constructor(comparator: Comparator<T>) {
+    this.heap = []
+    this.comparator = comparator
+  }
+
+  isEmpty(): boolean {
+    return this.heap.length === 0
+  }
+
+  size(): number {
+    return this.heap.length
+  }
+
+  clear(): void {
+    this.heap = []
+  }
+
+  peek(): T {
+    if (this.isEmpty()) {
+      throw new Error("PriorityQueue is empty")
+    }
+    const top = this.heap[0]
+    assert(top !== undefined)
+    return top
+  }
+
+  enqueue(item: T): void {
+    this.heap.push(item)
+    this.bubbleUp()
+  }
+
+  dequeue(): T {
+    if (this.isEmpty()) {
+      throw new Error("PriorityQueue is empty")
+    }
+    const top = this.heap[0]
+    assert(top !== undefined)
+    const bottom = this.heap.pop()
+    if (this.heap.length > 0 && bottom !== undefined) {
+      this.heap[0] = bottom
+      this.bubbleDown()
+    }
+    return top
+  }
+
+  private bubbleUp(): void {
+    let index = this.heap.length - 1
+    const item = this.heap[index]
+    assert(item !== undefined)
+
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2)
+      const parent = this.heap[parentIndex]
+      assert(parent !== undefined)
+
+      if (this.comparator(item, parent) >= 0) break
+
+      this.heap[index] = parent
+      index = parentIndex
+    }
+
+    this.heap[index] = item
+  }
+
+  private bubbleDown(): void {
+    let index = 0
+    const length = this.heap.length
+    const item = this.heap[index]
+    assert(item !== undefined)
+
+    let leftChild: T | undefined
+    let rightChild: T | undefined
+
+    while (true) {
+      const leftChildIndex = 2 * index + 1
+      const rightChildIndex = 2 * index + 2
+      let swapIndex = -1
+
+      if (leftChildIndex < length) {
+        leftChild = this.heap[leftChildIndex]
+        assert(leftChild !== undefined)
+
+        if (this.comparator(leftChild, item) < 0) {
+          swapIndex = leftChildIndex
+        }
+      }
+
+      if (rightChildIndex < length) {
+        rightChild = this.heap[rightChildIndex]
+        assert(rightChild !== undefined)
+        assert(leftChild !== undefined)
+
+        if (
+          (this.comparator(rightChild, item) < 0 && swapIndex === -1) ||
+          (swapIndex !== -1 && this.comparator(rightChild, leftChild) < 0)
+        ) {
+          swapIndex = rightChildIndex
+        }
+      }
+
+      if (swapIndex === -1) break
+
+      // biome-ignore lint/style/noNonNullAssertion: `swapIndex` is within bounds
+      this.heap[index] = this.heap[swapIndex]!
+      index = swapIndex
+    }
+
+    this.heap[index] = item
+  }
+}


### PR DESCRIPTION
How the best quote used to be determined:
1. We set initial quote
2. User starts signing a message with amount out from the initial quote
3. All coming quotes are compared to the initial quote: if a new one is better, then choose it
4. User finishes singing
5. Publish intent

It's straight forward approach, we store only two quotes.

Slippage introduces complexity and we can't do the same. Because we may end up with worse rates for the user.
Instead, we need to store all new quotes and at the moment of publishing the intent, we select the best quote.
So new flow will be:
1. (same) We set initial quote
2. (same) User starts signing a message with amount out from the initial quote
3. All coming quotes are compared to the initial quote adjusted to slippage: if a new one within slippage, then we store it in the queue, otherwise we discard it (as it is useless and we can't use it at all)
4. (same) User finishes singing
5. Choose the best quote from the queue that is valid for next 10 seconds
6. (same) Publish intent