### PR TITLE
feat: add optimistic balance updates

### DIFF
--- a/src/features/machines/depositedBalanceMachine.test.ts
+++ b/src/features/machines/depositedBalanceMachine.test.ts
@@ -12,8 +12,8 @@ import type { ParentActor } from "./depositedBalanceMachine"
 
 describe("depositedBalanceMachine", () => {
   const defaultActorImpls = {
-    fetchBalanceActor: vi.fn(async ({ parentRef }) => {
-      parentRef.send({
+    fetchBalanceActor: vi.fn(async ({ self }) => {
+      self.send({
         type: "UPDATE_BALANCE_SLICE",
         params: {
           balanceSlice: {

--- a/src/features/machines/depositedBalanceMachine.test.ts
+++ b/src/features/machines/depositedBalanceMachine.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  type Snapshot,
+  type StateValue,
+  createActor,
+  fromPromise,
+  getNextSnapshot,
+} from "xstate"
+import { prepareOptimisticBalanceUpdate } from "./depositedBalanceMachine"
+import { depositedBalanceMachine } from "./depositedBalanceMachine"
+import type { ParentActor } from "./depositedBalanceMachine"
+
+describe("depositedBalanceMachine", () => {
+  const defaultActorImpls = {
+    fetchBalanceActor: vi.fn(async ({ parentRef }) => {
+      parentRef.send({
+        type: "UPDATE_BALANCE_SLICE",
+        params: {
+          balanceSlice: {
+            BTC: 0n,
+            NEAR: 0n,
+            USDT: 0n,
+          },
+          transitBalanceSlice: {
+            BTC: 10000n,
+            NEAR: 0n,
+            USDT: 0n,
+          },
+        },
+      })
+      return true
+    }),
+  }
+
+  const defaultActors = {
+    fetchBalanceActor: fromPromise(defaultActorImpls.fetchBalanceActor),
+  }
+
+  const defaultParentRef = {
+    id: "mockParentActor",
+    getSnapshot: () =>
+      ({ value: {}, context: {} }) as unknown as Snapshot<unknown>,
+  } as ParentActor
+
+  const defaultContext = {
+    parentRef: defaultParentRef,
+    optimisticBalancesEnabled: true,
+    userAccountId: "Alice",
+    defuseTokenIds: ["BTC", "NEAR", "USDT"],
+  }
+
+  let actors: typeof defaultActors
+
+  function populateMachine() {
+    // @ts-expect-error
+    return depositedBalanceMachine.provide({ actors })
+  }
+
+  function interpret() {
+    return createActor(populateMachine(), {
+      input: {
+        parentRef: defaultParentRef,
+        tokenList: [],
+      },
+    })
+  }
+
+  beforeEach(() => {
+    actors = { ...defaultActors }
+  })
+
+  it.each`
+    expectedState                         | event                        | guards  | context
+    ${"authenticated.refreshing balance"} | ${"REQUEST_BALANCE_REFRESH"} | ${null} | ${null}
+  `(
+    'should reach "$expectedState" when the "$event" event occurs',
+    ({ expectedState, event, context }) => {
+      const machine = populateMachine()
+
+      const actualState = getNextSnapshot(
+        machine,
+        machine.resolveState({
+          value: parseDotNotation(expectedState) as StateValue,
+          context: context ?? defaultContext,
+        }),
+        {
+          type: event,
+        }
+      )
+
+      expect(actualState.matches(expectedState)).toBeTruthy()
+    }
+  )
+
+  it("should start in the unauthenticated state", () => {
+    const service = interpret().start()
+    expect(service.getSnapshot().value).toEqual("unauthenticated")
+  })
+
+  it("should transition to the authenticated state when the user is logged in", () => {
+    const service = interpret().start()
+    service.send({
+      type: "LOGIN",
+      params: { userAddress: "Alice", userChainType: "near" },
+    })
+    expect(service.getSnapshot().value).toEqual({
+      authenticated: "refreshing balance",
+    })
+  })
+
+  it("should transition to the unauthenticated state when the user is logged out", () => {
+    const service = interpret().start()
+    service.send({ type: "LOGOUT" })
+    expect(service.getSnapshot().value).toEqual("unauthenticated")
+  })
+
+  it("should have equal balances updates are enabled, the balances should be updated immediately after the intent is submitted", () => {})
+})
+
+describe("prepareOptimisticBalanceUpdate", () => {
+  it("should prepare correctly output with no onchain balances", () => {
+    const onchainBalances = {
+      BTC: 0n,
+      NEAR: 0n,
+      USDT: 0n,
+    }
+    const transitBalanceSlice = {
+      BTC: 10000n,
+      NEAR: 0n,
+      USDT: 0n,
+    }
+    // Swap 0.0001 BTC to 3 NEAR
+    const pendingDeltaBalance = {
+      BTC: -10000n,
+      NEAR: 3000000000000000000000000n,
+    }
+    const optimisticBalanceChanged = prepareOptimisticBalanceUpdate({
+      onchainBalances,
+      transitBalanceChanged: transitBalanceSlice,
+      pendingDeltaBalance,
+    })
+
+    expect(optimisticBalanceChanged).toEqual({
+      BTC: 0n,
+      NEAR: 3000000000000000000000000n,
+      USDT: 0n,
+    })
+  })
+
+  it("should prepare correct output withing several delta updates", () => {
+    const onchainBalances = {
+      BTC: 5000n,
+      NEAR: 0n,
+      USDT: 0n,
+    }
+    const transitBalanceSlice = {
+      BTC: 5000n,
+      NEAR: 0n,
+      USDT: 0n,
+    }
+    // Swap half of 0.0001 BTC to 1.5 NEAR and the other half to 0.5 USDT
+    const pendingDeltaBalance = {
+      BTC: -10000n,
+      NEAR: 1500000000000000000000000n,
+      USDT: 50000n,
+    }
+    const optimisticBalanceChanged = prepareOptimisticBalanceUpdate({
+      onchainBalances,
+      transitBalanceChanged: transitBalanceSlice,
+      pendingDeltaBalance,
+    })
+
+    expect(optimisticBalanceChanged).toEqual({
+      BTC: 0n,
+      NEAR: 1500000000000000000000000n,
+      USDT: 50000n,
+    })
+  })
+})
+
+/**
+ * This helper function to parse state paths in dot notation ("a.b.c" = {a: {b: c}})
+ */
+function parseDotNotation(str: string): object | string {
+  const keys = str.split(".")
+  const lastKey = keys.pop()
+
+  if (lastKey === undefined) {
+    throw new Error("lastKey is undefined")
+  }
+
+  return keys.reduceRight<string | object>((acc, key) => {
+    return { [key]: acc }
+  }, lastKey)
+}

--- a/src/features/machines/depositedBalanceMachine.ts
+++ b/src/features/machines/depositedBalanceMachine.ts
@@ -1,5 +1,6 @@
 import { providers } from "near-api-js"
 import { settings } from "src/config/settings"
+import { logger } from "src/logger"
 import {
   type ActorRef,
   type Snapshot,
@@ -35,7 +36,7 @@ type ParentReceivedEvents = {
     changedTransitBalanceMapping: BalanceMapping
   }
 }
-type ParentActor = ActorRef<Snapshot<unknown>, ParentReceivedEvents>
+export type ParentActor = ActorRef<Snapshot<unknown>, ParentReceivedEvents>
 
 type SharedEvents = {
   type: "UPDATE_BALANCE_SLICE"
@@ -84,6 +85,7 @@ export const depositedBalanceMachine = setup({
       onchainBalances: BalanceMapping
       transitBalances: BalanceMapping
       pendingDeltaBalances: BalanceMapping
+      optimisticBalancesEnabled: boolean
     },
     events: {} as Events | SharedEvents,
     input: {} as Input,
@@ -163,7 +165,7 @@ export const depositedBalanceMachine = setup({
           ...balanceChanged,
         }
 
-        if (settings.optimisticBalanceUpdates) {
+        if (context.optimisticBalancesEnabled) {
           optimisticBalanceChanged = prepareOptimisticBalanceUpdate({
             onchainBalances: onchainBalanceChanged,
             transitBalanceChanged,
@@ -171,7 +173,7 @@ export const depositedBalanceMachine = setup({
           })
         }
 
-        const balances = settings.optimisticBalanceUpdates
+        const balances = context.optimisticBalancesEnabled
           ? optimisticBalanceChanged
           : { ...context.onchainBalances, ...balanceChanged }
 
@@ -214,6 +216,9 @@ export const depositedBalanceMachine = setup({
         return context.pendingDeltaBalances
       },
     }),
+    logError: (_, params: { error: unknown }) => {
+      logger.error(params.error)
+    },
   },
   guards: {
     // TODO: Either use this guard or remove it
@@ -227,7 +232,7 @@ export const depositedBalanceMachine = setup({
     },
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBdICEBDAG0IDsBjMAYgBkB5AcQEkA5AbQAYBdRUDbDizoyfEAA9EAWgCMAZk4A6AOwBOAKwyALJ1UA2ZXLnqANCACe0mQA45ivda2G9WgExyt15VoC+PsygCuAQk5FSKhACuOAAWYGRCFIR4EHRM9ACqACpcvEggQUIiYpIIssaKqsq6Mhqunpw2ymaWZR4qWnWOnHKunH3WfgFomMEQRKSUYBHRcQlYSSnUAEoAogCKGasAylkA+vgAgrSHrADCq3trAGJr2wASuWKFwqL5pTKainK2ejI2tXUyiBrhaVj0dh+7lc6nqnGsek4vn8IECoxSEzC0yisXiiWSkEUACcwAAzEmwGJYMhQAAEACNQlNqBARNNqQA3dAAa2mpLAOAoMUxU2WZKe+RexXeiH+qkU6ms1iRCmqcj0MK0YIQf0UjS06us6gN3j0qkGKLRghCk3COLm+JSxLJFKpNIZTKo1AyAAUACKHLKXI4nc6Xba0ZgXCX8dGvEqIWEyFSfGR-VxqWFG7VSAyKBEyJHKQvGLTqPRDVEja3jT3Y2Z4hYEiCKLAQYg0cSwHAEiKkvBEgAU6k4o4AlCzq2MRXaG-NFoS2x2YwU49LQKUPMmtNoNRDNY5QRZELr9YbjXJTea-CiyOgUPB8lbp3Xnmu3hvpD8lOpVB4EUq1R6C4OZGNY3zWO4qZKoWqiuBWlpThidaKJEZD2o2C4QG+gjxjKbS9Aqf6eA4XicMBWrHggSgaD0Zb6B4nDeEaFrDIUNpYjMuLzs2OG4Hhn46nYGh6OomguMoaiuNoOYwkoSrQv02ieJ4riVs+yG2vW3GOoSJLknAbp0oyWl8UUH4SLK-yVOWYlpk4UkyVRubgUqciAvBMIaloyJseiHFTFxDpNk6S5gGZAmWQgrjWMmnC-jFiJKgaRiUa08h2BCqiqJ0kHGuoqo3j4QA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBdICEBDAG0IDsBjMAYgBkB5AcQEkA5AbQAYBdRUDbDizoyfEAA9EAWgCMAZk4A6AOwBOAKwyALDM4A2PQCYAHOsMAaEAE9pM1XMWGDyrZ1VGty43vUBfX5YoArgEJORUioQArjgAFmBkQhSEeBB0TPQAqgAqXLxIIMFCImKSCLJy6oqqym52ZlrGnHaWNuWViuqchmqGJjIDcjp+ASBBmCEQRKSUYJEx8YlYyanUAEoAogCKmRsAytkA+vgAgrQnrADCG4ebAGKbewASeWJFwqIFZTKaipxahi0qhkxh+NWMWlatmMyk6jVUTnU9ns8j0-kCaAmqWm4Tm0TiCSSKUgigATmAAGbk2CxLBkKAAAgARmFZtQICI5nSAG7oADWcwpYBwFFiONma0prwK7xKX0QIIcehqXTkgJkhhq+ihCHs1XU8LkCMMXR0MnRY0xglCMwi+MWRNSZMp1Np9OZrKo1DApNJ6FJilQpBwFP9AFtFEKRWLPWBJRTpfwsR9SgqIYo5D5NPZujo+sYdfIlEMDXplJp-vpGhbxtaprH5gSlisSeSqXA3YyWbaaJkAAoAERO2Rup3OVxue1ozGuicKybloDKWj0xgzakzRlUxk1oJ1shhcOMCJ8yLkqJrVsm4rtC0Jy2JEEUWAgxBo4lgOGJkQpeFJAApdE4YCAEp2SvbEG3te8WyfF83znWVPiXRAzFURRdCRYDDAGbRlD0QtYVqJF1DUMtjG8TM5H8UYyHQFB4AKWtr1jN4F2QiRpDkZQZE6dR+Nqew5Ao9RKn3TNDCPBFjCNY9lHkkYMSKG1cUUKIyGg5tHzYwQU3ldpDAcfiBLcORhNMMTrGkVQlBwzw7AUIY9BkNRL2U+se0bB0H1SHTcD0lCED0BwNCzGQ9E8XptH3Hoqn+Y8eiBCKDX4tysRU2YvJgx9nXbGk6S7ViZXY1MEFw-Uwoi+SEWiqzylXRQKPPDQnBNDwtDSusbzxO8tKdeCwD84oOLKA10Ii3R5NMA0NWUQsjUUYKfAirRVpSiiaN8IA */
   id: "depositedBalance",
 
   initial: "unauthenticated",
@@ -245,6 +250,7 @@ export const depositedBalanceMachine = setup({
           ? [token.defuseAssetId]
           : token.groupedTokens.map((t) => t.defuseAssetId)
       }),
+      optimisticBalancesEnabled: settings.optimisticBalanceUpdates,
     }
   },
 
@@ -268,7 +274,24 @@ export const depositedBalanceMachine = setup({
               }
             },
             onDone: "idle",
-            // todo: handle error
+            onError: {
+              target: "idle",
+
+              actions: [
+                {
+                  type: "logError",
+                  params: (error) => {
+                    // biome-ignore lint/suspicious/noConsole: <explanation>
+                    console.log("Error in fetch balance>>>>", error)
+                    return {
+                      error: new Error("Error in fetch balance"),
+                    }
+                  },
+                },
+              ],
+
+              reenter: true,
+            },
           },
 
           on: {
@@ -333,7 +356,7 @@ export const depositedBalanceMachine = setup({
   },
 })
 
-function prepareOptimisticBalanceUpdate({
+export function prepareOptimisticBalanceUpdate({
   onchainBalances,
   transitBalanceChanged,
   pendingDeltaBalance,

--- a/src/features/machines/depositedBalanceMachine.ts
+++ b/src/features/machines/depositedBalanceMachine.ts
@@ -46,8 +46,16 @@ type SharedEvents = {
 type ThisActor = ActorRef<Snapshot<unknown>, SharedEvents>
 
 export type Events =
-  | { type: "LOGOUT" | "REQUEST_BALANCE_REFRESH" }
+  | {
+      type: "LOGOUT"
+    }
   | { type: "LOGIN"; params: { userAddress: string; userChainType: ChainType } }
+  | {
+      type: "REQUEST_BALANCE_REFRESH"
+      // With optimistic balances enabled, we might have pending deltas
+      // that we need to take into token balance calculation
+      params?: { pendingDeltaBalance: BalanceMapping }
+    }
 
 export const depositedBalanceMachine = setup({
   types: {
@@ -55,8 +63,10 @@ export const depositedBalanceMachine = setup({
       parentRef: ParentActor
       defuseTokenIds: string[]
       userAccountId: DefuseUserId | null
+      // TODO rename balances to onchainBalances
       balances: BalanceMapping
       transitBalances: BalanceMapping
+      optimisticBalances: BalanceMapping
     },
     events: {} as Events | SharedEvents,
     input: {} as Input,
@@ -184,6 +194,7 @@ export const depositedBalanceMachine = setup({
           ? [token.defuseAssetId]
           : token.groupedTokens.map((t) => t.defuseAssetId)
       }),
+      optimisticBalances: {},
     }
   },
 

--- a/src/features/machines/depositedBalanceMachine.ts
+++ b/src/features/machines/depositedBalanceMachine.ts
@@ -280,9 +280,7 @@ export const depositedBalanceMachine = setup({
               actions: [
                 {
                   type: "logError",
-                  params: (error) => {
-                    // biome-ignore lint/suspicious/noConsole: <explanation>
-                    console.log("Error in fetch balance>>>>", error)
+                  params: () => {
                     return {
                       error: new Error("Error in fetch balance"),
                     }

--- a/src/features/machines/depositedBalanceMachine.ts
+++ b/src/features/machines/depositedBalanceMachine.ts
@@ -53,9 +53,25 @@ export type Events =
   | {
       type: "REQUEST_BALANCE_REFRESH"
       // With optimistic balances enabled, we might have pending deltas
-      // that we need to take into token balance calculation
       params?: { pendingDeltaBalance: BalanceMapping }
     }
+
+/**
+ * @note context.balances - might be either on chain balances or optimistic balances
+ * Optimistic balances are the sum of on chain balances, transit balances (in-flight), and pending delta balances (initiated intents in intent pool)
+ *
+ * Example:
+ * - User has 0 USDC on chain
+ * - User has 100 USDC in transit
+ * - User swaps 100 USDC to 20 NEAR (20 NEAR added to pending delta balance at pool)
+ *
+ * - onchainBalances: { "USDC": 0n, "NEAR": 0n }
+ * - transitBalances: { "USDC": 100n, "NEAR": 0n }
+ * - pendingDeltaBalances: { "USDC": -100n, "NEAR": +20n }
+ *
+ * Resulting balances:
+ * - balances: { "USDC": 0n +100n -100n, "NEAR": 0n +0n +20n }
+ */
 
 export const depositedBalanceMachine = setup({
   types: {
@@ -63,10 +79,10 @@ export const depositedBalanceMachine = setup({
       parentRef: ParentActor
       defuseTokenIds: string[]
       userAccountId: DefuseUserId | null
-      // TODO rename balances to onchainBalances
       balances: BalanceMapping
+      onchainBalances: BalanceMapping
       transitBalances: BalanceMapping
-      optimisticBalances: BalanceMapping
+      pendingDeltaBalances: BalanceMapping
     },
     events: {} as Events | SharedEvents,
     input: {} as Input,
@@ -188,6 +204,8 @@ export const depositedBalanceMachine = setup({
       userAccountId: null,
       balances: {},
       transitBalances: {},
+      onchainBalances: {},
+      pendingDeltaBalances: {},
       parentRef: input.parentRef,
       defuseTokenIds: input.tokenList.flatMap((token) => {
         return isBaseToken(token)

--- a/src/features/machines/depositedBalanceMachine.ts
+++ b/src/features/machines/depositedBalanceMachine.ts
@@ -1,4 +1,5 @@
 import { providers } from "near-api-js"
+import { settings } from "src/config/settings"
 import {
   type ActorRef,
   type Snapshot,
@@ -138,10 +139,12 @@ export const depositedBalanceMachine = setup({
         params: {
           balanceSlice: BalanceMapping
           transitBalanceSlice: BalanceMapping
+          pendingDeltaBalance: BalanceMapping
         }
       ) => {
         const balanceChanged: BalanceMapping = {}
         const transitBalanceChanged: BalanceMapping = {}
+        let optimisticBalanceChanged: BalanceMapping = {}
 
         for (const [key, val] of Object.entries(params.balanceSlice)) {
           if (context.balances[key] !== val) {
@@ -155,14 +158,33 @@ export const depositedBalanceMachine = setup({
           }
         }
 
+        const onchainBalanceChanged = {
+          ...context.onchainBalances,
+          ...balanceChanged,
+        }
+
+        if (settings.optimisticBalanceUpdates) {
+          optimisticBalanceChanged = prepareOptimisticBalanceUpdate({
+            onchainBalances: onchainBalanceChanged,
+            transitBalanceChanged,
+            pendingDeltaBalance: params.pendingDeltaBalance,
+          })
+        }
+
+        const balances = settings.optimisticBalanceUpdates
+          ? optimisticBalanceChanged
+          : { ...context.onchainBalances, ...balanceChanged }
+
         if (
           Object.keys(balanceChanged).length > 0 ||
           Object.keys(transitBalanceChanged).length > 0
         ) {
           // First update the local state
           enqueue.assign({
-            balances: () => ({ ...context.balances, ...balanceChanged }),
+            balances,
             transitBalances: transitBalanceChanged,
+            onchainBalances: onchainBalanceChanged,
+            pendingDeltaBalances: params.pendingDeltaBalance,
           })
           // Then send the event to the parent
           enqueue(({ context }) => {
@@ -180,6 +202,17 @@ export const depositedBalanceMachine = setup({
     clearBalance: assign({
       balances: {},
       transitBalances: {},
+    }),
+    setPendingDeltaBalances: assign({
+      pendingDeltaBalances: ({ context, event }) => {
+        if (
+          event.type === "REQUEST_BALANCE_REFRESH" &&
+          event.params?.pendingDeltaBalance
+        ) {
+          return event.params.pendingDeltaBalance
+        }
+        return context.pendingDeltaBalances
+      },
     }),
   },
   guards: {
@@ -212,7 +245,6 @@ export const depositedBalanceMachine = setup({
           ? [token.defuseAssetId]
           : token.groupedTokens.map((t) => t.defuseAssetId)
       }),
-      optimisticBalances: {},
     }
   },
 
@@ -244,9 +276,10 @@ export const depositedBalanceMachine = setup({
               target: "refreshing balance",
               actions: {
                 type: "updateBalance",
-                params: ({ event }) => ({
+                params: ({ context, event }) => ({
                   balanceSlice: event.params.balanceSlice,
                   transitBalanceSlice: event.params.transitBalanceSlice,
+                  pendingDeltaBalance: context.pendingDeltaBalances,
                 }),
               },
             },
@@ -269,6 +302,12 @@ export const depositedBalanceMachine = setup({
 
         REQUEST_BALANCE_REFRESH: {
           target: ".refreshing balance",
+          actions: [
+            {
+              type: "setPendingDeltaBalances",
+              params: ({ event }) => event,
+            },
+          ],
           reenter: true,
         },
       },
@@ -293,3 +332,24 @@ export const depositedBalanceMachine = setup({
     },
   },
 })
+
+function prepareOptimisticBalanceUpdate({
+  onchainBalances,
+  transitBalanceChanged,
+  pendingDeltaBalance,
+}: {
+  onchainBalances: BalanceMapping
+  transitBalanceChanged: BalanceMapping
+  pendingDeltaBalance: BalanceMapping
+}): BalanceMapping {
+  const optimisticBalanceChanged: BalanceMapping = {}
+
+  for (const [key, val] of Object.entries(onchainBalances)) {
+    optimisticBalanceChanged[key] =
+      val +
+      (transitBalanceChanged[key] || 0n) +
+      (pendingDeltaBalance[key] || 0n)
+  }
+
+  return optimisticBalanceChanged
+}

--- a/src/features/machines/intentPoolMachine.ts
+++ b/src/features/machines/intentPoolMachine.ts
@@ -16,6 +16,7 @@ import type { ChainType } from "../../types/deposit"
 import type { WalletMessage, WalletSignatureResult } from "../../types/swap"
 import { assert } from "../../utils/assert"
 import type { DefuseUserId } from "../../utils/defuse"
+import { getPendingDeltaBalances, isOptimisticIntent } from "../../utils/pool"
 import type { PriorityQueue } from "../../utils/priorityQueue"
 import type { QuoteInput } from "./backgroundQuoterMachine"
 import type { ParentEvents as BackgroundQuoterEvents } from "./backgroundQuoterMachine"
@@ -74,7 +75,7 @@ type PassthroughEvent = {
   }
 }
 
-type Intent = {
+export type Intent = {
   userAddress: string
   userChainType: ChainType
   defuseUserId: DefuseUserId
@@ -127,9 +128,38 @@ export const intentPoolMachine = setup({
         },
       })
 
+      const quoteToPublish = event.params.quoteToPublish
+      assert(
+        quoteToPublish !== null && quoteToPublish.tokenDeltas.length > 0,
+        "quoteToPublish is null"
+      )
+      const tokenDeltaIn = quoteToPublish.tokenDeltas[0]
+      assert(tokenDeltaIn !== undefined, "tokenDeltaIn is undefined")
+      assert(
+        context.depositedBalanceRef !== null,
+        "depositedBalanceRef is null"
+      )
+
+      const intentRefs = [intentRef, ...context.intentRefs]
+      const pool = new Map([[`intent-${id}`, event.params], ...context.pool])
+
+      const isOptimistic = isOptimisticIntent(
+        tokenDeltaIn,
+        context.depositedBalanceRef.getSnapshot().context.onchainBalances
+      )
+      if (isOptimistic) {
+        const pendingDeltaBalance = getPendingDeltaBalances(intentRefs, pool)
+        context.depositedBalanceRef.send({
+          type: "REQUEST_BALANCE_REFRESH",
+          params: {
+            pendingDeltaBalance,
+          },
+        })
+      }
+
       return {
-        intentRefs: [intentRef, ...context.intentRefs],
-        pool: new Map([[`intent-${id}`, event.params]]),
+        intentRefs,
+        pool,
       }
     }),
     setExecutingIntentRef: assign({
@@ -141,7 +171,7 @@ export const intentPoolMachine = setup({
         return findExecutableIntentRef(
           context.intentRefs,
           context.pool,
-          context.depositedBalanceRef.getSnapshot().context.balances
+          context.depositedBalanceRef.getSnapshot().context.onchainBalances
         )
       },
     }),
@@ -210,10 +240,18 @@ export const intentPoolMachine = setup({
     }),
     passthroughEventAndRefreshBalances: emit(
       ({ context }, event: PassthroughEvent) => {
-        context.depositedBalanceRef?.send({
+        assert(
+          context.depositedBalanceRef !== null,
+          "depositedBalanceRef is null"
+        )
+        const pendingDeltaBalance = getPendingDeltaBalances(
+          context.intentRefs,
+          context.pool
+        )
+        context.depositedBalanceRef.send({
           type: "REQUEST_BALANCE_REFRESH",
           params: {
-            pendingDeltaBalance: {},
+            pendingDeltaBalance,
           },
         })
         return event
@@ -226,8 +264,8 @@ export const intentPoolMachine = setup({
         const { value } = intentRef.getSnapshot()
         return value === "pending"
       }),
-    hasExecutingIntent: ({ context }) => context.executingIntentRef !== null,
     hasCheckingIntent: ({ context }) => context.checkingIntentRef !== null,
+    hasExecutingIntent: ({ context }) => context.executingIntentRef !== null,
     isOk: (_, a: { tag: "err" | "ok" }) => a.tag === "ok",
   },
 }).createMachine({

--- a/src/features/machines/intentPoolMachine.ts
+++ b/src/features/machines/intentPoolMachine.ts
@@ -4,6 +4,7 @@ import {
   type ActorRefFrom,
   type Snapshot,
   assign,
+  emit,
   setup,
 } from "xstate"
 import { findExecutableIntentRef } from "../../services/poolService"
@@ -41,10 +42,12 @@ type Context = {
   pool: Map<string, Intent>
   executingIntentRef: string | null
   checkingIntentRef: string | null
+  depositedBalanceRef: ActorRefFrom<typeof depositedBalanceMachine> | null
 }
 
 type Input = {
   parentRef: ParentActor
+  depositedBalanceRef: ActorRefFrom<typeof depositedBalanceMachine> | null
 }
 
 type ParentReceivedEvents = {
@@ -131,14 +134,14 @@ export const intentPoolMachine = setup({
     }),
     setExecutingIntentRef: assign({
       executingIntentRef: ({ context }) => {
-        const snapshot = context.parentRef.getSnapshot()
-        const balances =
-          // @ts-ignore - The parent ref's context type is not properly inferred by TypeScript
-          snapshot.context.depositedBalanceRef.getSnapshot().context.balances
+        assert(
+          context.depositedBalanceRef !== null,
+          "depositedBalanceRef is null"
+        )
         return findExecutableIntentRef(
           context.intentRefs,
           context.pool,
-          balances
+          context.depositedBalanceRef.getSnapshot().context.balances
         )
       },
     }),
@@ -154,32 +157,6 @@ export const intentPoolMachine = setup({
     }),
     clearCheckingIntentRef: assign({
       checkingIntentRef: null,
-    }),
-    spawnIntentStatusAndReplaceActor: assign({
-      intentRefs: (
-        { context, spawn },
-        output: { tag: "ok"; value: { intentHash: string } }
-      ) => {
-        if (output?.tag === "ok" && output?.value?.intentHash) {
-          assert(
-            context.checkingIntentRef !== null,
-            "checkingIntentRef is null"
-          )
-          return context.intentRefs.map((intentRef) => {
-            if (intentRef.id === context.checkingIntentRef) {
-              return spawn("intentStatusActor", {
-                id: intentRef.id,
-                input: {
-                  ...intentRef.getSnapshot().context,
-                  intentHash: output.value.intentHash,
-                },
-              })
-            }
-            return intentRef
-          })
-        }
-        return context.intentRefs
-      },
     }),
     sendIntentStatusRefIntentHash: assign({
       intentRefs: ({ context }) => {
@@ -231,6 +208,17 @@ export const intentPoolMachine = setup({
         ])
       },
     }),
+    passthroughEventAndRefreshBalances: emit(
+      ({ context }, event: PassthroughEvent) => {
+        context.depositedBalanceRef?.send({
+          type: "REQUEST_BALANCE_REFRESH",
+          params: {
+            pendingDeltaBalance: {},
+          },
+        })
+        return event
+      }
+    ),
   },
   guards: {
     hasUnexecutedIntents: ({ context }) =>
@@ -243,7 +231,7 @@ export const intentPoolMachine = setup({
     isOk: (_, a: { tag: "err" | "ok" }) => a.tag === "ok",
   },
 }).createMachine({
-  /** @xstate-layout N4IgpgJg5mDOIC5QEsB2AXMGC0AHA9vgDYDEAggCIUD6AkgHIAqAokwNoAMAuoqAbMnTJ8qXiAAeibAEYAbABYAdAE4O0gKwAOAEzS9AZnnz1AdgA0IAJ5T5mlZs3SOp-bM3r1ykwF9vFtJg4BMQk9MwA6tQAigCqAPIsnDxIIPyCwqIpkggGirLKmibark756tqaFtYI2LpKmsrlhaby2vLSPn4gAVjoeIREigCOAK5gY2hQJEliaUIiYtnqHYr6Jhya+lvyJtI6+lWIerKK0vqO6hxb5wWavv4Yvf3Ew2MTqFNs0sl8+ALzmVAS2kShM6nk+g2HFarX06kOCG04JUtnyHW0G3a0nu3UeQQGr3GYEmJHEsHQAENMIoKQAzTAAJwAFJcOABKEg9fEvUZEyYzFJzDKLI5yRRggrSZS3cFS+FWI6KYzaRrOZT6JHSbQmToPQJ9YKDXAjABGRGQsAAFiSICIwIo0AA3fAAa3tXPQACEGfgKRAAMYU8kAJTAtIFv3+wqyR3Kik0siRbkTmnajlkCP06qVW2U8mU2gxhYqutx+ueRtN5qtNrtDtQzrd9f13t9AaD6FD4e+sz+6QWMZqhfUimWDg0JmUxyc8uq7SUe0TIJ0862OI9FcUxrNFutHxIYAZPoZW6IVNp+AZAFtm71W37AyGwxHUn2ASKanITCoNY4ZSZ8w1BFimkRRiy1ZYCizaVSw3Q1FEdQ9kFpSwSRfIUByBRBNjsbU9DUHRlFkADKgVREITAvMOGcSEMTUToulQfAIDgMQ4IGXso0wiQpG1fRRz2C5J2nZwERkVwlXHM4zhVXQ9HXPEDQJZAICIMBOP7QEeIQVRtFObRZEuWwkTzaQES1fiANheQ1GI4iEwU8t4N5d4oA099BxkBwwN0BoFDk2RXG0BFVFWcd80M1MdQAxynng7dqz3NzBTfaMsJyDhvxsvMilM2Q9mUYCVVOAo0WhcE6PUWLuUGRCGWQ1CPnctLtJMVMwP0KVVEC2wszMsi01WQL8sLIj1EC9R9F8XwgA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QEsB2AXMGC0AHA9vgDYDEAggCIUD6AkgHIAqAokwNoAMAuoqAbMnTJ8qXiAAeibAEYAbABYAdAE4O0gKwAOAEzS9AZnnz1AdgA0IAJ5T5mlZs3SOp-bM3r1ykwF9vFtJg4BMQkDCxM1ADKzIyMADLMFJw8SCD8gsKiqZII+g6K8iYmyqpyhcqyyhbWCNja8rKK0sra6hwmeZry2tpuvv4YWOh4hKT0zADq1ACKAKoA8izJYulCImI5BoomHEYmmrJuJrJymtVSPfqKup7yhsX6Tsb9IAFDI8SKAI4ArmB-aCgJGWqVWmQ2iHU0hMin0O00+kRhWkOn05wQeka0jyGg4iLyygcLzeQVG3z+ANQQLY0hSfHwAjWWVAOShShM6juHE0u3q2n06nRrSUylslWh2m58j0xMGpM+v3+YEBJHEsHQAENMIoNQAzTAAJwAFG0OABKEgk4bBIjkpWAkH0xng7KITHbTyOEoOTnNQVWN0FdTaZRtTz6VrSbRFWWBa1k3A-ABGRGQsAAFiqICIwIo0AA3fAAa1zVoAQgb8BqIABjDXqgBKYF1jrSDIy61dGODigOrTcsm0XRRcnR+mUVzu4-kLUlPSHPj8rzl8c+iZTaczVJI2dQpdQhZLeZXFartfr6CbLdpK3bTIhtR66kUUIcGmKmKc-pq0qUKMH0i2PUgGIrG7w2oo66phmKpgAalYGpBRBarq+AGgAtsecantWdaNs2rZgp2LJSHIMITkOzQ+iYM4RkKjzXD0UZQoS44lIuAxxh8tr5nByC6pYKqEXeLokQgCJ2NGehqDoFQ0WcAYIPUVwhvIHDOPoHCSmoi5Lqg+AQHAYhWtxt7OsREgXB0L4oo4pjKJ+zjojIrgFG+2IKI4hiGGB8q2sgEBEGAZkdsylkIKo2hNL0bRAbc0jolGVw0d0hhqLIxz7LIvmrraiqUlAIX3l2Mj5ExmgVN0mKuNo6KqLCb4zrIWiFEU8g5dxkHJtBW6FaCIkWZs7QFBwoomKpcgolUik9MoTSEuKuyctp6gdRBvEGvxglUkVonhfsSj8s0qiyIYCIOei0p2K4rhRiGzWneo+i+L4QA */
   id: "intent-pool",
 
   initial: "idle",
@@ -255,12 +243,21 @@ export const intentPoolMachine = setup({
     intentCreationResult: null,
     checkingIntentRef: null,
     executingIntentRef: null,
+    depositedBalanceRef: input.depositedBalanceRef,
   }),
 
   on: {
     ADD_INTENT: {
       target: ".queueing",
       actions: ["clearIntentCreationResult", "spawnIntentStatusActor"],
+    },
+    INTENT_SETTLED: {
+      actions: [
+        {
+          type: "passthroughEventAndRefreshBalances",
+          params: ({ event }) => event,
+        },
+      ],
     },
     NEW_QUOTE: {},
   },

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -70,7 +70,7 @@ export type Context = {
   slippageBasisPoints: number
   intentSignResult: IntentSignMachineOutput | null
   depositedBalanceRef: ActorRefFrom<typeof depositedBalanceMachine>
-  intentPoolRef: ActorRefFrom<typeof intentPoolMachine>
+  intentPoolRef: ActorRefFrom<typeof intentPoolMachine> | null
 }
 
 type PassthroughEvent = {
@@ -289,6 +289,18 @@ export const swapUIMachine = setup({
         },
       }
     }),
+    spawnIntentPoolRef: assign({
+      intentPoolRef: ({ context, spawn, self }) => {
+        const intentPoolRef = spawn("intentPoolActor", {
+          id: "intentPoolRef",
+          input: {
+            parentRef: self,
+            depositedBalanceRef: context.depositedBalanceRef,
+          },
+        })
+        return intentPoolRef
+      },
+    }),
   },
   guards: {
     isQuoteRelevant: ({ context }) => {
@@ -338,15 +350,10 @@ export const swapUIMachine = setup({
         tokenList: input.tokenList,
       },
     }),
-    intentPoolRef: spawn("intentPoolActor", {
-      id: "intentPoolRef",
-      input: {
-        parentRef: self,
-      },
-    }),
+    intentPoolRef: null,
   }),
 
-  entry: ["spawnBackgroundQuoterRef"],
+  entry: ["spawnBackgroundQuoterRef", "spawnIntentPoolRef"],
 
   on: {
     INTENT_SETTLED: {

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -55,12 +55,18 @@ export const SwapForm = ({ onNavigateDeposit }: SwapFormProps) => {
   const swapUIActorRef = SwapUIMachineContext.useActorRef()
   const snapshot = SwapUIMachineContext.useSelector((snapshot) => snapshot)
 
-  const intentCreationResult = settings.optimisticBalanceUpdates
-    ? snapshot.context.intentPoolRef.getSnapshot().context.intentCreationResult
-    : snapshot.context.intentCreationResult
-  const intentRefs = settings.optimisticBalanceUpdates
-    ? snapshot.context.intentPoolRef.getSnapshot().context.intentRefs
-    : snapshot.context.intentRefs
+  const intentPoolRef =
+    snapshot.context.intentPoolRef !== null
+      ? snapshot.context.intentPoolRef
+      : null
+  const intentCreationResult =
+    settings.optimisticBalanceUpdates && intentPoolRef
+      ? intentPoolRef.getSnapshot().context.intentCreationResult
+      : snapshot.context.intentCreationResult
+  const intentRefs =
+    settings.optimisticBalanceUpdates && intentPoolRef
+      ? intentPoolRef.getSnapshot().context.intentRefs
+      : snapshot.context.intentRefs
 
   const { data: tokensUsdPriceData } = useTokensUsdPrices()
 

--- a/src/utils/pool.ts
+++ b/src/utils/pool.ts
@@ -1,0 +1,43 @@
+import type { ActorRefFrom } from "xstate"
+import type { BalanceMapping } from "../features/machines/depositedBalanceMachine"
+import type { Intent } from "../features/machines/intentPoolMachine"
+import type { intentStatusMachine } from "../features/machines/intentStatusMachine"
+import { assert } from "./assert"
+
+export function isOptimisticIntent(
+  requestedDeltaChanges: [string, bigint],
+  onchainBalances: BalanceMapping
+): boolean {
+  const balance = onchainBalances[requestedDeltaChanges[0]]
+  if (balance === undefined) {
+    return false
+  }
+  return balance < requestedDeltaChanges[1] * -1n
+}
+
+export function getPendingDeltaBalances(
+  intentRefs: ActorRefFrom<typeof intentStatusMachine>[],
+  pool: Map<string, Intent>
+): BalanceMapping {
+  const deltas: Record<string, bigint> = {}
+
+  for (const intentRef of intentRefs) {
+    const { value } = intentRef.getSnapshot()
+    if (value !== "pending") continue
+
+    const intent = pool.get(intentRef.id)
+    assert(intent !== undefined, "intent is undefined")
+    const tokenDeltas = intent.quoteToPublish?.tokenDeltas
+    assert(tokenDeltas !== undefined, "tokenDeltas is undefined")
+
+    for (const [key, value] of tokenDeltas) {
+      if (deltas[key] !== undefined) {
+        deltas[key] += value
+      } else {
+        deltas[key] = value
+      }
+    }
+  }
+
+  return deltas
+}


### PR DESCRIPTION
 This PR enables instant balance updates with local delta calculations. This change leverages optimistic balance updates, ensuring that users see the most up-to-date balance information based on pending transactions and intents.

<details>
<summary>Example</summary>
<img width="546" alt="Screenshot 2025-02-12 at 12 45 49" src="https://github.com/user-attachments/assets/d968b87c-dfff-4d2e-944e-a541e54a4591" />

</details>