### PR TITLE
fix(quote): adjust interval and timeout settings for solvers

### DIFF
--- a/src/features/machines/backgroundQuoterMachine.ts
+++ b/src/features/machines/backgroundQuoterMachine.ts
@@ -56,12 +56,12 @@ const QUOTE_TIMINGS = [
   },
   {
     auctionTimeMs: 2000, // normal solvers
-    intervalMs: 10000,
-    timeoutMs: 15000,
+    intervalMs: -1,
+    timeoutMs: 10000,
   },
   {
-    auctionTimeMs: 10000, // MPC solvers
-    intervalMs: 10000,
+    auctionTimeMs: 10000, // normal solvers + MPC solvers
+    intervalMs: 5000,
     timeoutMs: 20000,
   },
 ]


### PR DESCRIPTION
PR changes quoting intervals, which should make it even for different (slow and fast) solvers:
1. User inputs
2. We do:
  2.1. Fast quote (500 ms) once - just for better UX to show any number to the user
  2.2 Normal quote (2 sec) once - for immediate better price
  2.3 Polling for Slow quote (10 sec) every 5 sec

Slow quotes already include quotes from normal solvers and MPC solvers.
   
