### PR TITLE
refactor: use Query Client for retrieving balance

### DIFF
--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -6,9 +6,6 @@ interface Settings {
   quotePollingIntervalMs: number
   quoteMinDeadlineMs: number
   maxQuoteMinDeadlineMs: number
-  queries: {
-    staleTime: number
-  }
   rpcUrls: {
     [key in SupportedChainName]: string
   }
@@ -31,9 +28,6 @@ export const settings: Settings = {
    * The server will return quotes with at least this much time remaining.
    */
   maxQuoteMinDeadlineMs: 600_000,
-  queries: {
-    staleTime: 2000 * 60, // 2 minutes
-  },
   /**
    * RPC URLs for different blockchains.
    * Ensure these URLs are valid and accessible.

--- a/src/features/machines/depositedBalanceMachine.ts
+++ b/src/features/machines/depositedBalanceMachine.ts
@@ -1,3 +1,4 @@
+import { type QueryClient, QueryObserver } from "@tanstack/query-core"
 import { providers } from "near-api-js"
 import {
   type ActorRef,
@@ -5,9 +6,10 @@ import {
   type SnapshotFrom,
   assign,
   enqueueActions,
-  fromPromise,
+  fromCallback,
   setup,
 } from "xstate"
+import { queryClient } from "../../providers/QueryClientProvider"
 import {
   getDepositedBalances,
   getTransitBalances,
@@ -18,13 +20,14 @@ import type {
   UnifiedTokenInfo,
 } from "../../types/base"
 import type { ChainType } from "../../types/deposit"
-import { assert } from "../../utils/assert"
 import {
   type DefuseUserId,
   userAddressToDefuseUserId,
 } from "../../utils/defuse"
-import { isBaseToken } from "../../utils/token"
-import { computeTotalBalanceDifferentDecimals } from "../../utils/tokenUtils"
+import {
+  computeTotalBalanceDifferentDecimals,
+  getUnderlyingBaseTokenInfos,
+} from "../../utils/tokenUtils"
 
 export interface Input {
   parentRef?: ParentActor
@@ -59,59 +62,82 @@ export const depositedBalanceMachine = setup({
   types: {
     context: {} as {
       parentRef: ParentActor | undefined
-      defuseTokenIds: string[]
-      userAccountId: DefuseUserId | null
       balances: BalanceMapping
       transitBalances: BalanceMapping
+      depositedBalanceQueryObserver: DepositedBalanceQueryObserver
+      transitBalanceQueryObserver: TransitBalanceQueryObserver
     },
     events: {} as Events | SharedEvents,
     input: {} as Input,
   },
   actors: {
-    fetchBalanceActor: fromPromise(
-      async ({
+    getDepositedBalances: fromCallback(
+      ({
         input,
       }: {
-        input: {
-          parentRef: ThisActor
-          userAccountId: DefuseUserId
-          defuseTokenIds: string[]
-        }
+        input: { observer: DepositedBalanceQueryObserver; parentRef: ThisActor }
       }) => {
-        const { parentRef, userAccountId } = input
-
-        // If the token list is too large (>100 tokens) we should split it into multiple requests
-        // and `UPDATE_BALANCE_SLICE` on receiving each response
-        const balance = await getDepositedBalances(
-          userAccountId,
-          input.defuseTokenIds,
-          new providers.JsonRpcProvider({
-            url: "https://nearrpc.aurora.dev",
-          })
-        )
-
-        const transitBalances = await getTransitBalances(
-          userAccountId,
-          input.defuseTokenIds
-        )
-
-        parentRef.send({
-          type: "UPDATE_BALANCE_SLICE",
-          params: {
-            balanceSlice: balance,
-            transitBalanceSlice: transitBalances,
-          },
+        return input.observer.subscribe((result) => {
+          if (result.isSuccess) {
+            input.parentRef.send({
+              type: "UPDATE_BALANCE_SLICE",
+              params: {
+                balanceSlice: result.data,
+                transitBalanceSlice: {},
+              },
+            })
+          }
+        })
+      }
+    ),
+    getTransitBalances: fromCallback(
+      ({
+        input,
+      }: {
+        input: { observer: TransitBalanceQueryObserver; parentRef: ThisActor }
+      }) => {
+        return input.observer.subscribe((result) => {
+          if (result.isSuccess) {
+            input.parentRef.send({
+              type: "UPDATE_BALANCE_SLICE",
+              params: {
+                balanceSlice: {},
+                transitBalanceSlice: result.data,
+              },
+            })
+          }
         })
       }
     ),
   },
   actions: {
-    setUserAccountId: assign({
-      userAccountId: (_, accountId: DefuseUserId) => accountId,
-    }),
-    clearUserAccountId: assign({
-      userAccountId: null,
-    }),
+    updateUser: ({ context }, user: DefuseUserId | null) => {
+      {
+        const queryKey = structuredClone(
+          context.depositedBalanceQueryObserver.options.queryKey
+        )
+        queryKey[1].user = user
+
+        context.depositedBalanceQueryObserver.setOptions({
+          ...context.depositedBalanceQueryObserver.options,
+          queryKey: queryKey,
+          queryHash: undefined,
+        })
+      }
+
+      {
+        const queryKey = structuredClone(
+          context.transitBalanceQueryObserver.options.queryKey
+        )
+        queryKey[1].user = user
+
+        context.transitBalanceQueryObserver.setOptions({
+          ...context.transitBalanceQueryObserver.options,
+          queryKey: queryKey,
+          queryHash: undefined,
+        })
+      }
+    },
     updateBalance: enqueueActions(
       (
         { enqueue, context },
@@ -162,17 +188,6 @@ export const depositedBalanceMachine = setup({
       transitBalances: {},
     }),
   },
-  guards: {
-    // TODO: Either use this guard or remove it
-    balanceDifferent: ({ context }, balanceSlice: BalanceMapping) => {
-      for (const [key, val] of Object.entries(balanceSlice)) {
-        if (context.balances[key] !== val) {
-          return true
-        }
-      }
-      return false
-    },
-  },
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5QTABwPawJYBdICEBDAG0IDsBjMAYgBkB5AcQEkA5AbQAYBdRUDbDizoyfEAA9EAWgCMAZk4A6AOwBOAKwyALJ1UA2ZXLnqANCACe0mQA45ivda2G9WgExyt15VoC+PsygCuAQk5FSKhACuOAAWYGRCFIR4EHRM9ACqACpcvEggQUIiYpIIssaKqsq6Mhqunpw2ymaWZR4qWnWOnHKunH3WfgFomMEQRKSUYBHRcQlYSSnUAEoAogCKGasAylkA+vgAgrSHrADCq3trAGJr2wASuWKFwqL5pTKainK2ejI2tXUyiBrhaVj0dh+7lc6nqnGsek4vn8IECoxSEzC0yisXiiWSkEUACcwAAzEmwGJYMhQAAEACNQlNqBARNNqQA3dAAa2mpLAOAoMUxU2WZKe+RexXeiH+qkU6ms1iRCmqcj0MK0YIQf0UjS06us6gN3j0qkGKLRghCk3COLm+JSxLJFKpNIZTKo1AyAAUACKHLKXI4nc6Xba0ZgXCX8dGvEqIWEyFSfGR-VxqWFG7VSAyKBEyJHKQvGLTqPRDVEja3jT3Y2Z4hYEiCKLAQYg0cSwHAEiKkvBEgAU6k4o4AlCzq2MRXaG-NFoS2x2YwU49LQKUPMmtNoNRDNY5QRZELr9YbjXJTea-CiyOgUPB8lbp3Xnmu3hvpD8lOpVB4EUq1R6C4OZGNY3zWO4qZKoWqiuBWlpThidaKJEZD2o2C4QG+gjxjKbS9Aqf6eA4XicMBWrHggSgaD0Zb6B4nDeEaFrDIUNpYjMuLzs2OG4Hhn46nYGh6OomguMoaiuNoOYwkoSrQv02ieJ4riVs+yG2vW3GOoSJLknAbp0oyWl8UUH4SLK-yVOWYlpk4UkyVRubgUqciAvBMIaloyJseiHFTFxDpNk6S5gGZAmWQgrjWMmnC-jFiJKgaRiUa08h2BCqiqJ0kHGuoqo3j4QA */
   id: "depositedBalance",
@@ -180,16 +195,22 @@ export const depositedBalanceMachine = setup({
   initial: "unauthenticated",
 
   context: ({ input }) => {
+    const tokenIds = input.tokenList
+      .flatMap(getUnderlyingBaseTokenInfos)
+      .map((t) => t.defuseAssetId)
+
     return {
-      userAccountId: null,
+      depositedBalanceQueryObserver: createDepositedBalanceQueryObserver(
+        queryClient,
+        tokenIds
+      ),
+      transitBalanceQueryObserver: createTransitBalanceQueryObserver(
+        queryClient,
+        tokenIds
+      ),
       balances: {},
       transitBalances: {},
       parentRef: input.parentRef,
-      defuseTokenIds: input.tokenList.flatMap((token) => {
-        return isBaseToken(token)
-          ? [token.defuseAssetId]
-          : token.groupedTokens.map((t) => t.defuseAssetId)
-      }),
     }
   },
 
@@ -197,56 +218,42 @@ export const depositedBalanceMachine = setup({
     unauthenticated: {},
 
     authenticated: {
-      initial: "refreshing balance",
-
-      states: {
-        "refreshing balance": {
-          invoke: {
-            src: "fetchBalanceActor",
-            id: "fetchBalanceRef",
-            input: ({ self, context }) => {
-              assert(context.userAccountId != null, "User is not authenticated")
-              return {
-                parentRef: self,
-                userAccountId: context.userAccountId,
-                defuseTokenIds: context.defuseTokenIds,
-              }
-            },
-            onDone: "idle",
-            // todo: handle error
-          },
-
-          on: {
-            UPDATE_BALANCE_SLICE: {
-              target: "refreshing balance",
-              actions: {
-                type: "updateBalance",
-                params: ({ event }) => ({
-                  balanceSlice: event.params.balanceSlice,
-                  transitBalanceSlice: event.params.transitBalanceSlice,
-                }),
-              },
-            },
-          },
+      invoke: [
+        {
+          src: "getDepositedBalances",
+          input: ({ self, context }) => ({
+            parentRef: self,
+            observer: context.depositedBalanceQueryObserver,
+          }),
         },
-
-        idle: {
-          after: {
-            "10000": "refreshing balance",
-          },
+        {
+          src: "getTransitBalances",
+          input: ({ self, context }) => ({
+            parentRef: self,
+            observer: context.transitBalanceQueryObserver,
+          }),
         },
-      },
+      ],
 
       on: {
         LOGOUT: {
           target: "unauthenticated",
-          actions: ["clearBalance", "clearUserAccountId"],
-          reenter: true,
+          actions: ["clearBalance", { type: "updateUser", params: null }],
         },
 
         REQUEST_BALANCE_REFRESH: {
-          target: ".refreshing balance",
+          target: ".",
           reenter: true,
+        },
+
+        UPDATE_BALANCE_SLICE: {
+          actions: {
+            type: "updateBalance",
+            params: ({ event }) => ({
+              balanceSlice: event.params.balanceSlice,
+              transitBalanceSlice: event.params.transitBalanceSlice,
+            }),
+          },
         },
       },
     },
@@ -258,7 +265,7 @@ export const depositedBalanceMachine = setup({
       actions: [
         "clearBalance",
         {
-          type: "setUserAccountId",
+          type: "updateUser",
           params: ({ event }) =>
             userAddressToDefuseUserId(
               event.params.userAddress,
@@ -357,4 +364,62 @@ export function transitBalanceSelector(
     if (pending?.amount === 0n) return
     return pending
   }
+}
+
+type DepositedBalanceQueryObserver = ReturnType<
+  typeof createDepositedBalanceQueryObserver
+>
+
+function createDepositedBalanceQueryObserver(
+  queryClient: QueryClient,
+  tokenIds: string[]
+) {
+  const provider = new providers.JsonRpcProvider({
+    url: "https://nearrpc.aurora.dev",
+  })
+
+  return new QueryObserver(queryClient, {
+    queryKey: ["deposited_balance", { user: null, tokenIds }] as [
+      string,
+      { user: null | DefuseUserId; tokenIds: string[] },
+    ],
+    queryFn: ({ queryKey }) => {
+      if (queryKey[1].user == null) {
+        throw new Error("user is null")
+      }
+
+      return getDepositedBalances(
+        queryKey[1].user,
+        queryKey[1].tokenIds,
+        provider
+      )
+    },
+    enabled: (query) => query.queryKey[1].user != null,
+    refetchInterval: 30000,
+  })
+}
+
+type TransitBalanceQueryObserver = ReturnType<
+  typeof createTransitBalanceQueryObserver
+>
+
+function createTransitBalanceQueryObserver(
+  queryClient: QueryClient,
+  tokenIds: string[]
+) {
+  return new QueryObserver(queryClient, {
+    queryKey: ["transit_balance", { user: null, tokenIds }] as [
+      string,
+      { user: null | DefuseUserId; tokenIds: string[] },
+    ],
+    queryFn: ({ queryKey }) => {
+      if (queryKey[1].user == null) {
+        throw new Error("user is null")
+      }
+
+      return getTransitBalances(queryKey[1].user, queryKey[1].tokenIds)
+    },
+    enabled: (query) => query.queryKey[1].user != null,
+    refetchInterval: 30000,
+  })
 }

--- a/src/features/machines/withdrawUIMachine.ts
+++ b/src/features/machines/withdrawUIMachine.ts
@@ -1,6 +1,7 @@
 import type { providers } from "near-api-js"
 import {
   type ActorRefFrom,
+  type InputFrom,
   assign,
   emit,
   sendTo,
@@ -111,7 +112,8 @@ export const withdrawUIMachine = setup({
   },
   actors: {
     backgroundQuoterActor: backgroundQuoterMachine,
-    depositedBalanceActor: depositedBalanceMachine,
+    // biome-ignore lint/suspicious/noExplicitAny: bypass xstate+ts bloating; be careful when interacting with `depositedBalanceActor` string
+    depositedBalanceActor: depositedBalanceMachine as any,
     swapActor: swapIntentMachine,
     intentStatusActor: intentStatusMachine,
     withdrawFormActor: withdrawFormReducer,
@@ -333,7 +335,8 @@ export const withdrawUIMachine = setup({
       input: {
         parentRef: self,
         tokenList: input.tokenList,
-      },
+        // `depositedBalanceActor` is any, so we explicitly safeguard it with `satisfies`
+      } satisfies InputFrom<typeof depositedBalanceMachine>,
     }),
     withdrawFormRef: spawn("withdrawFormActor", {
       id: "withdrawFormRef",

--- a/src/providers/QueryClientProvider.tsx
+++ b/src/providers/QueryClientProvider.tsx
@@ -5,7 +5,8 @@ import {
 import type { PropsWithChildren } from "react"
 import { settings } from "../constants/settings"
 
-const queryClient = new QueryClient({
+// todo: accept queryClient instance from user
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: settings.queries,
   },

--- a/src/providers/QueryClientProvider.tsx
+++ b/src/providers/QueryClientProvider.tsx
@@ -3,14 +3,9 @@ import {
   QueryClientProvider as RCProvider,
 } from "@tanstack/react-query"
 import type { PropsWithChildren } from "react"
-import { settings } from "../constants/settings"
 
 // todo: accept queryClient instance from user
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: settings.queries,
-  },
-})
+export const queryClient = new QueryClient()
 
 export const QueryClientProvider: React.FC<PropsWithChildren> = ({
   children,

--- a/src/services/withdrawService.ts
+++ b/src/services/withdrawService.ts
@@ -356,7 +356,7 @@ async function getBalances(
     depositedBalanceRef.send({ type: "REQUEST_BALANCE_REFRESH" })
     const state = await waitFor(
       depositedBalanceRef,
-      (state) => state.matches({ authenticated: "idle" }),
+      (state) => state.matches("authenticated"),
       { signal } // todo: add timeout and error handling
     )
     balances = state.context.balances


### PR DESCRIPTION
# Summary

The main purpose of this refactoring is that we need to show balances on different part of the page. Which in current state will lead to duplication of requests. There were 2 solutions:
1. Create a high-level React provider which invokes Deposited Balance Machine, and every other part of the app re-use it
2. Use Query Client as a synchronization and request deduplication engine

I decided to go with 2, because I didn't want to bind us to a React providers. 

# Conclusion

Now you can invoke as many Deposited Balance Machine as you want and it won't trigger many duplicated requests. I still think that this is over-engineered Machine, and I believe we can get rid of it and use Query Client directly.