### PR TITLE
feat: support different timings for quotes

### DIFF
--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -2,8 +2,6 @@ import type { SupportedChainName } from "../types/base"
 
 interface Settings {
   swapExpirySec: number
-  quoteQueryTimeoutMs: number
-  quotePollingIntervalMs: number
   quoteMinDeadlineMs: number
   maxQuoteMinDeadlineMs: number
   rpcUrls: {
@@ -13,11 +11,6 @@ interface Settings {
 
 export const settings: Settings = {
   swapExpirySec: 600, // 10 minutes
-  /**
-   * Quote query lasts 1.4 seconds in good network conditions.
-   */
-  quoteQueryTimeoutMs: 4000,
-  quotePollingIntervalMs: 3000,
   /**
    * Minimum deadline for a quote.
    * The server will return quotes with at least this much time remaining.

--- a/src/features/machines/backgroundQuoterMachine.ts
+++ b/src/features/machines/backgroundQuoterMachine.ts
@@ -1,5 +1,4 @@
 import { type ActorRef, type Snapshot, fromCallback } from "xstate"
-import { settings } from "../../constants/settings"
 import { logger } from "../../logger"
 import { type QuoteResult, queryQuote } from "../../services/quoteService"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "../../types/base"
@@ -47,8 +46,25 @@ type ParentActor = ActorRef<Snapshot<unknown>, ParentEvents>
 
 type Input = {
   parentRef: ParentActor
-  delayMs: number
 }
+
+const QUOTE_TIMINGS = [
+  {
+    auctionTimeMs: 500, // for fast quotes
+    intervalMs: -1, // means no polling
+    timeoutMs: 15000,
+  },
+  {
+    auctionTimeMs: 2000, // normal solvers
+    intervalMs: 10000,
+    timeoutMs: 15000,
+  },
+  {
+    auctionTimeMs: 10000, // MPC solvers
+    intervalMs: 10000,
+    timeoutMs: 20000,
+  },
+]
 
 export const backgroundQuoterMachine = fromCallback<
   Events,
@@ -68,21 +84,16 @@ export const backgroundQuoterMachine = fromCallback<
       case "NEW_QUOTE_INPUT": {
         const quoteInput = event.params
 
-        pollQuote(
-          abortController.signal,
-          quoteInput,
-          input.delayMs,
-          (quote) => {
-            input.parentRef.send({
-              type: "NEW_QUOTE",
-              params: { quoteInput, quote },
-            })
-            emit({
-              type: "NEW_QUOTE",
-              params: { quoteInput, quote },
-            })
-          }
-        )
+        pollQuote(abortController.signal, quoteInput, (quote) => {
+          input.parentRef.send({
+            type: "NEW_QUOTE",
+            params: { quoteInput, quote },
+          })
+          emit({
+            type: "NEW_QUOTE",
+            params: { quoteInput, quote },
+          })
+        })
         break
       }
       default:
@@ -99,22 +110,37 @@ export const backgroundQuoterMachine = fromCallback<
 function pollQuote(
   signal: AbortSignal,
   quoteInput: QuoteInput,
-  delayMs: number,
   onResult: (result: QuoteResult) => void
 ): void {
-  pollQuoteLoop(signal, quoteInput, delayMs, onResult).catch((error) =>
-    logger.error(
-      new Error("pollQuote terminated unexpectedly", { cause: error })
+  for (const timings of QUOTE_TIMINGS) {
+    pollQuoteLoop({
+      signal,
+      quoteInput,
+      onResult,
+      ...timings,
+    }).catch((error) =>
+      logger.error(
+        new Error("pollQuote terminated unexpectedly", { cause: error })
+      )
     )
-  )
+  }
 }
 
-async function pollQuoteLoop(
-  signal: AbortSignal,
-  quoteInput: QuoteInput,
-  delayMs: number,
+async function pollQuoteLoop({
+  signal,
+  quoteInput,
+  auctionTimeMs,
+  intervalMs,
+  timeoutMs,
+  onResult,
+}: {
+  signal: AbortSignal
+  quoteInput: QuoteInput
+  auctionTimeMs: number
+  intervalMs: number
+  timeoutMs: number
   onResult: (result: QuoteResult) => void
-): Promise<void> {
+}): Promise<void> {
   let lastPropagatedResultRequestedAt: number | null = null
 
   while (!signal.aborted) {
@@ -128,9 +154,10 @@ async function pollQuoteLoop(
         tokenOut: quoteInput.tokenOut,
         amountIn: quoteInput.amountIn,
         balances: quoteInput.balances,
+        waitMs: auctionTimeMs,
       },
       {
-        signal: AbortSignal.timeout(settings.quoteQueryTimeoutMs),
+        signal: AbortSignal.timeout(timeoutMs),
       }
     ).then(
       (quote) => {
@@ -155,7 +182,10 @@ async function pollQuoteLoop(
       }
     )
 
-    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    if (intervalMs < 0) {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
   }
 }
 

--- a/src/features/machines/swapUIMachine.ts
+++ b/src/features/machines/swapUIMachine.ts
@@ -8,7 +8,6 @@ import {
   setup,
   spawnChild,
 } from "xstate"
-import { settings } from "../../constants/settings"
 import { logger } from "../../logger"
 import type { QuoteResult } from "../../services/quoteService"
 import type {
@@ -176,10 +175,7 @@ export const swapUIMachine = setup({
     passthroughEvent: emit((_, event: PassthroughEvent) => event),
     spawnBackgroundQuoterRef: spawnChild("backgroundQuoterActor", {
       id: "backgroundQuoterRef",
-      input: ({ self }) => ({
-        parentRef: self,
-        delayMs: settings.quotePollingIntervalMs,
-      }),
+      input: ({ self }) => ({ parentRef: self }),
     }),
     // Warning: This cannot be properly typed, so you can send an incorrect event
     sendToBackgroundQuoterRefNewQuoteInput: sendTo(

--- a/src/features/machines/withdrawUIMachine.ts
+++ b/src/features/machines/withdrawUIMachine.ts
@@ -8,7 +8,6 @@ import {
   setup,
   spawnChild,
 } from "xstate"
-import { settings } from "../../constants/settings"
 import { logger } from "../../logger"
 import type { QuoteResult } from "../../services/quoteService"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "../../types/base"
@@ -193,10 +192,7 @@ export const withdrawUIMachine = setup({
 
     spawnBackgroundQuoterRef: spawnChild("backgroundQuoterActor", {
       id: "backgroundQuoterRef",
-      input: ({ self }) => ({
-        parentRef: self,
-        delayMs: settings.quotePollingIntervalMs,
-      }),
+      input: ({ self }) => ({ parentRef: self }),
     }),
     sendToBackgroundQuoterRefNewQuoteInput: sendTo(
       "backgroundQuoterRef",

--- a/src/services/quoteService.test.ts
+++ b/src/services/quoteService.test.ts
@@ -88,6 +88,7 @@ describe("queryQuote()", () => {
         defuse_asset_identifier_out: "tokenOut",
         exact_amount_in: "150000000",
         min_deadline_ms: 60_000,
+        wait_ms: 0,
       },
       expect.any(Object)
     )
@@ -148,6 +149,7 @@ describe("queryQuote()", () => {
         defuse_asset_identifier_out: "tokenOut",
         exact_amount_in: "100000000",
         min_deadline_ms: 60_000,
+        wait_ms: 0,
       },
       expect.any(Object)
     )
@@ -157,6 +159,7 @@ describe("queryQuote()", () => {
         defuse_asset_identifier_out: "tokenOut",
         exact_amount_in: "5000000000",
         min_deadline_ms: 60_000,
+        wait_ms: 0,
       },
       expect.any(Object)
     )

--- a/src/services/quoteService.test.ts
+++ b/src/services/quoteService.test.ts
@@ -65,6 +65,7 @@ describe("queryQuote()", () => {
       tokenOut: tokenOut,
       amountIn: { amount: adjustDecimals(150n, 0, 6), decimals: 6 },
       balances: { token1: adjustDecimals(100n, 0, 6) },
+      waitMs: 0,
     }
 
     vi.mocked(relayClient.quote).mockImplementationOnce(async () => [
@@ -113,6 +114,7 @@ describe("queryQuote()", () => {
         token2: adjustDecimals(100n, 0, token2.decimals),
         token3: adjustDecimals(100n, 0, token3.decimals),
       },
+      waitMs: 0,
     }
 
     vi.mocked(relayClient.quote)
@@ -179,6 +181,7 @@ describe("queryQuote()", () => {
       tokenOut: tokenOut,
       amountIn: { amount: adjustDecimals(150n, 0, 6), decimals: 6 },
       balances: { token1: adjustDecimals(100n, 0, token1.decimals) },
+      waitMs: 0,
     }
 
     vi.mocked(relayClient.quote).mockImplementationOnce(async () => [
@@ -229,6 +232,7 @@ describe("queryQuote()", () => {
       tokenOut: tokenOut,
       amountIn: { amount: adjustDecimals(150n, 0, 6), decimals: 6 },
       balances: { token1: adjustDecimals(100n, 0, token1.decimals) },
+      waitMs: 0,
     }
 
     vi.mocked(relayClient.quote)
@@ -259,6 +263,7 @@ describe("queryQuote()", () => {
         token1: adjustDecimals(100n, 0, token1.decimals),
         token2: adjustDecimals(100n, 0, token2.decimals),
       },
+      waitMs: 0,
     }
 
     vi.mocked(relayClient.quote)
@@ -288,6 +293,7 @@ describe("queryQuote()", () => {
       tokenOut: tokenOut,
       amountIn: { amount: adjustDecimals(150n, 0, 6), decimals: 6 },
       balances: { token1: adjustDecimals(100n, 0, token1.decimals) },
+      waitMs: 0,
     }
 
     vi.mocked(relayClient.quote).mockImplementationOnce(async () => [

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -27,7 +27,11 @@ function isNotFailedQuote(quote: Quote | FailedQuote): quote is Quote {
 type TokenSlice = BaseTokenInfo
 type Balances = Record<string, bigint>
 
-export interface AggregatedQuoteParams {
+interface BaseQuoteParams {
+  waitMs: number
+}
+
+export interface AggregatedQuoteParams extends BaseQuoteParams {
   tokensIn: TokenSlice[] // set of close tokens, e.g. [USDC on Solana, USDC on Ethereum, USDC on Near]
   tokenOut: TokenSlice // set of close tokens, e.g. [USDC on Solana, USDC on Ethereum, USDC on Near]
   amountIn: TokenValue // total amount in
@@ -91,6 +95,7 @@ export async function queryQuote(
         defuse_asset_identifier_out: tokenOut.defuseAssetId,
         exact_amount_in: exactAmountIn.toString(),
         min_deadline_ms: settings.quoteMinDeadlineMs,
+        wait_ms: input.waitMs,
       },
       { signal }
     )
@@ -116,6 +121,7 @@ export async function queryQuote(
   const quotes = await fetchQuotesForTokens(
     tokenOut.defuseAssetId,
     amountsToQuote,
+    input.waitMs,
     {
       signal,
     }
@@ -410,9 +416,10 @@ export function aggregateQuotes(
   }
 }
 
-export async function fetchQuotesForTokens(
+async function fetchQuotesForTokens(
   tokenOut: string,
   amountsToQuote: Record<string, bigint>,
+  waitMs: number,
   { signal }: { signal?: AbortSignal } = {}
 ): Promise<null | NonNullable<QuoteResults>[]> {
   const quotes = await Promise.all(
@@ -423,6 +430,7 @@ export async function fetchQuotesForTokens(
           defuse_asset_identifier_out: tokenOut,
           exact_amount_in: amountIn.toString(),
           min_deadline_ms: settings.quoteMinDeadlineMs,
+          wait_ms: waitMs,
         },
         { signal }
       )

--- a/src/services/solverRelayHttpClient/types.ts
+++ b/src/services/solverRelayHttpClient/types.ts
@@ -25,6 +25,7 @@ export type QuoteRequest = JSONRPCRequest<
     exact_amount_in?: string
     exact_amount_out?: string
     min_deadline_ms?: number
+    wait_ms?: number
   }
 >
 


### PR DESCRIPTION
Now we request a quote each 3 sec with default solver `wait_ms` value (which is 1.5s). Need to send two parallel requests with 2s and 10s wait time, so MPC solver can be in time.