### PR TITLE
feat: add support for validating TEX addresses in Zcash

### DIFF
--- a/src/utils/validateAddress.test.ts
+++ b/src/utils/validateAddress.test.ts
@@ -90,8 +90,11 @@ describe("validateAddress", () => {
       "zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9slya"
     const unifiedAddress =
       "u1pv2h74qrlq9k9uqh6xk5p6vyzgvj84h6jedxg9e6hfhske3xjqf27f2qsm2qz4t3zqnll98t9n60"
+    const texAddress = "tex1m2g868nlnyw64xnraxzukf4aeuffvn2wyxwjqx"
+
     expect(validateAddress(transparentAddress, "zcash")).toBe(true)
     expect(validateAddress(shieldedAddress, "zcash")).toBe(false)
     expect(validateAddress(unifiedAddress, "zcash")).toBe(false)
+    expect(validateAddress(texAddress, "zcash")).toBe(true)
   })
 })

--- a/src/utils/validateAddress.ts
+++ b/src/utils/validateAddress.ts
@@ -60,10 +60,9 @@ export function validateAddress(
  */
 function validateZcashAddress(address: string) {
   // Transparent address validation
-  // t1 for P2PKH addresses, t3 for P2SH addresses
-  const tAddrRegex = /^t[13][a-km-zA-HJ-NP-Z1-9]{33}$/
   if (address.startsWith("t1") || address.startsWith("t3")) {
-    return tAddrRegex.test(address)
+    // t1 for P2PKH addresses, t3 for P2SH addresses
+    return /^t[13][a-km-zA-HJ-NP-Z1-9]{33}$/.test(address)
   }
 
   // TEX address validation

--- a/src/utils/validateAddress.ts
+++ b/src/utils/validateAddress.ts
@@ -1,3 +1,4 @@
+import { bech32m } from "@scure/base"
 import { PublicKey } from "@solana/web3.js"
 import {
   isValidClassicAddress as xrp_isValidClassicAddress,
@@ -43,10 +44,41 @@ export function validateAddress(
       return xrp_isValidClassicAddress(address) || xrp_isValidXAddress(address)
 
     case "zcash":
-      return /^t[13][a-km-zA-HJ-NP-Z1-9]{33}$/.test(address) // t-addr (transparent)
+      return validateZcashAddress(address)
 
     default:
       blockchain satisfies never
       return false
   }
+}
+
+/**
+ * Validates Zcash addresses
+ * Supports:
+ * - Transparent addresses (t1, t3)
+ * - TEX addresses (tex1)
+ */
+function validateZcashAddress(address: string) {
+  // Transparent address validation
+  // t1 for P2PKH addresses, t3 for P2SH addresses
+  const tAddrRegex = /^t[13][a-km-zA-HJ-NP-Z1-9]{33}$/
+  if (address.startsWith("t1") || address.startsWith("t3")) {
+    return tAddrRegex.test(address)
+  }
+
+  // TEX address validation
+  const expectedHrp = "tex"
+  if (address.startsWith(`${expectedHrp}1`)) {
+    try {
+      const decoded = bech32m.decodeToBytes(address)
+      if (decoded.prefix !== expectedHrp) {
+        return false
+      }
+      return decoded.bytes.length === 20
+    } catch {
+      return false
+    }
+  }
+
+  return false
 }


### PR DESCRIPTION
PR adds support for new TEX type addresses (https://zips.z.cash/zip-0320.html#specification). Basically it's bech32m address with specific prefix and specific size.