### PR TITLE
refactor: improve parsing RPC response and throwing RPC error

### DIFF
--- a/src/services/poaBridgeHttpClient/apis.ts
+++ b/src/services/poaBridgeHttpClient/apis.ts
@@ -5,52 +5,50 @@ export async function getSupportedTokens(
   params: types.GetSupportedTokensRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.GetSupportedTokensResponse["result"]> {
-  const json = await jsonRPCRequest<types.GetSupportedTokensRequest>(
+  const result = await jsonRPCRequest<types.GetSupportedTokensRequest>(
     "supported_tokens",
     params,
     config
   )
-  return json.result
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }
 
 export async function getDepositAddress(
   params: types.GetDepositAddressRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.GetDepositAddressResponse["result"]> {
-  const json = await jsonRPCRequest<types.GetDepositAddressRequest>(
+  const result = await jsonRPCRequest<types.GetDepositAddressRequest>(
     "deposit_address",
     params,
     config
   )
-  return json.result
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }
 
 export async function getDepositStatus(
   params: types.GetDepositStatusRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.GetDepositStatusResponse["result"]> {
-  const json = await jsonRPCRequest<types.GetDepositStatusRequest>(
+  const result = await jsonRPCRequest<types.GetDepositStatusRequest>(
     "recent_deposits",
     params,
     config
   )
-  return json.result ?? { deposits: [] }
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return (result as any) ?? { deposits: [] }
 }
 
 export async function getWithdrawalStatus(
   params: types.WithdrawalStatusRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.WithdrawalStatusResponseOk["result"]> {
-  const json:
-    | types.WithdrawalStatusResponseOk
-    | types.WithdrawalStatusResponseErr =
-    await jsonRPCRequest<types.WithdrawalStatusRequest>(
-      "withdrawal_status",
-      params,
-      config
-    )
-  if ("error" in json) {
-    throw new Error(json.error)
-  }
-  return json.result
+  const result = await jsonRPCRequest<types.WithdrawalStatusRequest>(
+    "withdrawal_status",
+    params,
+    config
+  )
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }

--- a/src/services/poaBridgeHttpClient/runtime.ts
+++ b/src/services/poaBridgeHttpClient/runtime.ts
@@ -1,6 +1,32 @@
+import * as v from "valibot"
 import { config as globalConfig } from "../../config"
+import { handleRPCResponse } from "../../utils/handleRPCResponse"
 import { request } from "../../utils/request"
 import type * as types from "./types"
+
+const rpcResponseSchema = v.union([
+  // success
+  v.object({
+    jsonrpc: v.literal("2.0"),
+    id: v.string(),
+    result: v.unknown(),
+  }),
+  // error
+  v.object({
+    jsonrpc: v.literal("2.0"),
+    id: v.string(),
+    error: v.pipe(
+      v.string(),
+      v.transform((v) => {
+        return {
+          code: -1,
+          data: null,
+          message: v,
+        }
+      })
+    ),
+  }),
+])
 
 export async function jsonRPCRequest<
   T extends types.JSONRPCRequest<unknown, unknown>,
@@ -9,19 +35,24 @@ export async function jsonRPCRequest<
   params: T["params"][0],
   config?: types.RequestConfig | undefined
 ) {
+  const url = `${globalConfig.env.poaBridgeBaseURL}/rpc`
+
+  const body = {
+    id: "dontcare",
+    jsonrpc: "2.0",
+    method,
+    params: params !== undefined ? [params] : undefined,
+  }
+
   const response = await request({
-    url: `${globalConfig.env.poaBridgeBaseURL}/rpc`,
-    body: {
-      id: "dontcare",
-      jsonrpc: "2.0",
-      method,
-      params: params !== undefined ? [params] : undefined,
-    },
+    url,
+    body,
     ...config,
     fetchOptions: {
       ...config?.fetchOptions,
       method: "POST",
     },
   })
-  return response.json()
+
+  return handleRPCResponse(response, body, rpcResponseSchema)
 }

--- a/src/services/poaBridgeHttpClient/types.ts
+++ b/src/services/poaBridgeHttpClient/types.ts
@@ -97,9 +97,3 @@ export type WithdrawalStatusResponseOk = JSONRPCResponse<{
     }
   }[]
 }>
-
-export type WithdrawalStatusResponseErr = {
-  id: string
-  jsonrpc: "2.0"
-  error: string
-}

--- a/src/services/solverRelayHttpClient/apis.ts
+++ b/src/services/solverRelayHttpClient/apis.ts
@@ -5,42 +5,50 @@ export async function quote(
   params: types.QuoteRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.QuoteResponse["result"]> {
-  const json = await jsonRPCRequest<types.QuoteRequest>("quote", params, config)
-  return json.result
+  const result = await jsonRPCRequest<types.QuoteRequest>(
+    "quote",
+    params,
+    config
+  )
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }
 
 export async function publishIntent(
   params: types.PublishIntentRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.PublishIntentResponse["result"]> {
-  const json = await jsonRPCRequest<types.PublishIntentRequest>(
+  const result = await jsonRPCRequest<types.PublishIntentRequest>(
     "publish_intent",
     params,
     config
   )
-  return json.result
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }
 
 export async function publishIntents(
   params: types.PublishIntentsRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.PublishIntentsResponse["result"]> {
-  const json = await jsonRPCRequest<types.PublishIntentsRequest>(
+  const result = await jsonRPCRequest<types.PublishIntentsRequest>(
     "publish_intents",
     params,
     config
   )
-  return json.result
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }
 
 export async function getStatus(
   params: types.GetStatusRequest["params"][0],
   config: types.RequestConfig = {}
 ): Promise<types.GetStatusResponse["result"]> {
-  const json = await jsonRPCRequest<types.GetStatusRequest>(
+  const result = await jsonRPCRequest<types.GetStatusRequest>(
     "get_status",
     params,
     config
   )
-  return json.result
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  return result as any
 }

--- a/src/services/solverRelayHttpClient/runtime.ts
+++ b/src/services/solverRelayHttpClient/runtime.ts
@@ -1,6 +1,35 @@
+import * as v from "valibot"
 import { config as globalConfig } from "../../config"
+import { handleRPCResponse } from "../../utils/handleRPCResponse"
 import { request } from "../../utils/request"
 import type * as types from "./types"
+
+const rpcResponseSchema = v.union([
+  // success
+  v.object({
+    jsonrpc: v.literal("2.0"),
+    id: v.string(),
+    result: v.unknown(),
+  }),
+  // error
+  v.object({
+    jsonrpc: v.literal("2.0"),
+    id: v.string(),
+    error: v.pipe(
+      v.object({
+        code: v.number(),
+        message: v.string(),
+      }),
+      v.transform((v) => {
+        return {
+          code: v.code,
+          data: null,
+          message: v.message,
+        }
+      })
+    ),
+  }),
+])
 
 export async function jsonRPCRequest<
   T extends types.JSONRPCRequest<unknown, unknown>,
@@ -9,19 +38,24 @@ export async function jsonRPCRequest<
   params: T["params"][0],
   config?: types.RequestConfig | undefined
 ) {
+  const url = `${globalConfig.env.solverRelayBaseURL}/rpc`
+
+  const body = {
+    id: "dontcare",
+    jsonrpc: "2.0",
+    method,
+    params: params !== undefined ? [params] : undefined,
+  }
+
   const response = await request({
-    url: `${globalConfig.env.solverRelayBaseURL}/rpc`,
-    body: {
-      id: "dontcare",
-      jsonrpc: "2.0",
-      method,
-      params: params !== undefined ? [params] : undefined,
-    },
+    url,
+    body,
     ...config,
     fetchOptions: {
       ...config?.fetchOptions,
       method: "POST",
     },
   })
-  return response.json()
+
+  return handleRPCResponse(response, body, rpcResponseSchema)
 }

--- a/src/utils/handleRPCResponse.ts
+++ b/src/utils/handleRPCResponse.ts
@@ -1,0 +1,46 @@
+import * as v from "valibot"
+import { RpcRequestError } from "../errors/request"
+
+type SuccessResult<result> = {
+  result: result
+  error?: undefined
+}
+type ErrorResult<error> = {
+  result?: undefined
+  error: error
+}
+export type RpcResponse<TResult = unknown, TError = unknown> = {
+  jsonrpc: `${number}`
+  id: number | string
+} & (SuccessResult<TResult> | ErrorResult<TError>)
+
+export async function handleRPCResponse<
+  TSchema extends v.BaseSchema<TInput, TOutput, TIssue>,
+  TInput,
+  TOutput extends RpcResponse<
+    unknown,
+    { code: number; data: unknown; message: string }
+  >,
+  TIssue extends v.BaseIssue<unknown>,
+>(response: Response, body: unknown, schema: TSchema) {
+  const json = await response.json()
+
+  const parsed = v.safeParse(schema, json)
+  if (parsed.success) {
+    if (parsed.output.error !== undefined) {
+      throw new RpcRequestError({
+        body,
+        error: parsed.output.error,
+        url: response.url,
+      })
+    }
+
+    return parsed.output.result
+  }
+
+  throw new RpcRequestError({
+    body,
+    error: { code: -1, data: json, message: "Invalid response" },
+    url: response.url,
+  })
+}


### PR DESCRIPTION
Example of errored RPC request:

<details><summary>Screenshot</summary>
<p>

<img width="891" alt="Screenshot 2025-04-08 at 18 09 28" src="https://github.com/user-attachments/assets/90f73b7b-dad1-436a-8908-b3a4b519a3fb" />


</p>
</details> 