### PR TITLE
feat: add support for singing using WebAuthn (ed25519 and p256 curves)

### DIFF
--- a/artifacts/defuse_contract_abi.json
+++ b/artifacts/defuse_contract_abi.json
@@ -3032,53 +3032,13 @@
             },
             {
               "type": "object",
-              "anyOf": [
-                {
-                  "description": "[COSE EdDSA (-8) algorithm](https://www.iana.org/assignments/cose/cose.xhtml#algorithms): ed25519 curve",
-                  "type": "object",
-                  "required": [
-                    "public_key",
-                    "signature"
-                  ],
-                  "properties": {
-                    "public_key": {
-                      "type": "string",
-                      "pattern": "^ed25519:",
-                      "contentEncoding": "base58"
-                    },
-                    "signature": {
-                      "type": "string",
-                      "pattern": "^ed25519:",
-                      "contentEncoding": "base58"
-                    }
-                  }
-                },
-                {
-                  "description": "[COSE ES256 (-7) algorithm](https://www.iana.org/assignments/cose/cose.xhtml#algorithms): NIST P-256 curve (a.k.a secp256r1) over SHA-256",
-                  "type": "object",
-                  "required": [
-                    "public_key",
-                    "signature"
-                  ],
-                  "properties": {
-                    "public_key": {
-                      "type": "string",
-                      "pattern": "^p256:",
-                      "contentEncoding": "base58"
-                    },
-                    "signature": {
-                      "type": "string",
-                      "pattern": "^p256:",
-                      "contentEncoding": "base58"
-                    }
-                  }
-                }
-              ],
               "required": [
                 "authenticator_data",
                 "client_data_json",
                 "payload",
-                "standard"
+                "standard",
+                "public_key",
+                "signature"
               ],
               "properties": {
                 "authenticator_data": {
@@ -3098,6 +3058,12 @@
                   "enum": [
                     "webauthn"
                   ]
+                },
+                "public_key": {
+                  "type": "string"
+                },
+                "signature": {
+                  "type": "string"
                 }
               }
             }

--- a/artifacts/defuse_contract_abi.json
+++ b/artifacts/defuse_contract_abi.json
@@ -4,10 +4,10 @@
     "name": "defuse",
     "version": "0.1.0",
     "build": {
-      "compiler": "rustc 1.82.0",
-      "builder": "cargo-near cargo-near-build 0.3.2"
+      "compiler": "rustc 1.84.1",
+      "builder": "cargo-near cargo-near-build 0.4.3"
     },
-    "wasm_hash": "2QLSTWx4W4aXhd8raRMuA4m1FYSZETpLU7YcvLVXohTE"
+    "wasm_hash": "BCub7PHNoLMZuWTNZ2eNqoTztxfG1FPdF9LrdGGZpe1v"
   },
   "body": {
     "functions": [
@@ -2226,6 +2226,9 @@
       {
         "name": "set_fee",
         "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
         "params": {
           "serialization_type": "json",
           "args": [
@@ -2241,6 +2244,9 @@
       {
         "name": "set_fee_collector",
         "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
         "params": {
           "serialization_type": "json",
           "args": [
@@ -2813,6 +2819,22 @@
                   "enum": [
                     "token_diff"
                   ]
+                },
+                "memo": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "referral": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/AccountId"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               }
             }
@@ -3004,6 +3026,77 @@
                   "type": "string",
                   "enum": [
                     "raw_ed25519"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "anyOf": [
+                {
+                  "description": "[COSE EdDSA (-8) algorithm](https://www.iana.org/assignments/cose/cose.xhtml#algorithms): ed25519 curve",
+                  "type": "object",
+                  "required": [
+                    "public_key",
+                    "signature"
+                  ],
+                  "properties": {
+                    "public_key": {
+                      "type": "string",
+                      "pattern": "^ed25519:",
+                      "contentEncoding": "base58"
+                    },
+                    "signature": {
+                      "type": "string",
+                      "pattern": "^ed25519:",
+                      "contentEncoding": "base58"
+                    }
+                  }
+                },
+                {
+                  "description": "[COSE ES256 (-7) algorithm](https://www.iana.org/assignments/cose/cose.xhtml#algorithms): NIST P-256 curve (a.k.a secp256r1) over SHA-256",
+                  "type": "object",
+                  "required": [
+                    "public_key",
+                    "signature"
+                  ],
+                  "properties": {
+                    "public_key": {
+                      "type": "string",
+                      "pattern": "^p256:",
+                      "contentEncoding": "base58"
+                    },
+                    "signature": {
+                      "type": "string",
+                      "pattern": "^p256:",
+                      "contentEncoding": "base58"
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "authenticator_data",
+                "client_data_json",
+                "payload",
+                "standard"
+              ],
+              "properties": {
+                "authenticator_data": {
+                  "description": "Base64Url-encodded [authenticatorData](https://w3c.github.io/webauthn/#authenticator-data)",
+                  "type": "string",
+                  "contentEncoding": "base64"
+                },
+                "client_data_json": {
+                  "description": "Serialized [clientDataJSON](https://w3c.github.io/webauthn/#dom-authenticatorresponse-clientdatajson)",
+                  "type": "string"
+                },
+                "payload": {
+                  "type": "string"
+                },
+                "standard": {
+                  "type": "string",
+                  "enum": [
+                    "webauthn"
                   ]
                 }
               }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@radix-ui/react-toast": "^1.0.0",
     "@radix-ui/themes": "^3.0.0",
     "@scure/base": "^1.1.9",
+    "@simplewebauthn/server": "^13.1.1",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.4",
     "@tanstack/react-query": "^5.59.16",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "dependencies": {
     "@lifeomic/attempt": "^3.1.0",
     "@noble/curves": "1.4.0",
+    "@peculiar/asn1-ecc": "^2.3.15",
+    "@peculiar/asn1-schema": "^2.3.15",
     "@radix-ui/react-accordion": "^1.0.0",
     "@radix-ui/react-checkbox": "^1.0.0",
     "@radix-ui/react-dialog": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@tanstack/react-query": "^5.59.16",
     "@xstate/react": "^4.1.3",
     "bs58": "^6.0.0",
+    "cbor": "^10.0.3",
     "clsx": "^2.1.1",
     "near-api-js": "^0.44.2",
     "qrcode.react": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@radix-ui/react-toast": "^1.0.0",
     "@radix-ui/themes": "^3.0.0",
     "@scure/base": "^1.1.9",
-    "@simplewebauthn/server": "^13.1.1",
     "@solana/spl-token": "^0.4.9",
     "@solana/web3.js": "^1.95.4",
     "@tanstack/react-query": "^5.59.16",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@lifeomic/attempt": "^3.1.0",
     "@noble/curves": "1.4.0",
+    "@noble/hashes": "^1.7.1",
     "@peculiar/asn1-ecc": "^2.3.15",
     "@peculiar/asn1-schema": "^2.3.15",
     "@radix-ui/react-accordion": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@tanstack/react-query": "^5.59.16",
     "@xstate/react": "^4.1.3",
     "bs58": "^6.0.0",
-    "cbor": "^10.0.3",
     "clsx": "^2.1.1",
     "near-api-js": "^0.44.2",
     "qrcode.react": "^4.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -62,6 +62,8 @@ const config = [
       "zustand/vanilla",
       "react/jsx-runtime", // Implicitly required by React JSX transform
       "@noble/curves/secp256k1",
+      "@noble/hashes/sha3",
+      "@noble/hashes/sha256",
     ],
   },
   {

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -34,6 +34,10 @@ import {
   type WalletErrorCode,
   extractWalletErrorCode,
 } from "../../utils/walletErrorExtractor"
+import {
+  parsePublicKey,
+  verifyAuthenticatorAssertion,
+} from "../../utils/webAuthn"
 import type { ParentEvents as BackgroundQuoterEvents } from "./backgroundQuoterMachine"
 import {
   type ErrorCodes as PublicKeyVerifierErrorCodes,
@@ -717,6 +721,12 @@ async function verifyWalletSignature(
         base58.decode(userAddress)
       )
     }
+    case "WEBAUTHN":
+      return verifyAuthenticatorAssertion(
+        signature.signatureData,
+        parsePublicKey(userAddress),
+        signature.signedData.challenge
+      )
     default:
       signatureType satisfies never
       throw new Error("exhaustive check failed")

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -799,6 +799,33 @@ export function getAvailableDepositRoutes(
           network satisfies never
           throw new Error("exhaustive check failed")
       }
+    case ChainType.WebAuthn:
+      switch (network) {
+        case BlockchainEnum.NEAR:
+        case BlockchainEnum.TURBOCHAIN:
+        case BlockchainEnum.AURORA:
+          return {
+            activeDeposit: false,
+            passiveDeposit: false,
+          }
+        case BlockchainEnum.ETHEREUM:
+        case BlockchainEnum.BASE:
+        case BlockchainEnum.ARBITRUM:
+        case BlockchainEnum.BITCOIN:
+        case BlockchainEnum.DOGECOIN:
+        case BlockchainEnum.XRPLEDGER:
+        case BlockchainEnum.ZCASH:
+        case BlockchainEnum.GNOSIS:
+        case BlockchainEnum.BERACHAIN:
+        case BlockchainEnum.SOLANA:
+          return {
+            activeDeposit: false,
+            passiveDeposit: true,
+          }
+        default:
+          network satisfies never
+          throw new Error("exhaustive check failed")
+      }
     default:
       chainTypeFromWallet satisfies never
       throw new Error("exhaustive check failed")

--- a/src/types/deposit.ts
+++ b/src/types/deposit.ts
@@ -2,12 +2,13 @@ import type { Transaction as TransactionSolana } from "@solana/web3.js"
 import type { Address, Hash } from "viem"
 import type { SwappableToken } from "./swap"
 
-export type ChainType = "near" | "evm" | "solana"
+export type ChainType = "near" | "evm" | "solana" | "webauthn"
 
 export const ChainType = {
   Near: "near",
   EVM: "evm",
   Solana: "solana",
+  WebAuthn: "webauthn",
 } as const
 
 export type UserInfo = {

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -1,5 +1,6 @@
 import type { SendNearTransaction } from "../features/machines/publicKeyVerifierMachine"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "./base"
+import type { DefusePayloadFor_DefuseIntents } from "./defuse-contracts-types"
 import type { ChainType } from "./deposit"
 
 // Message for EVM wallets
@@ -54,8 +55,12 @@ export type SolanaSignatureData = {
 // WebAuthn
 
 export type WebAuthnMessage = {
-  /** Bytes of UTF-8 JSON string */
-  message: Uint8Array
+  /** Hash that needs to be signed */
+  challenge: Uint8Array
+  /** Underlying payload that will be executed onchain */
+  payload: string
+  /** Parsed payload in case UI needs to display it */
+  parsedPayload: DefusePayloadFor_DefuseIntents
 }
 
 /** Full response of WebAuthn Login */

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -51,16 +51,34 @@ export type SolanaSignatureData = {
   signedData: SolanaMessage
 }
 
+// WebAuthn
+
+export type WebAuthnMessage = {
+  /** Bytes of UTF-8 JSON string */
+  message: Uint8Array
+}
+
+/** Full response of WebAuthn Login */
+export type WebAuthnSignature = AuthenticatorAssertionResponse
+
+export type WebAuthnSignatureData = {
+  type: "WEBAUTHN"
+  signatureData: WebAuthnSignature
+  signedData: WebAuthnMessage
+}
+
 export type WalletMessage = {
   ERC191: ERC191Message
   NEP413: NEP413Message
   SOLANA: SolanaMessage
+  WEBAUTHN: WebAuthnMessage
 }
 
 export type WalletSignatureResult =
   | ERC191SignatureData
   | NEP413SignatureData
   | SolanaSignatureData
+  | WebAuthnSignatureData
 
 export type SwapEvent = {
   type: string

--- a/src/types/webAuthn.ts
+++ b/src/types/webAuthn.ts
@@ -1,7 +1,12 @@
+// Supported curves
 export type CurveType = "p256" | "ed25519"
 
-export type FormattedPublicKey = `${CurveType}:${string}`
+type Base58 = string
+export type FormattedPublicKey = `${CurveType}:${Base58}`
 
+/**
+ * https://www.w3.org/TR/webauthn-2/#credential-public-key
+ */
 export type CredentialKey = {
   curveType: CurveType
   publicKey: Uint8Array

--- a/src/types/webAuthn.ts
+++ b/src/types/webAuthn.ts
@@ -1,0 +1,8 @@
+export type CurveType = "p256" | "ed25519"
+
+export type FormattedPublicKey = `${CurveType}:${string}`
+
+export type CredentialKey = {
+  curveType: CurveType
+  publicKey: Uint8Array
+}

--- a/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
+++ b/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
@@ -23,6 +23,17 @@ exports[`prepareSwapSignedData() > should return the correct signed data for a S
 }
 `;
 
+exports[`prepareSwapSignedData() > should return the correct signed data for a WebAuthn signature 1`] = `
+{
+  "authenticator_data": "3q0",
+  "client_data_json": "{"some": "json"}",
+  "payload": "{"signer_id":"user.near","verifying_contract":"intents.near","deadline":"2024-01-01T12:00:00.000Z","nonce":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","intents":[{"intent":"token_diff","diff":{"foo.near":"100"}}]}",
+  "public_key": "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
+  "signature": "ed25519:FXk",
+  "standard": "webauthn",
+}
+`;
+
 exports[`prepareSwapSignedData() > should return the correct signed data for an ERC191 signature 1`] = `
 {
   "payload": "{"foo":"bar"}",

--- a/src/utils/defuse.test.ts
+++ b/src/utils/defuse.test.ts
@@ -24,4 +24,31 @@ describe("userAddressToDefuseUserId", () => {
       "2c1af676c3580b2ecde77673a38886cc16429b4b17744da5985a25152843a570"
     )
   })
+
+  it("returns derived address for 'webauthn' chain type with P-256 curve", () => {
+    const result = userAddressToDefuseUserId(
+      "p256:3NSY8SFTWoPFMrTGdLVqPogirCyt3kMnUajXoDQuVeCsA6wzkMMp5whBqymAPM7xFiBthDKueiUv1zVAj7GDT8rQ",
+      "webauthn"
+    )
+    expect(result).toBe("0xf54df4d2598c83e2293c616384442a70335e7859")
+  })
+
+  it("returns hex encoded public key for 'webauthn' chain type with Ed25519 curve", () => {
+    const result = userAddressToDefuseUserId(
+      "ed25519:Gz9STDrgGWdt2fh1g91v2n6SUsy5QKHbx86Nrjy2kFz5",
+      "webauthn"
+    )
+    expect(result).toBe(
+      "ed82f3aaf32b8825b67d23d1581edee4f90240ee57a2963c46f529c93d6ce5ae"
+    )
+  })
+
+  it("throws if incorrect curve is provided", () => {
+    expect(() =>
+      userAddressToDefuseUserId(
+        "foo:Gz9STDrgGWdt2fh1g91v2n6SUsy5QKHbx86Nrjy2kFz5",
+        "webauthn"
+      )
+    ).toThrow()
+  })
 })

--- a/src/utils/defuse.ts
+++ b/src/utils/defuse.ts
@@ -1,28 +1,75 @@
+import { keccak_256 } from "@noble/hashes/sha3"
 import { base58, hex } from "@scure/base"
 import type { ChainType } from "../types/deposit"
+import { parsePublicKey } from "./webAuthn"
 
-// Branding a string type with a unique symbol to prevent accidental misuse.
+/**
+ * A branded string type representing a Defuse user ID.
+ * The brand prevents accidental mixing with regular strings in TypeScript.
+ */
 export type DefuseUserId = string & { __brand: "DefuseAccountId" }
 
 /**
- * Any valid Near account ID can be used as a Defuse user ID.
- * Near accounts are lowercased and have a maximum length of 64 characters.
- * Examples of valid Near account IDs:
- * - explicit Near account: "bob.near"
- * - implicit Near account: "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1"
- * - Ethereum address: "0xc0ffee254729296a45a3885639ac7e10f9d54979"
- * - Solana address: "3yAnWiDUbv2Ckjptk1D1HAwYHgqZKoqbR755ckY3n9oV"
+ * Converts a blockchain address to a standardized Defuse user ID.
+ *
+ * The conversion follows these rules:
+ * 1. NEAR addresses: Used as-is (lowercased)
+ *   - Explicit: "bob.near"
+ *   - Implicit: "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1"
+ *
+ * 2. EVM addresses: Used as-is (lowercased)
+ *   - Format: "0xc0ffee254729296a45a3885639ac7e10f9d54979"
+ *
+ * 3. Solana addresses: Converted from base58 to hex
+ *   - Input: base58 public key
+ *   - Output: hex-encoded string
+ *
+ * 4. WebAuthn credentials: Converted based on curve type
+ *   - P-256: Keccak256(prefix + pubkey) -> last 20 bytes -> hex with 0x prefix
+ *   - Ed25519: Raw public key -> hex encoding
+ *
+ * @param credential - The user's identifier (blockchain address or WebAuthn public key)
+ * @param credentialType - The type of credential ("evm", "near", "solana", "webauthn")
+ * @returns A standardized Defuse user ID
  */
 export function userAddressToDefuseUserId(
-  userAddress: string,
-  addressChainType: ChainType
+  credential: string,
+  credentialType: ChainType
 ): DefuseUserId {
-  switch (addressChainType) {
+  switch (credentialType) {
     case "evm":
     case "near":
-      return userAddress.toLowerCase() as DefuseUserId
+      return credential.toLowerCase() as DefuseUserId
 
     case "solana":
-      return hex.encode(base58.decode(userAddress)) as DefuseUserId
+      return hex.encode(base58.decode(credential)) as DefuseUserId
+
+    case "webauthn": {
+      return webAuthnCredentialToDefuseUserId(credential) as DefuseUserId
+    }
+  }
+}
+
+function webAuthnCredentialToDefuseUserId(credential: string): string {
+  const { curveType, publicKey } = parsePublicKey(credential)
+
+  switch (curveType) {
+    case "p256": {
+      const p256 = new TextEncoder().encode("p256")
+      const addressBytes = keccak_256(
+        new Uint8Array([...p256, ...publicKey])
+      ).slice(-20)
+
+      // biome-ignore lint/style/useTemplate: it's fine
+      return "0x" + hex.encode(addressBytes)
+    }
+
+    case "ed25519": {
+      return hex.encode(publicKey)
+    }
+
+    default:
+      curveType satisfies never
+      throw new Error("Unsupported curve type")
   }
 }

--- a/src/utils/messageFactory.test.ts
+++ b/src/utils/messageFactory.test.ts
@@ -56,6 +56,64 @@ describe("makeSwapMessage()", () => {
           )
         ),
       },
+      WEBAUTHN: expect.any(Object),
+    })
+  })
+
+  describe("WEBAUTHN format", () => {
+    const config = {
+      innerMessage: makeInnerSwapMessage({
+        tokenDeltas: [["foo.near", 100n]],
+        signerId: userAddressToDefuseUserId("user.near", "near"),
+        deadlineTimestamp: 1704110400000, // 2024-01-01T12:00:00.000Z,
+      }),
+      recipient: "recipient.near",
+      nonce: new Uint8Array(32),
+    }
+
+    it("should return WEBAUTHN object", () => {
+      const message = makeSwapMessage(config)
+
+      expect(message.WEBAUTHN.payload).toMatchInlineSnapshot(
+        `"{"signer_id":"user.near","verifying_contract":"intents.near","deadline":"2024-01-01T12:00:00.000Z","nonce":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","intents":[{"intent":"token_diff","diff":{"foo.near":"100"}}]}"`
+      )
+      expect(message.WEBAUTHN.challenge).toHaveLength(32) // SHA-256 is 32 bytes
+    })
+
+    it("should compute challenge using SHA-256", async () => {
+      const message = makeSwapMessage(config)
+
+      const webauthnPayload = message.WEBAUTHN.payload
+      const webauthnChallenge = message.WEBAUTHN.challenge
+
+      expect(webauthnChallenge).toEqual(
+        new Uint8Array(
+          await crypto.subtle.digest(
+            "SHA-256",
+            Buffer.from(webauthnPayload, "utf-8")
+          )
+        )
+      )
+    })
+
+    it("should generate deterministic challenge for same inputs", () => {
+      const message1 = makeSwapMessage(structuredClone(config))
+      const message2 = makeSwapMessage(structuredClone(config))
+
+      expect(message1.WEBAUTHN.challenge).toEqual(message2.WEBAUTHN.challenge)
+    })
+
+    it("should change challenge when any input field changes", () => {
+      const baseMessage = makeSwapMessage(config)
+
+      const differentDeltasMsg = makeSwapMessage({
+        ...config,
+        nonce: crypto.getRandomValues(new Uint8Array(32)),
+      })
+
+      expect(differentDeltasMsg.WEBAUTHN.challenge).not.toEqual(
+        baseMessage.WEBAUTHN.challenge
+      )
     })
   })
 

--- a/src/utils/messageFactory.ts
+++ b/src/utils/messageFactory.ts
@@ -1,3 +1,4 @@
+import { sha256 } from "@noble/hashes/sha256"
 import { base64 } from "@scure/base"
 import { getAddress } from "viem"
 import { settings } from "../config/settings"
@@ -186,6 +187,16 @@ export function makeSwapMessage({
   recipient: string
   nonce?: Uint8Array
 }): WalletMessage {
+  const payload = {
+    signer_id: innerMessage.signer_id,
+    verifying_contract: settings.defuseContractId,
+    deadline: innerMessage.deadline,
+    nonce: base64.encode(nonce),
+    intents: innerMessage.intents,
+  }
+  const payloadSerialized = JSON.stringify(payload)
+  const payloadBytes = new TextEncoder().encode(payloadSerialized)
+
   return {
     NEP413: {
       message: JSON.stringify(innerMessage),
@@ -193,28 +204,15 @@ export function makeSwapMessage({
       nonce,
     },
     ERC191: {
-      message: JSON.stringify(
-        {
-          signer_id: innerMessage.signer_id,
-          verifying_contract: settings.defuseContractId,
-          deadline: innerMessage.deadline,
-          nonce: base64.encode(nonce),
-          intents: innerMessage.intents,
-        },
-        null,
-        2
-      ),
+      message: JSON.stringify(payload, null, 2),
     },
     SOLANA: {
-      message: new TextEncoder().encode(
-        JSON.stringify({
-          signer_id: innerMessage.signer_id,
-          verifying_contract: settings.defuseContractId,
-          deadline: innerMessage.deadline,
-          nonce: base64.encode(nonce),
-          intents: innerMessage.intents,
-        })
-      ),
+      message: payloadBytes,
+    },
+    WEBAUTHN: {
+      challenge: makeChallenge(payloadBytes),
+      payload: payloadSerialized,
+      parsedPayload: payload,
     },
   }
 }
@@ -234,4 +232,14 @@ function randomBytes(length: number): Uint8Array {
 function makeAuroraEngineDepositMsg(recipientAddress: string): string {
   const parsedRecipientAddress = getAddress(recipientAddress)
   return parsedRecipientAddress.slice(2).toLowerCase()
+}
+
+/**
+ * Converts UTF-8 string to bytes for WebAuthn challenge
+ */
+export function makeChallenge(payload: Uint8Array): Uint8Array {
+  // It's possible to use native crypto, but it's async, and this would break existing flow:
+  // await crypto.subtle.digest("SHA-256", messageBytes)
+  const hash = sha256(payload)
+  return new Uint8Array(hash)
 }

--- a/src/utils/multiPayload/webauthn.ts
+++ b/src/utils/multiPayload/webauthn.ts
@@ -1,0 +1,46 @@
+import { base58, base64urlnopad } from "@scure/base"
+import type { MultiPayload } from "../../types/defuse-contracts-types"
+import type { ChainType } from "../../types/deposit"
+import type { WebAuthnSignatureData } from "../../types/swap"
+import type { CurveType, FormattedPublicKey } from "../../types/webAuthn"
+import { assert } from "../assert"
+import { extractRawSignature, parsePublicKey } from "../webAuthn"
+
+export function makeWebAuthnMultiPayload(
+  userInfo: { userAddress: string; userChainType: ChainType },
+  signature: WebAuthnSignatureData
+): MultiPayload {
+  assert(
+    userInfo.userChainType === "webauthn",
+    "User chain and signature chain must match"
+  )
+
+  const { curveType, publicKey } = parsePublicKey(userInfo.userAddress)
+
+  return {
+    standard: "webauthn",
+    payload: signature.signedData.payload,
+    public_key: formatPublicKey(publicKey, curveType),
+    signature: formatSignature(
+      extractRawSignature(signature.signatureData.signature, curveType),
+      curveType
+    ),
+    client_data_json: new TextDecoder("utf-8").decode(
+      signature.signatureData.clientDataJSON
+    ),
+    authenticator_data: base64urlnopad.encode(
+      new Uint8Array(signature.signatureData.authenticatorData)
+    ),
+  }
+}
+
+function formatPublicKey(
+  publicKey: Uint8Array,
+  curveType: CurveType
+): FormattedPublicKey {
+  return `${curveType}:${base58.encode(publicKey)}`
+}
+
+function formatSignature(signature: ArrayBuffer, curveType: CurveType) {
+  return `${curveType}:${base58.encode(new Uint8Array(signature))}`
+}

--- a/src/utils/prepareBroadcastRequest.test.ts
+++ b/src/utils/prepareBroadcastRequest.test.ts
@@ -4,7 +4,10 @@ import type {
   NEP413SignatureData,
   SolanaSignatureData,
   WalletMessage,
+  WebAuthnSignatureData,
 } from "../types/swap"
+import { userAddressToDefuseUserId } from "./defuse"
+import { makeInnerSwapMessage, makeSwapMessage } from "./messageFactory"
 import { prepareSwapSignedData } from "./prepareBroadcastRequest"
 
 describe("prepareSwapSignedData()", () => {
@@ -25,6 +28,15 @@ describe("prepareSwapSignedData()", () => {
         Buffer.from(JSON.stringify({ foo: "bar" }), "utf8")
       ),
     },
+    WEBAUTHN: makeSwapMessage({
+      innerMessage: makeInnerSwapMessage({
+        tokenDeltas: [["foo.near", 100n]],
+        signerId: userAddressToDefuseUserId("user.near", "near"),
+        deadlineTimestamp: 1704110400000,
+      }),
+      recipient: "recipient.near",
+      nonce: new Uint8Array(32),
+    }).WEBAUTHN,
   }
 
   it("should return the correct signed data for a NEP141 signature", () => {
@@ -72,6 +84,26 @@ describe("prepareSwapSignedData()", () => {
       prepareSwapSignedData(signature, {
         userAddress: "DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy",
         userChainType: "solana",
+      })
+    ).toMatchSnapshot()
+  })
+
+  it("should return the correct signed data for a WebAuthn signature", async () => {
+    const signature: WebAuthnSignatureData = {
+      type: "WEBAUTHN",
+      signatureData: {
+        authenticatorData: Buffer.from("dead", "hex"),
+        clientDataJSON: Buffer.from('{"some": "json"}', "utf-8"),
+        signature: Buffer.from("beef", "hex"),
+        userHandle: Buffer.from("1ee7", "hex"),
+      },
+      signedData: walletMessage.WEBAUTHN,
+    }
+
+    expect(
+      prepareSwapSignedData(signature, {
+        userAddress: "ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga",
+        userChainType: "webauthn",
       })
     ).toMatchSnapshot()
   })

--- a/src/utils/prepareBroadcastRequest.ts
+++ b/src/utils/prepareBroadcastRequest.ts
@@ -6,6 +6,7 @@ import type {
 import type { ChainType } from "../types/deposit"
 import type { WalletSignatureResult } from "../types/swap"
 import { assert } from "./assert"
+import { makeWebAuthnMultiPayload } from "./multiPayload/webauthn"
 
 export function prepareSwapSignedData(
   signature: WalletSignatureResult,
@@ -45,6 +46,9 @@ export function prepareSwapSignedData(
         public_key: `ed25519:${userInfo.userAddress}`,
         signature: transformSolanaSignature(signature.signatureData),
       }
+    case "WEBAUTHN": {
+      return makeWebAuthnMultiPayload(userInfo, signature)
+    }
     default:
       signatureType satisfies never
       throw new Error("exhaustive check failed")

--- a/src/utils/uint8Array.test.ts
+++ b/src/utils/uint8Array.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+import { concatUint8Arrays } from "./uint8Array"
+
+describe("concatUint8Arrays", () => {
+  it("combines multiple uint8 arrays", () => {
+    expect(
+      concatUint8Arrays([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])])
+    ).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]))
+  })
+})

--- a/src/utils/uint8Array.ts
+++ b/src/utils/uint8Array.ts
@@ -1,0 +1,13 @@
+export function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+  let pointer = 0
+  const totalLength = arrays.reduce((prev, curr) => prev + curr.length, 0)
+
+  const toReturn = new Uint8Array(totalLength)
+
+  for (const arr of arrays) {
+    toReturn.set(arr, pointer)
+    pointer += arr.length
+  }
+
+  return toReturn
+}

--- a/src/utils/webAuthn.test.ts
+++ b/src/utils/webAuthn.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { extractRawSignature } from "./webAuthn"
+
+describe("extractRawSignature()", () => {
+  it("should return signature for ed25519 curve", () => {
+    const signature = new Uint8Array([0, 1, 2, 3])
+    expect(extractRawSignature(signature, "ed25519")).toEqual(signature)
+  })
+
+  it.each([
+    {
+      input:
+        "304402200b858e8d13abdf3ed76bf3cf952d334010ed758e215d1db07d3a33e637d6caf1022051571f169a8ee96d083be9d13a12cf81923d6f3df87023ee5f3aa84f807af84a",
+      expected:
+        "0b858e8d13abdf3ed76bf3cf952d334010ed758e215d1db07d3a33e637d6caf151571f169a8ee96d083be9d13a12cf81923d6f3df87023ee5f3aa84f807af84a",
+    },
+    {
+      input:
+        "3045022100832953e1d9f09ca0896c735c8c6123e81cc2cf4935d31447010fa335703b71740220196fd6811317997dd6b570a8cf84cadd53ec3f7fe6f32080f55d2753f618e8a0",
+      expected:
+        "832953e1d9f09ca0896c735c8c6123e81cc2cf4935d31447010fa335703b7174196fd6811317997dd6b570a8cf84cadd53ec3f7fe6f32080f55d2753f618e8a0",
+    },
+    {
+      input:
+        "3045022001c42949178201fd9bcddff0415d4f0323431e1d02ed71d09a98882cb2bf3a4d022100aef1075c0c4d06e9879fef30169e107677e31efe2e653e00deefa11527df9b2c",
+      expected:
+        "01c42949178201fd9bcddff0415d4f0323431e1d02ed71d09a98882cb2bf3a4daef1075c0c4d06e9879fef30169e107677e31efe2e653e00deefa11527df9b2c",
+    },
+    {
+      input:
+        "3046022100dc21f05d647d510ea22e9c7246a80331eae727255c3664f1473abfd83c3ee112022100f3f6b66ecd94148a01b36a2664e77b08a442d0041a05a7ae12b1147190ec356b",
+      expected:
+        "dc21f05d647d510ea22e9c7246a80331eae727255c3664f1473abfd83c3ee112f3f6b66ecd94148a01b36a2664e77b08a442d0041a05a7ae12b1147190ec356b",
+    },
+  ])("should return signature for p256 curve", ({ input, expected }) => {
+    const signature = Buffer.from(input, "hex")
+    expect(extractRawSignature(signature, "p256")).toEqual(
+      new Uint8Array(Buffer.from(expected, "hex"))
+    )
+  })
+})

--- a/src/utils/webAuthn.ts
+++ b/src/utils/webAuthn.ts
@@ -1,13 +1,7 @@
 import { base58 } from "@scure/base"
+import type { CredentialKey, CurveType } from "../types/webAuthn"
 
-export type ParsedPublicKey = {
-  curveType: CurveType
-  publicKey: Uint8Array
-}
-
-type CurveType = "p256" | "ed25519"
-
-export function parsePublicKey(formattedPublicKey: string): ParsedPublicKey {
+export function parsePublicKey(formattedPublicKey: string): CredentialKey {
   const curveType = getCurveType(formattedPublicKey)
 
   switch (curveType) {

--- a/src/utils/webAuthn.ts
+++ b/src/utils/webAuthn.ts
@@ -1,0 +1,66 @@
+import { base58 } from "@scure/base"
+
+export type ParsedPublicKey = {
+  curveType: CurveType
+  publicKey: Uint8Array
+}
+
+type CurveType = "p256" | "ed25519"
+
+export function parsePublicKey(formattedPublicKey: string): ParsedPublicKey {
+  const curveType = getCurveType(formattedPublicKey)
+
+  switch (curveType) {
+    case "p256": {
+      let publicKey: Uint8Array
+
+      try {
+        publicKey = base58.decode(formattedPublicKey.slice(5))
+      } catch (err) {
+        throw new Error("Public key is not base58 encoded", { cause: err })
+      }
+
+      if (publicKey.length !== 64) {
+        throw new Error(
+          `Invalid public key size for P-256 curve, it must be 64 bytes, but got ${publicKey.length} bytes`
+        )
+      }
+
+      return { curveType, publicKey }
+    }
+
+    case "ed25519": {
+      let publicKey: Uint8Array
+
+      try {
+        publicKey = base58.decode(formattedPublicKey.slice(8))
+      } catch (err) {
+        throw new Error("Public key is not base58 encoded", { cause: err })
+      }
+
+      if (publicKey.length !== 32) {
+        throw new Error(
+          `Invalid public key size for Ed25519 curve, it must be 32 bytes, but got ${publicKey.length} bytes`
+        )
+      }
+
+      return { curveType, publicKey }
+    }
+
+    default:
+      curveType satisfies never
+      throw new Error(`Unsupported curve type ${curveType}`)
+  }
+}
+
+export function getCurveType(publicKey: string): CurveType {
+  if (publicKey.startsWith("p256:")) {
+    return "p256"
+  }
+
+  if (publicKey.startsWith("ed25519:")) {
+    return "ed25519"
+  }
+
+  throw new Error(`Unsupported public key type ${publicKey.slice(0, 5)}`)
+}

--- a/src/utils/webAuthn.ts
+++ b/src/utils/webAuthn.ts
@@ -1,5 +1,5 @@
 import { base58 } from "@scure/base"
-import type { CredentialKey, CurveType } from "../types/webAuthn"
+import type { CredentialKey } from "../types/webAuthn"
 
 export function parsePublicKey(formattedPublicKey: string): CredentialKey {
   const curveType = getCurveType(formattedPublicKey)
@@ -42,19 +42,14 @@ export function parsePublicKey(formattedPublicKey: string): CredentialKey {
     }
 
     default:
-      curveType satisfies never
       throw new Error(`Unsupported curve type ${curveType}`)
   }
 }
 
-export function getCurveType(publicKey: string): CurveType {
-  if (publicKey.startsWith("p256:")) {
-    return "p256"
+function getCurveType(formattedPublicKey: string): string {
+  const delim = formattedPublicKey.indexOf(":")
+  if (delim === -1) {
+    throw new Error("Invalid public key format")
   }
-
-  if (publicKey.startsWith("ed25519:")) {
-    return "ed25519"
-  }
-
-  throw new Error(`Unsupported public key type ${publicKey.slice(0, 5)}`)
+  return formattedPublicKey.slice(0, delim)
 }

--- a/src/utils/webAuthn.ts
+++ b/src/utils/webAuthn.ts
@@ -1,6 +1,9 @@
 import { ECDSASigValue } from "@peculiar/asn1-ecc"
 import { AsnParser } from "@peculiar/asn1-schema"
 import { base58 } from "@scure/base"
+import { base64urlnopad } from "@scure/base"
+import { sign } from "tweetnacl"
+import { logger } from "../logger"
 import type { CredentialKey, CurveType } from "../types/webAuthn"
 import { concatUint8Arrays } from "./uint8Array"
 
@@ -55,6 +58,106 @@ function getCurveType(formattedPublicKey: string): string {
     throw new Error("Invalid public key format")
   }
   return formattedPublicKey.slice(0, delim)
+}
+
+/**
+ * Confirms that the assertion was signed by the authenticator with specified public key
+ */
+export async function verifyAuthenticatorAssertion(
+  assertation: AuthenticatorAssertionResponse,
+  { curveType, publicKey }: CredentialKey,
+  challenge: Uint8Array
+): Promise<boolean> {
+  if (
+    extractSignedChallenge(assertation) !== base64urlnopad.encode(challenge)
+  ) {
+    return false
+  }
+
+  const clientDataHash = await crypto.subtle.digest(
+    "SHA-256",
+    assertation.clientDataJSON
+  )
+
+  const signedBytes = concatUint8Arrays([
+    new Uint8Array(assertation.authenticatorData),
+    new Uint8Array(clientDataHash),
+  ])
+
+  const signature = extractRawSignature(assertation.signature, curveType)
+  const publicKeyWebCryptoAPI = reconstructWebCryptoAPIPublicKey(
+    publicKey,
+    curveType
+  )
+
+  switch (curveType) {
+    case "p256": {
+      const key = await crypto.subtle.importKey(
+        "raw",
+        publicKeyWebCryptoAPI,
+        { name: "ECDSA", namedCurve: "P-256" },
+        true,
+        ["verify"]
+      )
+      return crypto.subtle.verify(
+        { name: "ECDSA", hash: { name: "SHA-256" } },
+        key,
+        signature,
+        signedBytes
+      )
+    }
+
+    case "ed25519": {
+      return sign.detached.verify(signedBytes, signature, publicKeyWebCryptoAPI)
+    }
+
+    default:
+      curveType satisfies never
+      throw new Error(`Unsupported curve type ${curveType}`)
+  }
+}
+
+/**
+ * Makes a public key that can be used with WebCryptoAPI from the raw public key bytes
+ */
+function reconstructWebCryptoAPIPublicKey(
+  publicKey: Uint8Array,
+  curveType: CurveType
+): Uint8Array {
+  switch (curveType) {
+    case "p256": {
+      const x = publicKey.slice(0, 32)
+      const y = publicKey.slice(32, 64)
+      return concatUint8Arrays([new Uint8Array([0x04]), x, y])
+    }
+
+    case "ed25519":
+      return publicKey
+
+    default:
+      curveType satisfies never
+      throw new Error(`Unsupported curve type ${curveType}`)
+  }
+}
+
+/**
+ * Tries to determine the challenge that was signed by the authenticator
+ */
+function extractSignedChallenge(
+  assertation: AuthenticatorAssertionResponse
+): string | null {
+  const clientDataJSON = new TextDecoder().decode(assertation.clientDataJSON)
+
+  try {
+    const clientData = JSON.parse(clientDataJSON)
+    if (typeof clientData.challenge === "string") {
+      return clientData.challenge
+    }
+  } catch {
+    logger.error("Failed to parse clientDataJSON")
+  }
+
+  return null
 }
 
 /**

--- a/src/utils/webAuthn.ts
+++ b/src/utils/webAuthn.ts
@@ -1,5 +1,8 @@
+import { ECDSASigValue } from "@peculiar/asn1-ecc"
+import { AsnParser } from "@peculiar/asn1-schema"
 import { base58 } from "@scure/base"
-import type { CredentialKey } from "../types/webAuthn"
+import type { CredentialKey, CurveType } from "../types/webAuthn"
+import { concatUint8Arrays } from "./uint8Array"
 
 export function parsePublicKey(formattedPublicKey: string): CredentialKey {
   const curveType = getCurveType(formattedPublicKey)
@@ -52,4 +55,49 @@ function getCurveType(formattedPublicKey: string): string {
     throw new Error("Invalid public key format")
   }
   return formattedPublicKey.slice(0, delim)
+}
+
+/**
+ * Gets the actual signature from AuthenticatorAssertionResponse#signature bytes
+ */
+export function extractRawSignature(
+  signature_: ArrayBuffer,
+  curveType: CurveType
+): Uint8Array {
+  const signature = new Uint8Array(signature_)
+
+  switch (curveType) {
+    case "ed25519":
+      return signature
+
+    case "p256": {
+      // Refer to the WebAuthn specification for signature attestation types:
+      // https://www.w3.org/TR/webauthn-3/#sctn-signature-attestation-types
+      // For COSEAlgorithmIdentifier -7 (ES256) and other ECDSA-based algorithms,
+      // the signature value MUST be encoded as an ASN.1 DER Ecdsa-Sig-Value.
+      const parsedSignature = AsnParser.parse(signature, ECDSASigValue)
+      let rBytes = new Uint8Array(parsedSignature.r)
+      let sBytes = new Uint8Array(parsedSignature.s)
+      if (shouldRemoveLeadingZero(rBytes)) {
+        rBytes = rBytes.slice(1)
+      }
+      if (shouldRemoveLeadingZero(sBytes)) {
+        sBytes = sBytes.slice(1)
+      }
+      return concatUint8Arrays([rBytes, sBytes])
+    }
+
+    default:
+      curveType satisfies never
+      throw new Error(`Unsupported curve type ${curveType}`)
+  }
+}
+
+/**
+ * Specific for DER encoding of ECDSA signature.
+ * Shouldn't be used for other purposes.
+ */
+function shouldRemoveLeadingZero(bytes: Uint8Array): boolean {
+  // biome-ignore lint/style/noNonNullAssertion: trust me bro
+  return bytes[0] === 0x0 && (bytes[1]! & (1 << 7)) !== 0
 }

--- a/src/utils/webAuthn.ts
+++ b/src/utils/webAuthn.ts
@@ -164,21 +164,24 @@ function extractSignedChallenge(
  * Gets the actual signature from AuthenticatorAssertionResponse#signature bytes
  */
 export function extractRawSignature(
-  signature_: ArrayBuffer,
+  attestationSignature_: ArrayBuffer | Uint8Array,
   curveType: CurveType
 ): Uint8Array {
-  const signature = new Uint8Array(signature_)
+  const attestationSignature = new Uint8Array(attestationSignature_)
 
   switch (curveType) {
     case "ed25519":
-      return signature
+      return attestationSignature
 
     case "p256": {
       // Refer to the WebAuthn specification for signature attestation types:
       // https://www.w3.org/TR/webauthn-3/#sctn-signature-attestation-types
       // For COSEAlgorithmIdentifier -7 (ES256) and other ECDSA-based algorithms,
       // the signature value MUST be encoded as an ASN.1 DER Ecdsa-Sig-Value.
-      const parsedSignature = AsnParser.parse(signature, ECDSASigValue)
+      const parsedSignature = AsnParser.parse(
+        attestationSignature,
+        ECDSASigValue
+      )
       let rBytes = new Uint8Array(parsedSignature.r)
       let sBytes = new Uint8Array(parsedSignature.s)
       if (shouldRemoveLeadingZero(rBytes)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "target": "es2020",
     "declaration": true,
+    "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
     "module": "esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,6 +811,35 @@
   dependencies:
     "@octokit/openapi-types" "^22.2.0"
 
+"@peculiar/asn1-ecc@^2.3.15":
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz#2301cff76a089bfa2ec93b4cfd9071a382aa677f"
+  integrity sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.15"
+    "@peculiar/asn1-x509" "^2.3.15"
+    asn1js "^3.0.5"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-schema@^2.3.15":
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz#e926bfdeed51945a06f38be703499e7d8341a5d3"
+  integrity sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==
+  dependencies:
+    asn1js "^3.0.5"
+    pvtsutils "^1.3.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509@^2.3.15":
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz#55adc616a075512ace64128eb34a9e071841ab14"
+  integrity sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.15"
+    asn1js "^3.0.5"
+    pvtsutils "^1.3.6"
+    tslib "^2.8.1"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -2553,6 +2582,15 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+asn1js@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
+  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
+  dependencies:
+    pvtsutils "^1.3.2"
+    pvutils "^1.1.3"
+    tslib "^2.4.0"
 
 assertion-error@^2.0.1:
   version "2.0.1"
@@ -5934,6 +5972,18 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
+pvtsutils@^1.3.2, pvtsutils@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.6.tgz#ec46e34db7422b9e4fdc5490578c1883657d6001"
+  integrity sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==
+  dependencies:
+    tslib "^2.8.1"
+
+pvutils@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
+  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
+
 qrcode-terminal@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
@@ -6979,7 +7029,7 @@ tslib@^2.0.0, tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-tslib@^2.8.0:
+tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,13 +2861,6 @@ capability@^0.2.5:
   resolved "https://registry.yarnpkg.com/capability/-/capability-0.2.5.tgz#51ad87353f1936ffd77f2f21c74633a4dea88801"
   integrity sha512-rsJZYVCgXd08sPqwmaIqjAd5SUTfonV0z/gDJ8D6cN8wQphky1kkAYEqQ+hmDxTw7UihvBfjUVUSY+DBEe44jg==
 
-cbor@^10.0.3:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/cbor/-/cbor-10.0.3.tgz#202d79cd696f408700af51b0c9771577048a860e"
-  integrity sha512-72Jnj81xMsqepqdcSdf2+fflz/UDsThOHy5hj2MW5F5xzHL8Oa0KQ6I6V9CwVUPxg5pf+W9xp6W2KilaRXWWtw==
-  dependencies:
-    nofilter "^3.0.2"
-
 chai@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.1.tgz#f035d9792a22b481ead1c65908d14bb62ec1c82c"
@@ -5103,11 +5096,6 @@ node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
-
-nofilter@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
-  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@^7.0.0, nopt@^7.2.1:
   version "7.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,11 +436,6 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
   integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
 
-"@hexagon/base64@^1.1.27":
-  version "1.1.28"
-  resolved "https://registry.yarnpkg.com/@hexagon/base64/-/base64-1.1.28.tgz#7d306a97f1423829be5b27c9d388fe50e3099d48"
-  integrity sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==
-
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -494,11 +489,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@levischuck/tiny-cbor@^0.2.2":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz#833ddf7f3627dcb62d855d9c184061b4a1a875b3"
-  integrity sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==
 
 "@lifeomic/attempt@^3.1.0":
   version "3.1.0"
@@ -826,16 +816,7 @@
   dependencies:
     "@octokit/openapi-types" "^22.2.0"
 
-"@peculiar/asn1-android@^2.3.10":
-  version "2.3.15"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-android/-/asn1-android-2.3.15.tgz#5eb36597bb0133ecaf9ed6b5cfc847d367deabd0"
-  integrity sha512-8U2TIj59cRlSXTX2d0mzUKP7whfWGFMzTeC3qPgAbccXFrPNZLaDhpNEdG5U2QZ/tBv/IHlCJ8s+KYXpJeop6w==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.3.15"
-    asn1js "^3.0.5"
-    tslib "^2.8.1"
-
-"@peculiar/asn1-ecc@^2.3.15", "@peculiar/asn1-ecc@^2.3.8":
+"@peculiar/asn1-ecc@^2.3.15":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz#2301cff76a089bfa2ec93b4cfd9071a382aa677f"
   integrity sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==
@@ -845,17 +826,7 @@
     asn1js "^3.0.5"
     tslib "^2.8.1"
 
-"@peculiar/asn1-rsa@^2.3.8":
-  version "2.3.15"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz#0e24aadcc96b34f57b488c6c95e3eedbb1cb1c73"
-  integrity sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==
-  dependencies:
-    "@peculiar/asn1-schema" "^2.3.15"
-    "@peculiar/asn1-x509" "^2.3.15"
-    asn1js "^3.0.5"
-    tslib "^2.8.1"
-
-"@peculiar/asn1-schema@^2.3.15", "@peculiar/asn1-schema@^2.3.8":
+"@peculiar/asn1-schema@^2.3.15":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz#e926bfdeed51945a06f38be703499e7d8341a5d3"
   integrity sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==
@@ -864,7 +835,7 @@
     pvtsutils "^1.3.6"
     tslib "^2.8.1"
 
-"@peculiar/asn1-x509@^2.3.15", "@peculiar/asn1-x509@^2.3.8":
+"@peculiar/asn1-x509@^2.3.15":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz#55adc616a075512ace64128eb34a9e071841ab14"
   integrity sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==
@@ -2058,19 +2029,6 @@
     "@sigstore/bundle" "^2.3.2"
     "@sigstore/core" "^1.1.0"
     "@sigstore/protobuf-specs" "^0.3.2"
-
-"@simplewebauthn/server@^13.1.1":
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/@simplewebauthn/server/-/server-13.1.1.tgz#5ea88cfa11fbfe91779ae1da8cd566ec3f510284"
-  integrity sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==
-  dependencies:
-    "@hexagon/base64" "^1.1.27"
-    "@levischuck/tiny-cbor" "^0.2.2"
-    "@peculiar/asn1-android" "^2.3.10"
-    "@peculiar/asn1-ecc" "^2.3.8"
-    "@peculiar/asn1-rsa" "^2.3.8"
-    "@peculiar/asn1-schema" "^2.3.8"
-    "@peculiar/asn1-x509" "^2.3.8"
 
 "@sindresorhus/is@^4.6.0":
   version "4.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,6 +2861,13 @@ capability@^0.2.5:
   resolved "https://registry.yarnpkg.com/capability/-/capability-0.2.5.tgz#51ad87353f1936ffd77f2f21c74633a4dea88801"
   integrity sha512-rsJZYVCgXd08sPqwmaIqjAd5SUTfonV0z/gDJ8D6cN8wQphky1kkAYEqQ+hmDxTw7UihvBfjUVUSY+DBEe44jg==
 
+cbor@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-10.0.3.tgz#202d79cd696f408700af51b0c9771577048a860e"
+  integrity sha512-72Jnj81xMsqepqdcSdf2+fflz/UDsThOHy5hj2MW5F5xzHL8Oa0KQ6I6V9CwVUPxg5pf+W9xp6W2KilaRXWWtw==
+  dependencies:
+    nofilter "^3.0.2"
+
 chai@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.1.tgz#f035d9792a22b481ead1c65908d14bb62ec1c82c"
@@ -5096,6 +5103,11 @@ node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
+
+nofilter@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@^7.0.0, nopt@^7.2.1:
   version "7.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,6 +531,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.1.tgz#df6e5943edcea504bac61395926d6fd67869a0d5"
   integrity sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==
 
+"@noble/hashes@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
+  integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,6 +436,11 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
   integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
 
+"@hexagon/base64@^1.1.27":
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/@hexagon/base64/-/base64-1.1.28.tgz#7d306a97f1423829be5b27c9d388fe50e3099d48"
+  integrity sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -489,6 +494,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@levischuck/tiny-cbor@^0.2.2":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz#833ddf7f3627dcb62d855d9c184061b4a1a875b3"
+  integrity sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==
 
 "@lifeomic/attempt@^3.1.0":
   version "3.1.0"
@@ -816,7 +826,16 @@
   dependencies:
     "@octokit/openapi-types" "^22.2.0"
 
-"@peculiar/asn1-ecc@^2.3.15":
+"@peculiar/asn1-android@^2.3.10":
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-android/-/asn1-android-2.3.15.tgz#5eb36597bb0133ecaf9ed6b5cfc847d367deabd0"
+  integrity sha512-8U2TIj59cRlSXTX2d0mzUKP7whfWGFMzTeC3qPgAbccXFrPNZLaDhpNEdG5U2QZ/tBv/IHlCJ8s+KYXpJeop6w==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.15"
+    asn1js "^3.0.5"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-ecc@^2.3.15", "@peculiar/asn1-ecc@^2.3.8":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz#2301cff76a089bfa2ec93b4cfd9071a382aa677f"
   integrity sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==
@@ -826,7 +845,17 @@
     asn1js "^3.0.5"
     tslib "^2.8.1"
 
-"@peculiar/asn1-schema@^2.3.15":
+"@peculiar/asn1-rsa@^2.3.8":
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz#0e24aadcc96b34f57b488c6c95e3eedbb1cb1c73"
+  integrity sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.3.15"
+    "@peculiar/asn1-x509" "^2.3.15"
+    asn1js "^3.0.5"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-schema@^2.3.15", "@peculiar/asn1-schema@^2.3.8":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz#e926bfdeed51945a06f38be703499e7d8341a5d3"
   integrity sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==
@@ -835,7 +864,7 @@
     pvtsutils "^1.3.6"
     tslib "^2.8.1"
 
-"@peculiar/asn1-x509@^2.3.15":
+"@peculiar/asn1-x509@^2.3.15", "@peculiar/asn1-x509@^2.3.8":
   version "2.3.15"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz#55adc616a075512ace64128eb34a9e071841ab14"
   integrity sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==
@@ -2029,6 +2058,19 @@
     "@sigstore/bundle" "^2.3.2"
     "@sigstore/core" "^1.1.0"
     "@sigstore/protobuf-specs" "^0.3.2"
+
+"@simplewebauthn/server@^13.1.1":
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/@simplewebauthn/server/-/server-13.1.1.tgz#5ea88cfa11fbfe91779ae1da8cd566ec3f510284"
+  integrity sha512-1hsLpRHfSuMB9ee2aAdh0Htza/X3f4djhYISrggqGe3xopNjOcePiSDkDDoPzDYaaMCrbqGP1H2TYU7bgL9PmA==
+  dependencies:
+    "@hexagon/base64" "^1.1.27"
+    "@levischuck/tiny-cbor" "^0.2.2"
+    "@peculiar/asn1-android" "^2.3.10"
+    "@peculiar/asn1-ecc" "^2.3.8"
+    "@peculiar/asn1-rsa" "^2.3.8"
+    "@peculiar/asn1-schema" "^2.3.8"
+    "@peculiar/asn1-x509" "^2.3.8"
 
 "@sindresorhus/is@^4.6.0":
   version "4.6.0"


### PR DESCRIPTION
In order to allow user to use widget with passkeys, they must provide user's public key in the next format `curve:base58`. For example:
```
ed25519:Gxa24TGbJu4mqdhW3GbvLXmf4bSEyxVicrtpChDWbgga
p256:3NSY8SFTWoPFMrTGdLVqPogirCyt3kMnUajXoDQuVeCsA6wzkMMp5whBqymAPM7xFiBthDKueiUv1zVAj7GDT8rQ
```

Formatted public key can be provided instead of address of the user:
```tsx
<Widget userAddress="ed25519:..." chainType="webauth" />
```

Such public keys will be converted to user id within Near Intents:
1. "ed25519" keys will produce Near-implicit-like address (64 symbol hex)
2. "p256" keys will produce ethereum-like address (0x...)

Such addresses are made up, so nobody has access to such addresses outside the protocol and users can't sign Ethereum (or Near) transactions on behalf of these addresses. They are just for sake of users identification within the protocol, because the protocol mandates that all users must have valid Near address. We need to be careful with such addresses (don't show them ideally).

# Tests

Important part of the feature (`verifyAuthenticatorAssertion` and `makeWebAuthnMultiPayload` in specific) is not covered with tests, because the code directly operates with the raw output of WebAuthn. It's hard to reproduce WebAuthn behaviour in nodejs. 

# Follow up

In the future it's better to rename `userAddress` and `chainType` props and variables to properly reflect purpose. I think about `credential` and `credentialType`.

I also worry about bundle size, because this feature adds new dependencies. Maybe in the future we would need lazy execution, or allow to opt-in for specific features.