### PR TITLE
feat: add extra log for no liquidity when user has enough funds

### DIFF
--- a/src/features/otcDesk/hooks/useOtcTakerConfirmTrade.ts
+++ b/src/features/otcDesk/hooks/useOtcTakerConfirmTrade.ts
@@ -81,7 +81,9 @@ export function useOtcTakerConfirmTrade({
 
       // todo: UI performance: add re-quoting in the background
       // It's totally alright do async stuff after singing
-      const quoteHashesResult = await getFreshQuoteHashes(quotes, quoteParams)
+      const quoteHashesResult = await getFreshQuoteHashes(quotes, quoteParams, {
+        logBalanceSufficient: true,
+      })
       if (quoteHashesResult.isErr()) {
         return Err(quoteHashesResult.unwrapErr())
       }

--- a/src/features/otcDesk/hooks/useOtcTakerPreparation.ts
+++ b/src/features/otcDesk/hooks/useOtcTakerPreparation.ts
@@ -127,7 +127,9 @@ export function useOtcTakerPreparation({
         }
       }
 
-      const quotesResult = await manyQuotes(quoteParams)
+      const quotesResult = await manyQuotes(quoteParams, {
+        logBalanceSufficient: true,
+      })
 
       return quotesResult.map((quotes) => {
         logger.verbose("return", { quotes, quoteParams, tokenDelta })

--- a/src/features/otcDesk/utils/quoteUtils.ts
+++ b/src/features/otcDesk/utils/quoteUtils.ts
@@ -18,7 +18,8 @@ export type QuoteExactInParams = {
 }
 
 export async function manyQuotes(
-  swapParams: QuoteExactInParams[]
+  swapParams: QuoteExactInParams[],
+  config: { logBalanceSufficient: boolean }
 ): Promise<Result<AggregatedQuote[], AggregatedQuoteErr>> {
   const quoteResults = await Promise.all(
     swapParams.map(async ({ tokenIn, tokenOut, amountIn }) => {
@@ -29,7 +30,7 @@ export async function manyQuotes(
           exact_amount_in: amountIn.toString(),
           min_deadline_ms: settings.quoteMinDeadlineMs,
         },
-        {}
+        config
       ).then(handleQuote)
     })
   )
@@ -102,10 +103,11 @@ export function areQuotesExpired(quotes: AggregatedQuote[]): boolean {
 
 export async function getFreshQuoteHashes(
   quotes: AggregatedQuote[],
-  quoteParams: QuoteExactInParams[]
+  quoteParams: QuoteExactInParams[],
+  config: { logBalanceSufficient: boolean }
 ): Promise<Result<string[], AggregatedQuoteErr>> {
   if (areQuotesExpired(quotes)) {
-    const newQuotes = await manyQuotes(quoteParams)
+    const newQuotes = await manyQuotes(quoteParams, config)
     if (newQuotes.isErr()) {
       return Err(newQuotes.unwrapErr())
     }

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -97,7 +97,10 @@ export async function queryQuote(
         min_deadline_ms: settings.quoteMinDeadlineMs,
         wait_ms: input.waitMs,
       },
-      { fetchOptions: { signal } }
+      {
+        logBalanceSufficient: false,
+        fetchOptions: { signal },
+      }
     )
 
     if (q == null) {
@@ -124,6 +127,7 @@ export async function queryQuote(
     input.waitMs,
     {
       signal,
+      logBalanceSufficient: true,
     }
   )
 
@@ -146,7 +150,13 @@ export async function queryQuoteExactOut(
     exactAmountOut: bigint
     minDeadlineMs?: number
   },
-  { signal }: { signal?: AbortSignal } = {}
+  {
+    logBalanceSufficient,
+    signal,
+  }: {
+    logBalanceSufficient: boolean
+    signal?: AbortSignal
+  }
 ): Promise<QuoteResult> {
   const quotes = await quoteWithLog(
     {
@@ -155,7 +165,11 @@ export async function queryQuoteExactOut(
       exact_amount_out: input.exactAmountOut.toString(),
       min_deadline_ms: input.minDeadlineMs ?? settings.quoteMinDeadlineMs,
     },
-    { fetchOptions: { signal } }
+
+    {
+      fetchOptions: { signal },
+      logBalanceSufficient: logBalanceSufficient,
+    }
   )
 
   if (quotes == null) {
@@ -420,7 +434,13 @@ async function fetchQuotesForTokens(
   tokenOut: string,
   amountsToQuote: Record<string, bigint>,
   waitMs: number,
-  { signal }: { signal?: AbortSignal } = {}
+  {
+    logBalanceSufficient,
+    signal,
+  }: {
+    logBalanceSufficient: boolean
+    signal?: AbortSignal
+  }
 ): Promise<null | NonNullable<QuoteResults>[]> {
   const quotes = await Promise.all(
     Object.entries(amountsToQuote).map(async ([tokenIn, amountIn]) => {
@@ -432,7 +452,10 @@ async function fetchQuotesForTokens(
           min_deadline_ms: settings.quoteMinDeadlineMs,
           wait_ms: waitMs,
         },
-        { fetchOptions: { signal } }
+        {
+          fetchOptions: { signal },
+          logBalanceSufficient,
+        }
       )
     })
   )
@@ -445,10 +468,22 @@ function ensureAllNonNull<T>(array: (T | null)[]): T[] | null {
   return filtered.length === array.length ? filtered : null
 }
 
-export const quoteWithLog = (async (params, config) => {
+export async function quoteWithLog(
+  params: Parameters<typeof quote>[0],
+  {
+    logBalanceSufficient,
+    ...config
+  }: { logBalanceSufficient: boolean } & Parameters<typeof quote>[1]
+) {
   const result = await quote(params, config)
   if (result == null) {
-    logger.warn("No liquidity", { quoteParams: params })
+    logger.warn("quote: No liquidity available", { quoteParams: params })
+    if (logBalanceSufficient) {
+      logger.warn(
+        "quote: No liquidity available for user with sufficient balance",
+        { quoteParams: params }
+      )
+    }
   }
   return result
-}) satisfies typeof quote
+}

--- a/src/services/withdrawService.ts
+++ b/src/services/withdrawService.ts
@@ -256,7 +256,7 @@ async function determineNEP141StorageRequirement(
          */
         minDeadlineMs: settings.maxQuoteMinDeadlineMs,
       },
-      { signal }
+      { logBalanceSufficient: true, signal }
     )
     if (nep141StorageQuote.tag === "err") {
       return { tag: "err", value: { reason: nep141StorageQuote.value.type } }


### PR DESCRIPTION
PR adds logging of a new event when user has enough funds, but solvers can't give them quotes.