### PR TITLE
fix: update OTC fee calculation

### DIFF
--- a/src/features/otcDesk/components/OtcMakerReadyOrderDialog.tsx
+++ b/src/features/otcDesk/components/OtcMakerReadyOrderDialog.tsx
@@ -87,8 +87,9 @@ function OrderDialog({
   const breakdown =
     protocolFee != null
       ? computeTradeBreakdown({
-          amountIn: context.parsed.amountIn,
-          amountOut: context.parsed.amountOut,
+          multiPayload: context.multiPayload,
+          tokenIn: context.parsed.tokenIn,
+          tokenOut: context.parsed.tokenOut,
           protocolFee,
         })
       : null

--- a/src/features/otcDesk/components/OtcMakerTrades.tsx
+++ b/src/features/otcDesk/components/OtcMakerTrades.tsx
@@ -45,9 +45,8 @@ import {
 } from "../stores/otcMakerTrades"
 import type { SignMessage } from "../types/sharedTypes"
 import {
-  type DetermineTokenInAndOutErr,
-  determineTokenInAndOut,
-  getTokenIds,
+  type DetermineInvolvedTokensErr,
+  determineInvolvedTokens,
 } from "../utils/deriveTradeTerms"
 import {
   type ParseTradeTermsErr,
@@ -127,22 +126,16 @@ function OtcMakerTradeItem({
   signerCredentials,
 }: OtcMakerTradeItemProps) {
   const tradeTermsResult = parseTradeTerms(multiPayload)
-    .mapErr<ParseTradeTermsErr | DetermineTokenInAndOutErr>((a) => a)
-    .andThen((tradeTerms) => {
-      const { tokenIdsIn, tokenIdsOut } = getTokenIds(tradeTerms.tokenDiff)
-      const tokensResult = determineTokenInAndOut(
-        tokenList,
-        tokenIdsIn,
-        tokenIdsOut
-      )
-      return tokensResult.map(({ tokenIn, tokenOut }) => {
-        return {
+    .mapErr<ParseTradeTermsErr | DetermineInvolvedTokensErr>((a) => a)
+    .andThen((tradeTerms) =>
+      determineInvolvedTokens(tokenList, tradeTerms.tokenDiff).map(
+        ({ tokenIn, tokenOut }) => ({
           tradeTerms: tradeTerms,
           tokenIn: tokenIn,
           tokenOut: tokenOut,
-        }
-      })
-    })
+        })
+      )
+    )
 
   if (tradeTermsResult.isErr()) {
     return <div>Error: {tradeTermsResult.unwrapErr()}</div>

--- a/src/features/otcDesk/components/OtcTakerForm.tsx
+++ b/src/features/otcDesk/components/OtcTakerForm.tsx
@@ -7,6 +7,7 @@ import { ButtonCustom } from "../../../components/Button/ButtonCustom"
 import type { SignerCredentials } from "../../../core/formatters"
 import { useTokensUsdPrices } from "../../../hooks/useTokensUsdPrices"
 import { getDepositedBalances } from "../../../services/defuseBalanceService"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../../../types/base"
 import type { MultiPayload } from "../../../types/defuse-contracts-types"
 import { assert } from "../../../utils/assert"
 import { userAddressToDefuseUserId } from "../../../utils/defuse"
@@ -26,6 +27,8 @@ export type OtcTakerFormProps = {
   tradeId: string
   makerMultiPayload: MultiPayload
   tradeTerms: TradeTerms
+  tokenIn: BaseTokenInfo | UnifiedTokenInfo
+  tokenOut: BaseTokenInfo | UnifiedTokenInfo
   signerCredentials: SignerCredentials | null
   signMessage: SignMessage
   protocolFee: number
@@ -37,6 +40,8 @@ export function OtcTakerForm({
   tradeId,
   makerMultiPayload,
   tradeTerms,
+  tokenIn,
+  tokenOut,
   protocolFee,
   signerCredentials,
   signMessage,
@@ -44,14 +49,14 @@ export function OtcTakerForm({
   referral,
 }: OtcTakerFormProps) {
   const totalAmountIn = computeTotalBalanceDifferentDecimals(
-    tradeTerms.tokenIn,
+    tokenIn,
     tradeTerms.takerTokenDiff,
     { strict: false }
   )
   assert(totalAmountIn)
 
   const totalAmountOut = computeTotalBalanceDifferentDecimals(
-    tradeTerms.tokenOut,
+    tokenOut,
     tradeTerms.takerTokenDiff,
     { strict: false }
   )
@@ -60,12 +65,12 @@ export function OtcTakerForm({
   const { data: tokensUsdPriceData } = useTokensUsdPrices()
   const usdAmountIn = getTokenUsdPrice(
     formatTokenValue(-totalAmountIn.amount, totalAmountIn.decimals),
-    tradeTerms.tokenIn,
+    tokenIn,
     tokensUsdPriceData
   )
   const usdAmountOut = getTokenUsdPrice(
     formatTokenValue(totalAmountOut.amount, totalAmountOut.decimals),
-    tradeTerms.tokenOut,
+    tokenOut,
     tokensUsdPriceData
   )
 
@@ -89,10 +94,10 @@ export function OtcTakerForm({
       const balances = await getDepositedBalances(
         signerId,
         [
-          ...getUnderlyingBaseTokenInfos(tradeTerms.tokenIn).map(
+          ...getUnderlyingBaseTokenInfos(tokenIn).map(
             (token) => token.defuseAssetId
           ),
-          ...getUnderlyingBaseTokenInfos(tradeTerms.tokenOut).map(
+          ...getUnderlyingBaseTokenInfos(tokenOut).map(
             (token) => token.defuseAssetId
           ),
         ],
@@ -102,13 +107,13 @@ export function OtcTakerForm({
       )
 
       const tokenInBalance = computeTotalBalanceDifferentDecimals(
-        tradeTerms.tokenIn,
+        tokenIn,
         balances,
         { strict: false }
       )
 
       const tokenOutBalance = computeTotalBalanceDifferentDecimals(
-        tradeTerms.tokenOut,
+        tokenOut,
         balances,
         { strict: false }
       )
@@ -122,7 +127,7 @@ export function OtcTakerForm({
   })
 
   const preparation = useOtcTakerPreparation({
-    tokenIn: tradeTerms.tokenIn,
+    tokenIn: tokenIn,
     takerTokenDiff: tradeTerms.takerTokenDiff,
     protocolFee,
     takerId: signerId,
@@ -175,9 +180,7 @@ export function OtcTakerForm({
                 )}
               />
             }
-            tokenSlot={
-              <TokenAmountInputCard.DisplayToken token={tradeTerms.tokenIn} />
-            }
+            tokenSlot={<TokenAmountInputCard.DisplayToken token={tokenIn} />}
             balanceSlot={
               <BlockMultiBalances
                 balance={balances?.tokenIn?.amount ?? 0n}
@@ -223,9 +226,7 @@ export function OtcTakerForm({
                 )}
               />
             }
-            tokenSlot={
-              <TokenAmountInputCard.DisplayToken token={tradeTerms.tokenOut} />
-            }
+            tokenSlot={<TokenAmountInputCard.DisplayToken token={tokenOut} />}
             balanceSlot={
               <BlockMultiBalances
                 balance={balances?.tokenOut?.amount ?? 0n}

--- a/src/features/otcDesk/components/OtcTakerForm.tsx
+++ b/src/features/otcDesk/components/OtcTakerForm.tsx
@@ -1,5 +1,6 @@
 import { ArrowDown } from "@phosphor-icons/react"
 import { useQuery } from "@tanstack/react-query"
+import { None } from "@thames/monads"
 import clsx from "clsx"
 import { providers } from "near-api-js"
 import { BlockMultiBalances } from "../../../components/Block/BlockMultiBalances"
@@ -15,7 +16,9 @@ import { formatTokenValue, formatUsdAmount } from "../../../utils/format"
 import getTokenUsdPrice from "../../../utils/getTokenUsdPrice"
 import {
   computeTotalBalanceDifferentDecimals,
+  computeTotalDeltaDifferentDecimals,
   getUnderlyingBaseTokenInfos,
+  negateTokenValue,
 } from "../../../utils/tokenUtils"
 import { TokenAmountInputCard } from "../../deposit/components/DepositForm/TokenAmountInputCard"
 import { useOtcTakerConfirmTrade } from "../hooks/useOtcTakerConfirmTrade"
@@ -48,32 +51,6 @@ export function OtcTakerForm({
   onSuccessTrade,
   referral,
 }: OtcTakerFormProps) {
-  const totalAmountIn = computeTotalBalanceDifferentDecimals(
-    tokenIn,
-    tradeTerms.takerTokenDiff,
-    { strict: false }
-  )
-  assert(totalAmountIn)
-
-  const totalAmountOut = computeTotalBalanceDifferentDecimals(
-    tokenOut,
-    tradeTerms.takerTokenDiff,
-    { strict: false }
-  )
-  assert(totalAmountOut)
-
-  const { data: tokensUsdPriceData } = useTokensUsdPrices()
-  const usdAmountIn = getTokenUsdPrice(
-    formatTokenValue(-totalAmountIn.amount, totalAmountIn.decimals),
-    tokenIn,
-    tokensUsdPriceData
-  )
-  const usdAmountOut = getTokenUsdPrice(
-    formatTokenValue(totalAmountOut.amount, totalAmountOut.decimals),
-    tokenOut,
-    tokensUsdPriceData
-  )
-
   const signerId =
     signerCredentials != null
       ? userAddressToDefuseUserId(
@@ -141,6 +118,59 @@ export function OtcTakerForm({
     referral,
   })
 
+  const { totalAmountIn, totalAmountOut } = (
+    preparation.data?.ok() || None
+  ).match({
+    some: ({ tokenDelta }) => {
+      // This is the actual amount that the taker will send and receive
+
+      const totalAmountIn = negateTokenValue(
+        computeTotalDeltaDifferentDecimals(
+          getUnderlyingBaseTokenInfos(tokenIn),
+          tokenDelta
+        )
+      )
+      const totalAmountOut = computeTotalDeltaDifferentDecimals(
+        getUnderlyingBaseTokenInfos(tokenOut),
+        tokenDelta
+      )
+      return { totalAmountIn, totalAmountOut }
+    },
+
+    none: () => {
+      // This is the fallback amount, since the preparation didn't complete
+
+      let totalAmountIn = computeTotalBalanceDifferentDecimals(
+        tokenIn,
+        tradeTerms.takerTokenDiff,
+        { strict: false }
+      )
+      assert(totalAmountIn)
+      totalAmountIn = negateTokenValue(totalAmountIn)
+
+      const totalAmountOut = computeTotalBalanceDifferentDecimals(
+        tokenOut,
+        tradeTerms.takerTokenDiff,
+        { strict: false }
+      )
+      assert(totalAmountOut)
+
+      return { totalAmountIn, totalAmountOut }
+    },
+  })
+
+  const { data: tokensUsdPriceData } = useTokensUsdPrices()
+  const usdAmountIn = getTokenUsdPrice(
+    formatTokenValue(totalAmountIn.amount, totalAmountIn.decimals),
+    tokenIn,
+    tokensUsdPriceData
+  )
+  const usdAmountOut = getTokenUsdPrice(
+    formatTokenValue(totalAmountOut.amount, totalAmountOut.decimals),
+    tokenOut,
+    tokensUsdPriceData
+  )
+
   return (
     <div className="flex flex-col">
       {/* Header Section */}
@@ -175,7 +205,7 @@ export function OtcTakerForm({
                 readOnly
                 name="amount"
                 value={formatTokenValue(
-                  -totalAmountIn.amount,
+                  totalAmountIn.amount,
                   totalAmountIn.decimals
                 )}
               />

--- a/src/features/otcDesk/components/OtcTakerInvalidOrder.tsx
+++ b/src/features/otcDesk/components/OtcTakerInvalidOrder.tsx
@@ -1,7 +1,11 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
 import { Cross2Icon } from "@radix-ui/react-icons"
 import { Callout } from "@radix-ui/themes"
-import type { TokenValue } from "../../../types/base"
+import type {
+  BaseTokenInfo,
+  TokenValue,
+  UnifiedTokenInfo,
+} from "../../../types/base"
 import { assert } from "../../../utils/assert"
 import {
   computeTotalBalanceDifferentDecimals,
@@ -14,9 +18,13 @@ import { SwapStrip } from "./shared/SwapStrip"
 export function OtcTakerInvalidOrder({
   error,
   tradeTerms,
+  tokenIn,
+  tokenOut,
 }: {
   error?: string
   tradeTerms?: TradeTerms
+  tokenIn?: BaseTokenInfo | UnifiedTokenInfo
+  tokenOut?: BaseTokenInfo | UnifiedTokenInfo
 }) {
   let amountIn: TokenValue | undefined
   let amountOut: TokenValue | undefined
@@ -27,15 +35,15 @@ export function OtcTakerInvalidOrder({
       }
     | undefined
 
-  if (tradeTerms != null) {
+  if (tradeTerms != null && tokenIn != null && tokenOut != null) {
     amountIn = computeTotalBalanceDifferentDecimals(
-      getUnderlyingBaseTokenInfos(tradeTerms.tokenIn),
+      getUnderlyingBaseTokenInfos(tokenIn),
       tradeTerms.takerTokenDiff,
       { strict: false }
     )
 
     amountOut = computeTotalBalanceDifferentDecimals(
-      getUnderlyingBaseTokenInfos(tradeTerms.tokenOut),
+      getUnderlyingBaseTokenInfos(tokenOut),
       tradeTerms.takerTokenDiff,
       { strict: false }
     )
@@ -82,14 +90,17 @@ export function OtcTakerInvalidOrder({
       )}
 
       {/* Order Section */}
-      {tradeTerms != null && breakdown != null && (
-        <SwapStrip
-          tokenIn={tradeTerms.tokenIn}
-          tokenOut={tradeTerms.tokenOut}
-          amountIn={breakdown.takerSends}
-          amountOut={breakdown.takerReceives}
-        />
-      )}
+      {tradeTerms != null &&
+        breakdown != null &&
+        tokenIn != null &&
+        tokenOut != null && (
+          <SwapStrip
+            tokenIn={tokenIn}
+            tokenOut={tokenOut}
+            amountIn={breakdown.takerSends}
+            amountOut={breakdown.takerReceives}
+          />
+        )}
     </div>
   )
 }

--- a/src/features/otcDesk/components/OtcTakerSuccessScreen.tsx
+++ b/src/features/otcDesk/components/OtcTakerSuccessScreen.tsx
@@ -2,6 +2,7 @@ import { Check as CheckIcon } from "@phosphor-icons/react"
 import { useQuery } from "@tanstack/react-query"
 import { CopyButton } from "src/components/IntentCard/CopyButton"
 import { waitForIntentSettlement } from "../../../services/intentService"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../../../types/base"
 import { assert } from "../../../utils/assert"
 import {
   computeTotalBalanceDifferentDecimals,
@@ -16,18 +17,22 @@ const NEAR_EXPLORER = "https://nearblocks.io"
 export function OtcTakerSuccessScreen({
   tradeTerms,
   intentHashes,
+  tokenIn,
+  tokenOut,
 }: {
   tradeTerms: TradeTerms
   intentHashes: string[]
+  tokenIn: BaseTokenInfo | UnifiedTokenInfo
+  tokenOut: BaseTokenInfo | UnifiedTokenInfo
 }) {
   const amountIn = computeTotalBalanceDifferentDecimals(
-    getUnderlyingBaseTokenInfos(tradeTerms.tokenIn),
+    getUnderlyingBaseTokenInfos(tokenIn),
     tradeTerms.takerTokenDiff,
     { strict: false }
   )
 
   const amountOut = computeTotalBalanceDifferentDecimals(
-    getUnderlyingBaseTokenInfos(tradeTerms.tokenOut),
+    getUnderlyingBaseTokenInfos(tokenOut),
     tradeTerms.takerTokenDiff,
     { strict: false }
   )
@@ -81,8 +86,8 @@ export function OtcTakerSuccessScreen({
 
       {/* Order Section */}
       <SwapStrip
-        tokenIn={tradeTerms.tokenIn}
-        tokenOut={tradeTerms.tokenOut}
+        tokenIn={tokenIn}
+        tokenOut={tokenOut}
         amountIn={breakdown.takerSends}
         amountOut={breakdown.takerReceives}
       />

--- a/src/features/otcDesk/components/OtcTakerWidget.tsx
+++ b/src/features/otcDesk/components/OtcTakerWidget.tsx
@@ -17,7 +17,13 @@ import { fetchProtocolFee } from "../actors/otcMakerConfigLoadActor"
 import { SignIntentActorProvider } from "../providers/SignIntentActorProvider"
 import { useOtcTakerTrades } from "../stores/otcTakerTrades"
 import type { SignMessage } from "../types/sharedTypes"
-import { type TradeTerms, deriveTradeTerms } from "../utils/deriveTradeTerms"
+import {
+  type DeriveTradeTermsErr,
+  type DetermineInvolvedTokensErr,
+  type TradeTerms,
+  deriveTradeTerms,
+  determineInvolvedTokens,
+} from "../utils/deriveTradeTerms"
 import { genLocalTradeId } from "../utils/genLocalTradeId"
 import { OtcTakerForm } from "./OtcTakerForm"
 import { OtcTakerInvalidOrder } from "./OtcTakerInvalidOrder"
@@ -79,18 +85,28 @@ function OtcTakerScreens({
     queryFn: fetchProtocolFee,
   })
 
-  const tradeTerms = useMemo(() => {
+  const enrichedTradeTerms = useMemo(() => {
     if (protocolFee == null) {
       return null
     }
 
-    const tradeTerms = deriveTradeTerms(multiPayload, tokenList, protocolFee)
+    const result = deriveTradeTerms(multiPayload, protocolFee)
+      .mapErr<DeriveTradeTermsErr | DetermineInvolvedTokensErr>((a) => a)
+      .andThen((tradeTerms) => {
+        return determineInvolvedTokens(
+          tokenList,
+          tradeTerms.takerTokenDiff
+        ).map((tokens) => ({
+          ...tokens,
+          tradeTerms,
+        }))
+      })
 
-    if (tradeTerms.isErr()) {
-      logger.error(tradeTerms.unwrapErr())
+    if (result.isErr()) {
+      logger.error(result.unwrapErr())
     }
 
-    return tradeTerms
+    return result
   }, [multiPayload, tokenList, protocolFee])
 
   const [publishResult, setPublishResult] = useState<{
@@ -101,28 +117,39 @@ function OtcTakerScreens({
 
   const knownOtcTakerTrade = useOtcTakerTrades((state) => state.trades[tradeId])
 
-  if (tradeTerms == null || protocolFee == null) {
+  if (enrichedTradeTerms == null || protocolFee == null) {
     return loading
   }
 
-  return tradeTerms.match({
-    ok: (tradeTerms) =>
+  return enrichedTradeTerms.match({
+    ok: ({ tradeTerms, tokenIn, tokenOut }) =>
       publishResult != null ? (
         <OtcTakerSuccessScreen
           tradeTerms={tradeTerms}
           intentHashes={publishResult.intentHashes}
+          tokenIn={tokenIn}
+          tokenOut={tokenOut}
         />
       ) : knownOtcTakerTrade?.status === "completed" ? (
         <OtcTakerSuccessScreen
           tradeTerms={tradeTerms}
           intentHashes={knownOtcTakerTrade.intentHashes}
+          tokenIn={tokenIn}
+          tokenOut={tokenOut}
         />
       ) : (
-        <OtcTakerValidationOrder tradeTerms={tradeTerms} fallback={loading}>
+        <OtcTakerValidationOrder
+          tradeTerms={tradeTerms}
+          tokenIn={tokenIn}
+          tokenOut={tokenOut}
+          fallback={loading}
+        >
           <SignIntentActorProvider sendNearTransaction={sendNearTransaction}>
             <OtcTakerForm
               tradeId={tradeId}
               tradeTerms={tradeTerms}
+              tokenIn={tokenIn}
+              tokenOut={tokenOut}
               makerMultiPayload={tradeTerms.makerMultiPayload}
               signerCredentials={signerCredentials}
               signMessage={signMessage}
@@ -139,9 +166,17 @@ function OtcTakerScreens({
 
 function OtcTakerValidationOrder({
   tradeTerms,
+  tokenIn,
+  tokenOut,
   fallback,
   children,
-}: { tradeTerms: TradeTerms; fallback: ReactNode; children: ReactNode }) {
+}: {
+  tradeTerms: TradeTerms
+  tokenIn: BaseTokenInfo | UnifiedTokenInfo
+  tokenOut: BaseTokenInfo | UnifiedTokenInfo
+  fallback: ReactNode
+  children: ReactNode
+}) {
   let error: Result<true, string> = Ok(true)
 
   if (new Date(tradeTerms.deadline) < new Date()) {
@@ -226,7 +261,12 @@ function OtcTakerValidationOrder({
       .andThen(() => makerBalanceValidation.data ?? noError)
 
     return (
-      <OtcTakerInvalidOrder error={error.unwrapErr()} tradeTerms={tradeTerms} />
+      <OtcTakerInvalidOrder
+        error={error.unwrapErr()}
+        tradeTerms={tradeTerms}
+        tokenIn={tokenIn}
+        tokenOut={tokenOut}
+      />
     )
   }
 

--- a/src/features/otcDesk/hooks/useOtcTakerConfirmTrade.ts
+++ b/src/features/otcDesk/hooks/useOtcTakerConfirmTrade.ts
@@ -62,9 +62,9 @@ export function useOtcTakerConfirmTrade({
         signerCredentials.credentialType
       )
 
-      const { quotes, quoteParams, tokenDiff } = preparation
+      const { quotes, quoteParams, tokenDelta } = preparation
 
-      const walletMessage = createSwapIntentMessage(tokenDiff, {
+      const walletMessage = createSwapIntentMessage(tokenDelta, {
         signerId,
         referral,
         memo: "OTC_FILL",

--- a/src/features/otcDesk/hooks/useOtcTakerPreparation.ts
+++ b/src/features/otcDesk/hooks/useOtcTakerPreparation.ts
@@ -18,7 +18,7 @@ import {
 export type OTCTakerPreparationOk = {
   quotes: AggregatedQuote[]
   quoteParams: QuoteExactInParams[]
-  tokenDiff: [string, bigint][]
+  tokenDelta: [string, bigint][]
 }
 
 export type OTCTakerPreparationErr = { reason: string } | AggregatedQuoteErr
@@ -82,11 +82,11 @@ export function useOtcTakerPreparation({
         })
       }
 
-      const tokenDiff: [string, bigint][] = Object.entries(tokensToReceive)
+      const tokenDelta: [string, bigint][] = Object.entries(tokensToReceive)
       const quoteParams: QuoteExactInParams[] = []
 
       for (const step of fillResult.steps) {
-        tokenDiff.push([step.fromToken, -step.fromAmount])
+        tokenDelta.push([step.fromToken, -step.fromAmount])
 
         if (step.fromToken !== step.toToken) {
           quoteParams.push({
@@ -100,8 +100,8 @@ export function useOtcTakerPreparation({
       const quotesResult = await manyQuotes(quoteParams)
 
       return quotesResult.map((quotes) => {
-        logger.verbose("return", { quotes, quoteParams, tokenDiff })
-        return { quotes, quoteParams, tokenDiff }
+        logger.verbose("return", { quotes, quoteParams, tokenDelta })
+        return { quotes, quoteParams, tokenDelta }
       })
     },
   })

--- a/src/features/otcDesk/utils/deriveTradeTerms.ts
+++ b/src/features/otcDesk/utils/deriveTradeTerms.ts
@@ -17,7 +17,7 @@ export type TradeTerms = {
   makerMultiPayload: MultiPayload
 }
 
-type DeriveTradeTermsErr = ParseTradeTermsErr | DetermineTokenInAndOutErr
+type DeriveTradeTermsErr = ParseTradeTermsErr | DetermineInvolvedTokensErr
 
 export function deriveTradeTerms(
   makerMultiPayload: MultiPayload | string,
@@ -56,18 +56,23 @@ function determineOppositeSideTradeDetails(
   protocolFee: number
 ) {
   const oppositeTokenDiff = computeOppositeSideTokenDiff(tokenDiff, protocolFee)
-  const { tokenIdsIn, tokenIdsOut } = getTokenIds(oppositeTokenDiff)
-  const tokensResult = determineTokenInAndOut(
-    tokenList,
-    tokenIdsIn,
-    tokenIdsOut
-  )
+  const tokensResult = determineInvolvedTokens(tokenList, oppositeTokenDiff)
 
   return tokensResult.map(({ tokenIn, tokenOut }) => ({
     oppositeTokenDiff,
-    tokenIn,
-    tokenOut,
+    tokenIn: tokenOut,
+    tokenOut: tokenIn,
   }))
+}
+
+export type DetermineInvolvedTokensErr = DetermineTokenInAndOutErr
+
+export function determineInvolvedTokens(
+  tokenList: (BaseTokenInfo | UnifiedTokenInfo)[],
+  tokenDiff: Record<BaseTokenInfo["defuseAssetId"], bigint>
+) {
+  const { tokenIdsIn, tokenIdsOut } = getTokenIds(tokenDiff)
+  return determineTokenInAndOut(tokenList, tokenIdsIn, tokenIdsOut)
 }
 
 export function computeOppositeSideTokenDiff(
@@ -88,7 +93,7 @@ export function computeOppositeSideTokenDiff(
   return oppositeTokenDiff
 }
 
-export function getTokenIds(
+function getTokenIds(
   tokenDiff: Record<BaseTokenInfo["defuseAssetId"], bigint>
 ) {
   const tokenIdsIn: BaseTokenInfo["defuseAssetId"][] = []
@@ -126,11 +131,11 @@ function findTokens(
   return Array.from(new Set(tokens))
 }
 
-export type DetermineTokenInAndOutErr =
+type DetermineTokenInAndOutErr =
   | "MULTIPLE_TOKENS_NOT_SUPPORTED"
   | "TOKEN_NOT_FOUND_IN_LIST"
 
-export function determineTokenInAndOut(
+function determineTokenInAndOut(
   tokenList: (BaseTokenInfo | UnifiedTokenInfo)[],
   tokenIdsIn: BaseTokenInfo["defuseAssetId"][],
   tokenIdsOut: BaseTokenInfo["defuseAssetId"][]

--- a/src/features/otcDesk/utils/deriveTradeTerms.ts
+++ b/src/features/otcDesk/utils/deriveTradeTerms.ts
@@ -12,57 +12,32 @@ export type TradeTerms = {
   makerTokenDiff: Record<BaseTokenInfo["defuseAssetId"], bigint>
   makerNonceBase64: string
   takerTokenDiff: Record<BaseTokenInfo["defuseAssetId"], bigint>
-  tokenIn: BaseTokenInfo | UnifiedTokenInfo
-  tokenOut: BaseTokenInfo | UnifiedTokenInfo
   makerMultiPayload: MultiPayload
 }
 
-type DeriveTradeTermsErr = ParseTradeTermsErr | DetermineInvolvedTokensErr
+export type DeriveTradeTermsErr = ParseTradeTermsErr
 
 export function deriveTradeTerms(
   makerMultiPayload: MultiPayload | string,
-  tokenList: (BaseTokenInfo | UnifiedTokenInfo)[],
   protocolFee: number
 ): Result<TradeTerms, DeriveTradeTermsErr> {
   const makerTermsResult = parseTradeTerms(makerMultiPayload)
 
-  return makerTermsResult
-    .mapErr<DeriveTradeTermsErr>((a) => a)
-    .andThen((makerTerms) => {
-      const takerTermsResult = determineOppositeSideTradeDetails(
-        tokenList,
-        makerTerms.tokenDiff,
-        protocolFee
-      )
+  return makerTermsResult.map((makerTerms) => {
+    const takerTokenDiff = computeOppositeSideTokenDiff(
+      makerTerms.tokenDiff,
+      protocolFee
+    )
 
-      return takerTermsResult.map(
-        ({ oppositeTokenDiff, tokenIn, tokenOut }) => ({
-          deadline: makerTerms.deadline,
-          makerUserId: makerTerms.userId,
-          makerTokenDiff: makerTerms.tokenDiff,
-          makerNonceBase64: makerTerms.nonceBase64,
-          takerTokenDiff: oppositeTokenDiff,
-          tokenIn,
-          tokenOut,
-          makerMultiPayload: makerTerms.multiPayload,
-        })
-      )
-    })
-}
-
-function determineOppositeSideTradeDetails(
-  tokenList: (BaseTokenInfo | UnifiedTokenInfo)[],
-  tokenDiff: Record<BaseTokenInfo["defuseAssetId"], bigint>,
-  protocolFee: number
-) {
-  const oppositeTokenDiff = computeOppositeSideTokenDiff(tokenDiff, protocolFee)
-  const tokensResult = determineInvolvedTokens(tokenList, oppositeTokenDiff)
-
-  return tokensResult.map(({ tokenIn, tokenOut }) => ({
-    oppositeTokenDiff,
-    tokenIn: tokenOut,
-    tokenOut: tokenIn,
-  }))
+    return {
+      deadline: makerTerms.deadline,
+      makerUserId: makerTerms.userId,
+      makerTokenDiff: makerTerms.tokenDiff,
+      makerNonceBase64: makerTerms.nonceBase64,
+      takerTokenDiff,
+      makerMultiPayload: makerTerms.multiPayload,
+    }
+  })
 }
 
 export type DetermineInvolvedTokensErr = DetermineTokenInAndOutErr

--- a/src/features/otcDesk/utils/deriveTradeTerms.ts
+++ b/src/features/otcDesk/utils/deriveTradeTerms.ts
@@ -124,17 +124,17 @@ function determineTokenInAndOut(
   const tokensIn = findTokens(tokenList, tokenIdsIn)
   const tokensOut = findTokens(tokenList, tokenIdsOut)
 
-  // We need to ensure that each group of tokens are resolved into a single token,
-  // otherwise it means user needs to sell multiple tokens or buy multiple tokens
-  if (tokensIn.length !== 1 || tokensOut.length !== 1) {
-    return Err("MULTIPLE_TOKENS_NOT_SUPPORTED")
-  }
-
   const tokenIn = tokensIn[0]
   const tokenOut = tokensOut[0]
 
   if (tokenIn == null || tokenOut == null) {
     return Err("TOKEN_NOT_FOUND_IN_LIST")
+  }
+
+  // We need to ensure that each group of tokens are resolved into a single token,
+  // otherwise it means user needs to sell multiple tokens or buy multiple tokens
+  if (tokensIn.length !== 1 || tokensOut.length !== 1) {
+    return Err("MULTIPLE_TOKENS_NOT_SUPPORTED")
   }
 
   return Ok({ tokenIn, tokenOut })

--- a/src/features/otcDesk/utils/deriveTradeTerms.ts
+++ b/src/features/otcDesk/utils/deriveTradeTerms.ts
@@ -1,4 +1,5 @@
 import { Err, Ok, type Result } from "@thames/monads"
+import { logger } from "../../../logger"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "../../../types/base"
 import type { MultiPayload } from "../../../types/defuse-contracts-types"
 import type { DefuseUserId } from "../../../utils/defuse"
@@ -47,6 +48,7 @@ export function determineInvolvedTokens(
   tokenDiff: Record<BaseTokenInfo["defuseAssetId"], bigint>
 ) {
   const { tokenIdsIn, tokenIdsOut } = getTokenIds(tokenDiff)
+
   return determineTokenInAndOut(tokenList, tokenIdsIn, tokenIdsOut)
 }
 
@@ -128,6 +130,9 @@ function determineTokenInAndOut(
   const tokenOut = tokensOut[0]
 
   if (tokenIn == null || tokenOut == null) {
+    logger.error("Couldn't find token in or out in token list", {
+      tokens: { in: tokenIdsIn, out: tokenIdsOut },
+    })
     return Err("TOKEN_NOT_FOUND_IN_LIST")
   }
 

--- a/src/features/otcDesk/utils/fillWithMinimalExchanges.test.ts
+++ b/src/features/otcDesk/utils/fillWithMinimalExchanges.test.ts
@@ -1,43 +1,9 @@
 import { describe, expect, it } from "vitest"
 import {
   type FillResult,
-  computeDoubleSwapResult,
   fillWithMinimalExchanges,
 } from "./fillWithMinimalExchanges"
 import type { TokenBalances } from "./fillWithMinimalExchanges"
-
-describe("computeDoubleSwapResult", () => {
-  it("calculates fees correctly for round numbers", () => {
-    const result = computeDoubleSwapResult(1000n, 30n) // 0.3% fee
-    expect(result.received).toBeLessThan(1000n)
-    expect(result.totalFee).toBe(6n) // 3n + 3n for both sides
-    expect(result.received + result.totalFee).toBe(1000n)
-  })
-
-  it("rounds fees up", () => {
-    const result = computeDoubleSwapResult(1001n, 30n)
-    expect(result.totalFee).toBe(7n) // Rounds up 3.003 to 4 for first swap, 3 for second
-    expect(result.received).toBe(994n)
-  })
-
-  it("handles small amounts correctly", () => {
-    const result = computeDoubleSwapResult(10n, 30n)
-    expect(result.totalFee).toBe(2n)
-    expect(result.received).toBe(8n)
-  })
-
-  it("handles zero amount", () => {
-    const result = computeDoubleSwapResult(0n, 30n)
-    expect(result.totalFee).toBe(0n)
-    expect(result.received).toBe(0n)
-  })
-
-  it("handles high fee percentage", () => {
-    const result = computeDoubleSwapResult(1000n, 500n) // 5% fee
-    expect(result.totalFee).toBe(98n)
-    expect(result.received).toBe(902n)
-  })
-})
 
 describe("fillWithMinimalExchanges", () => {
   it("handles direct fills without exchanges", () => {
@@ -101,7 +67,7 @@ describe("fillWithMinimalExchanges", () => {
       expect.objectContaining({
         success: true,
         remainingBalances: {
-          A: 448n,
+          A: 449n,
           B: 0n,
           C: 200n,
         },
@@ -148,8 +114,8 @@ describe("fillWithMinimalExchanges", () => {
           "toToken": "B",
         },
         {
-          "fee": 2n,
-          "fromAmount": 92n,
+          "fee": 1n,
+          "fromAmount": 91n,
           "fromToken": "A",
           "toAmount": 90n,
           "toToken": "B",
@@ -162,8 +128,8 @@ describe("fillWithMinimalExchanges", () => {
           "toToken": "C",
         },
         {
-          "fee": 2n,
-          "fromAmount": 92n,
+          "fee": 1n,
+          "fromAmount": 91n,
           "fromToken": "A",
           "toAmount": 90n,
           "toToken": "C",
@@ -219,11 +185,11 @@ describe("fillWithMinimalExchanges", () => {
 
   it("verifies fee calculation in exchanges", () => {
     const balances: TokenBalances = {
-      A: 1000n,
+      A: 500000n,
       B: 0n,
     }
     const required: TokenBalances = {
-      B: 100n,
+      B: 250000n,
     }
     const result = fillWithMinimalExchanges(balances, required, 30n)
 
@@ -234,9 +200,9 @@ describe("fillWithMinimalExchanges", () => {
       {
         fromToken: "A",
         toToken: "B",
-        fromAmount: 102n,
-        toAmount: 100n,
-        fee: 2n,
+        fromAmount: 250753n,
+        toAmount: 250000n,
+        fee: 753n,
       },
     ])
   })
@@ -258,9 +224,9 @@ describe("fillWithMinimalExchanges", () => {
       {
         fromToken: "A",
         toToken: "B",
-        fromAmount: 112n,
+        fromAmount: 106n,
         toAmount: 100n,
-        fee: 12n,
+        fee: 6n,
       },
     ])
   })

--- a/src/features/otcDesk/utils/fillWithMinimalExchanges.ts
+++ b/src/features/otcDesk/utils/fillWithMinimalExchanges.ts
@@ -1,3 +1,5 @@
+import { grossUpAmount, netDownAmount } from "../../../utils/tokenUtils"
+
 export interface TokenBalances {
   [token: string]: bigint
 }
@@ -16,87 +18,29 @@ export interface FillResult {
   success: boolean
 }
 
-export function computeDoubleSwapResult(
-  amount: bigint,
-  feeBasisPoints: bigint
-): {
-  received: bigint
-  totalFee: bigint
-} {
-  // If fee is zero, no fees are charged
-  if (feeBasisPoints === 0n) {
-    return {
-      received: amount,
-      totalFee: 0n,
-    }
-  }
-
-  // First swap fee (sending)
-  const firstFee = (amount * feeBasisPoints + 9999n) / 10000n
-  const afterFirstFee = amount - firstFee
-
-  // Second swap fee (receiving)
-  const secondFee = (afterFirstFee * feeBasisPoints + 9999n) / 10000n
-  const finalAmount = afterFirstFee - secondFee
-
-  return {
-    received: finalAmount,
-    totalFee: firstFee + secondFee,
-  }
-}
-
-function calculateRequiredSourceAmount(
-  targetAmount: bigint,
-  feeBasisPoints: bigint
-): bigint {
-  // If fee is zero, the required amount is the same as the target amount
-  if (feeBasisPoints === 0n) {
-    return targetAmount
-  }
-
-  // We need to solve the equation:
-  // sourceAmount - fee1 - fee2 = targetAmount
-  // where fee1 = ceil(sourceAmount * feeBps / 10000)
-  // and fee2 = ceil((sourceAmount - fee1) * feeBps / 10000)
-
-  // Using a simple approximation and then adjusting up if needed
-  let sourceAmount = (targetAmount * 10000n) / (10000n - 2n * feeBasisPoints)
-
-  while (true) {
-    const result = computeDoubleSwapResult(sourceAmount, feeBasisPoints)
-    if (result.received >= targetAmount) {
-      return sourceAmount
-    }
-    sourceAmount += 1n
-  }
-}
-
 // Find best sources combining multiple tokens if necessary
-function findBestSourceTokens(
+function findOptimalTokenSources(
   remainingBalances: TokenBalances,
   requiredAmount: bigint,
-  excludeToken: string,
+  targetToken: string,
   feeBasisPoints: bigint
 ): { steps: FillStep[]; success: boolean } {
-  const sourceAmount = calculateRequiredSourceAmount(
-    requiredAmount,
-    feeBasisPoints
-  )
+  const sourceAmount = grossUpAmount(requiredAmount, Number(feeBasisPoints))
 
-  // Try to find a single token first (original approach)
+  // Try to find a single token first
   for (const [token, balance] of Object.entries(remainingBalances)) {
-    if (token !== excludeToken && balance >= sourceAmount) {
+    if (token !== targetToken && balance >= sourceAmount) {
       // We found a single token with sufficient balance
-      const swapResult = computeDoubleSwapResult(sourceAmount, feeBasisPoints)
+      const received = netDownAmount(sourceAmount, Number(feeBasisPoints))
 
       return {
         steps: [
           {
             fromToken: token,
-            toToken: excludeToken,
+            toToken: targetToken,
             fromAmount: sourceAmount,
-            toAmount: swapResult.received,
-            fee: swapResult.totalFee,
+            toAmount: received,
+            fee: sourceAmount - received,
           },
         ],
         success: true,
@@ -107,7 +51,7 @@ function findBestSourceTokens(
   // If no single token is sufficient, try combining tokens
   // Sort tokens by balance (descending) to use larger balances first
   const sortedTokens = Object.entries(remainingBalances)
-    .filter(([token]) => token !== excludeToken)
+    .filter(([token]) => token !== targetToken)
     .sort(([, a], [, b]) => (b > a ? -1 : b < a ? 1 : 0))
 
   if (sortedTokens.length === 0) {
@@ -136,14 +80,14 @@ function findBestSourceTokens(
     remainingNeeded -= amountToUse
 
     if (amountToUse > 0n) {
-      const swapResult = computeDoubleSwapResult(amountToUse, feeBasisPoints)
+      const received = netDownAmount(amountToUse, Number(feeBasisPoints))
 
       steps.push({
         fromToken: token,
-        toToken: excludeToken,
+        toToken: targetToken,
         fromAmount: amountToUse,
-        toAmount: swapResult.received,
-        fee: swapResult.totalFee,
+        toAmount: received,
+        fee: amountToUse - received,
       })
     }
   }
@@ -202,8 +146,8 @@ export function fillWithMinimalExchanges(
       result.remainingBalances[token] = 0n
     }
 
-    // Find best sources, possibly combining multiple tokens
-    const sourceResult = findBestSourceTokens(
+    // Find best sources for the remaining required amount
+    const sourceResult = findOptimalTokenSources(
       result.remainingBalances,
       remainingRequired,
       token,

--- a/src/features/otcDesk/utils/otcMakerBreakdown.ts
+++ b/src/features/otcDesk/utils/otcMakerBreakdown.ts
@@ -1,31 +1,57 @@
-import type { TokenValue } from "../../../types/base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "../../../types/base"
+import type { MultiPayload } from "../../../types/defuse-contracts-types"
+import { assert } from "../../../utils/assert"
 import {
-  grossUpAmount,
-  netDownAmount,
+  computeTotalBalanceDifferentDecimals,
+  negateTokenValue,
   subtractAmounts,
 } from "../../../utils/tokenUtils"
 import type { TradeBreakdown } from "../types/sharedTypes"
+import { deriveTradeTerms } from "./deriveTradeTerms"
 
 export function computeTradeBreakdown(params: {
-  amountIn: TokenValue
-  amountOut: TokenValue
+  multiPayload: MultiPayload
+  tokenIn: BaseTokenInfo | UnifiedTokenInfo
+  tokenOut: BaseTokenInfo | UnifiedTokenInfo
   protocolFee: number
 }): TradeBreakdown {
-  const takerSends = {
-    amount: grossUpAmount(params.amountOut.amount, params.protocolFee),
-    decimals: params.amountOut.decimals,
-  }
-  const takerReceives = {
-    amount: netDownAmount(params.amountIn.amount, params.protocolFee),
-    decimals: params.amountIn.decimals,
-  }
+  const tradeTerms = deriveTradeTerms(
+    params.multiPayload,
+    params.protocolFee
+  ).unwrap()
+
+  let makerSends = computeTotalBalanceDifferentDecimals(
+    params.tokenIn,
+    tradeTerms.makerTokenDiff,
+    { strict: false }
+  )
+  const makerReceives = computeTotalBalanceDifferentDecimals(
+    params.tokenOut,
+    tradeTerms.makerTokenDiff,
+    { strict: false }
+  )
+  assert(makerSends != null && makerReceives != null)
+  makerSends = negateTokenValue(makerSends)
+
+  const takerReceives = computeTotalBalanceDifferentDecimals(
+    params.tokenIn, // tokenOut is tokenIn in the context of the taker
+    tradeTerms.takerTokenDiff,
+    { strict: false }
+  )
+  let takerSends = computeTotalBalanceDifferentDecimals(
+    params.tokenOut, // tokenIn is tokenOut in the context of the taker
+    tradeTerms.takerTokenDiff,
+    { strict: false }
+  )
+  assert(takerSends != null && takerReceives != null)
+  takerSends = negateTokenValue(takerSends)
 
   return {
-    makerSends: params.amountIn,
-    makerReceives: params.amountOut,
-    makerPaysFee: subtractAmounts(params.amountIn, takerReceives),
+    makerSends,
+    makerReceives,
+    makerPaysFee: subtractAmounts(makerSends, takerReceives),
     takerSends,
     takerReceives,
-    takerPaysFee: subtractAmounts(takerSends, params.amountOut),
+    takerPaysFee: subtractAmounts(takerSends, makerReceives),
   }
 }


### PR DESCRIPTION
In both OTC forms, we show approximate amounts, which doesn't represent actual breakdown. Because trade breakdown depends on user's balance. This PR addresses this issue and incorrect fee computation issue, also includes required refactoring. Pr can be reviewed by commits.