### PR TITLE
fix: update 1 bip to be 1/10000 of 1%

### DIFF
--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -296,7 +296,7 @@ export const swapUIMachine = setup({
     intentRefs: [],
     tokenList: input.tokenList,
     referral: input.referral,
-    slippageBasisPoints: 100, // 1%
+    slippageBasisPoints: 10_000, // 1%
   }),
 
   entry: ["spawnBackgroundQuoterRef", "spawnDepositedBalanceRef"],

--- a/src/features/otcDesk/actors/otcMakerConfigLoadActor.ts
+++ b/src/features/otcDesk/actors/otcMakerConfigLoadActor.ts
@@ -70,6 +70,6 @@ export async function fetchProtocolFee() {
     throw new Error(`Expected number, got ${typeof value}`)
   }
 
-  // in bip: 1 bip = 0.01% = 0.0001
+  // in bip: 1 bip = 0.0001% = 0.000001
   return value
 }

--- a/src/features/otcDesk/utils/deriveTradeTerms.test.ts
+++ b/src/features/otcDesk/utils/deriveTradeTerms.test.ts
@@ -7,6 +7,6 @@ describe("computeOppositeSideTokenDiff()", () => {
       { usdc: -1_000_000n, usdt: 1_000_000n },
       1
     )
-    expect(result).toEqual({ usdc: 999_900n, usdt: -1_000_101n })
+    expect(result).toEqual({ usdc: 999_999n, usdt: -1_000_002n })
   })
 })

--- a/src/features/otcDesk/utils/fillWithMinimalExchanges.test.ts
+++ b/src/features/otcDesk/utils/fillWithMinimalExchanges.test.ts
@@ -200,9 +200,9 @@ describe("fillWithMinimalExchanges", () => {
       {
         fromToken: "A",
         toToken: "B",
-        fromAmount: 250753n,
+        fromAmount: 250008n,
         toAmount: 250000n,
-        fee: 753n,
+        fee: 8n,
       },
     ])
   })
@@ -215,7 +215,7 @@ describe("fillWithMinimalExchanges", () => {
     const required: TokenBalances = {
       B: 100n,
     }
-    const result = fillWithMinimalExchanges(balances, required, 500n) // 5% fee
+    const result = fillWithMinimalExchanges(balances, required, 50000n) // 5% fee
 
     expect(result.success).toBe(true)
     fillInvariant(balances, required, result)

--- a/src/utils/tokenUtils.test.ts
+++ b/src/utils/tokenUtils.test.ts
@@ -890,10 +890,10 @@ describe("getUnderlyingBaseTokenInfos", () => {
 describe("netDownAmount", () => {
   it("throws error for invalid feeBip", () => {
     expect(() => netDownAmount(100000n, -1)).toThrow(
-      "Invalid feeBip value. It must be between 0 and 10000."
+      "Invalid feeBip value. It must be between 0 and 1000000."
     )
-    expect(() => netDownAmount(100000n, 10001)).toThrow(
-      "Invalid feeBip value. It must be between 0 and 10000."
+    expect(() => netDownAmount(100000n, 1000001)).toThrow(
+      "Invalid feeBip value. It must be between 0 and 1000000."
     )
   })
 
@@ -902,18 +902,19 @@ describe("netDownAmount", () => {
   })
 
   /**
-   * 1 bip = 0.01% = 0.0001
-   * 30 bips = 0.3% = 0.003
-   * 10000 bips = 100% = 1
+   * 1 bip = 0.0001% = 0.000001
+   * 3000 bips = 0.3% = 0.003
+   * 1000000 bips = 100% = 1
    */
   it.each([
-    [1000000n, 1, 999900n],
-    [100300n, 30, 99999n],
-    [100000n, 30, 99700n],
+    [10000000n, 1, 9999990n],
+    [1000000n, 1, 999999n],
+    [100300n, 30, 100296n],
+    [100000n, 30, 99997n],
     [100000n, 0, 100000n],
-    [100000n, 10000, 0n],
-    [10002n, 1, 10000n],
-    [10001n, 1, 9999n],
+    [100000n, 1000000, 0n],
+    [10002n, 1, 10001n],
+    [10001n, 1, 10000n],
     [10000n, 1, 9999n],
     [1000n, 1, 999n],
     [100n, 1, 99n],
@@ -928,10 +929,10 @@ describe("netDownAmount", () => {
 describe("grossUpAmount", () => {
   it("throws error for invalid feeBip", () => {
     expect(() => grossUpAmount(100000n, -1)).toThrow(
-      "Invalid feeBip value. It must be between 0 and 10000."
+      "Invalid feeBip value. It must be between 0 and 1000000."
     )
-    expect(() => grossUpAmount(100000n, 10001)).toThrow(
-      "Invalid feeBip value. It must be between 0 and 10000."
+    expect(() => grossUpAmount(100000n, 1000001)).toThrow(
+      "Invalid feeBip value. It must be between 0 and 1000000."
     )
   })
 
@@ -940,15 +941,17 @@ describe("grossUpAmount", () => {
   })
 
   /**
-   * 1 bip = 0.01% = 0.0001
-   * 30 bips = 0.3% = 0.003
-   * 10000 bips = 100% = 1
+   * 1 bip = 0.0001% = 0.000001
+   * 3000 bips = 0.3% = 0.003
+   * 1000000 bips = 100% = 1
    */
   it.each([
-    [99999n, 30, 100300n],
-    [99700n, 30, 100000n],
+    [1_000_000n, 1, 1_000_002n],
+    [999_999n, 1, 1_000_000n],
+    [999999n, 30, 1000030n],
+    [99700n, 30, 99703n],
     [100000n, 0, 100000n],
-    [10000n, 1, 10002n],
+    [10000n, 1, 10001n],
     [9999n, 1, 10000n],
     [999n, 1, 1000n],
     [99n, 1, 100n],
@@ -966,16 +969,16 @@ describe("accountSlippageExactIn", () => {
   type Delta = [string, bigint][]
 
   it.each([
-    [[["token1", 1000n]], 100, [["token1", 990n]]],
-    [[["token1", 0n]], 100, [["token1", 0n]]],
-    [[["token1", -1000n]], 100, [["token1", -1000n]]],
+    [[["token1", 1000n]], 10000, [["token1", 990n]]],
+    [[["token1", 0n]], 10000, [["token1", 0n]]],
+    [[["token1", -1000n]], 10000, [["token1", -1000n]]],
     [
       [
         ["token1", 1000n],
         ["token2", -500n],
         ["token3", 0n],
       ],
-      100,
+      10000,
       [
         ["token1", 990n],
         ["token2", -500n],
@@ -983,11 +986,11 @@ describe("accountSlippageExactIn", () => {
       ],
     ],
     [[["token1", 1000n]], 0, [["token1", 1000n]]],
-    [[["token1", 1000n]], 10000, [["token1", 0n]]],
-    [[["token1", 100n]], 1, [["token1", 99n]]],
-    [[["token1", 99n]], 1, [["token1", 98n]]],
-    [[["token1", 2n]], 1, [["token1", 1n]]],
-    [[["token1", 1n]], 1, [["token1", 0n]]],
+    [[["token1", 1000n]], 1000000, [["token1", 0n]]],
+    [[["token1", 100n]], 100, [["token1", 99n]]],
+    [[["token1", 99n]], 100, [["token1", 98n]]],
+    [[["token1", 2n]], 100, [["token1", 1n]]],
+    [[["token1", 1n]], 100, [["token1", 0n]]],
   ] satisfies [Delta, number, Delta][])(
     "applies slippage to positive number",
     (delta, bip, expected) => {

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -274,18 +274,24 @@ export function negateTokenValue(value: TokenValue): TokenValue {
   }
 }
 
-// It's 100%
-const BASIS_POINTS_DENOMINATOR = 10_000n
+/**
+ * 1 bip = 0.0001% = 0.000001
+ * 3000 bips = 0.3% = 0.003
+ * 1000000 bips = 100% = 1
+ */
+const BASIS_POINTS_DENOMINATOR = 1_000_000n
 
 /**
  * Calculates net amount by deducting fee from gross amount.
  * @example
  * // If gross amount is 100000n with 0.3% fee, net amount is 99700n
- * netDownAmount({ amount: 100000n, decimals: 6 }, 30) == 99700n
+ * netDownAmount(100000n, 3000) == 99700n
  */
 export function netDownAmount(amount: bigint, feeBip: number): bigint {
   if (feeBip < 0 || feeBip > Number(BASIS_POINTS_DENOMINATOR)) {
-    throw new Error("Invalid feeBip value. It must be between 0 and 10000.")
+    throw new Error(
+      `Invalid feeBip value. It must be between 0 and ${BASIS_POINTS_DENOMINATOR}.`
+    )
   }
 
   if (amount < 0n) {
@@ -306,11 +312,13 @@ export function netDownAmount(amount: bigint, feeBip: number): bigint {
  * Calculates gross amount needed to achieve desired net amount after fee.
  * @example
  * // To receive net 100000n after 0.3% fee, gross amount needed is 100300n
- * grossUpAmount({ amount: 100000n, decimals: 6 }, 30) == 100300n
+ * grossUpAmount(100000n, 3000) == 100300n
  */
 export function grossUpAmount(amount: bigint, feeBip: number): bigint {
   if (feeBip < 0 || feeBip > Number(BASIS_POINTS_DENOMINATOR)) {
-    throw new Error("Invalid feeBip value. It must be between 0 and 10000.")
+    throw new Error(
+      `Invalid feeBip value. It must be between 0 and ${BASIS_POINTS_DENOMINATOR}.`
+    )
   }
 
   if (amount < 0n) {


### PR DESCRIPTION
The protocol assumes 1 point is 1/10000 of 1%. My initial assumption that 1 point is 1/100 of 1% was incorrect, which led to incorrect calculation.