### PR TITLE
fix: switch token event on OTC maker form

### DIFF
--- a/src/components/Modal/ModalSelectAssets.tsx
+++ b/src/components/Modal/ModalSelectAssets.tsx
@@ -37,6 +37,7 @@ export type ModalSelectAssetsPayload = {
   fieldName?: "tokenIn" | "tokenOut" | "token"
   balances?: BalanceMapping
   accountId?: string
+  onConfirm?: (payload: ModalSelectAssetsPayload) => void
 }
 
 export type SelectItemToken<T = Token> = {
@@ -82,6 +83,10 @@ export const ModalSelectAssets = () => {
         selectedItem.token,
     }
     onCloseModal(newPayload)
+
+    if (newPayload?.onConfirm) {
+      newPayload.onConfirm(newPayload)
+    }
   }
 
   useEffect(() => {

--- a/src/features/otcDesk/components/OtcMakerForm.tsx
+++ b/src/features/otcDesk/components/OtcMakerForm.tsx
@@ -168,44 +168,40 @@ export function OtcMakerForm({
       fieldName,
       [fieldName]: token,
       balances: depositedBalanceRef?.getSnapshot().context.balances,
+      onConfirm: (payload: ModalSelectAssetsPayload) => {
+        const { fieldName } = payload as ModalSelectAssetsPayload
+        const _payload = payload as ModalSelectAssetsPayload
+        const token = _payload[fieldName || "token"]
+
+        if (fieldName && token) {
+          switch (fieldName) {
+            case SWAP_TOKEN_FLAGS.IN:
+              if (
+                formValues.tokenOut === token &&
+                formValues.tokenIn !== null
+              ) {
+                formValuesRef.trigger.updateTokenOut({
+                  value: formValues.tokenIn,
+                })
+              }
+              formValuesRef.trigger.updateTokenIn({ value: token })
+              break
+            case SWAP_TOKEN_FLAGS.OUT:
+              if (
+                formValues.tokenIn === token &&
+                formValues.tokenOut !== null
+              ) {
+                formValuesRef.trigger.updateTokenIn({
+                  value: formValues.tokenOut,
+                })
+              }
+              formValuesRef.trigger.updateTokenOut({ value: token })
+              break
+          }
+        }
+      },
     })
   }
-
-  useEffect(() => {
-    if (
-      (payload as ModalSelectAssetsPayload)?.modalType !==
-      ModalType.MODAL_SELECT_ASSETS
-    ) {
-      return
-    }
-
-    const { modalType, fieldName } = payload as ModalSelectAssetsPayload
-    const _payload = payload as ModalSelectAssetsPayload
-    const token = _payload[fieldName || "token"]
-
-    if (modalType === ModalType.MODAL_SELECT_ASSETS && fieldName && token) {
-      switch (fieldName) {
-        case SWAP_TOKEN_FLAGS.IN:
-          if (formValues.tokenOut === token && formValues.tokenIn !== null) {
-            formValuesRef.trigger.updateTokenOut({
-              value: formValues.tokenIn,
-            })
-          }
-          formValuesRef.trigger.updateTokenIn({ value: token })
-          break
-        case SWAP_TOKEN_FLAGS.OUT:
-          if (formValues.tokenIn === token && formValues.tokenOut !== null) {
-            formValuesRef.trigger.updateTokenIn({
-              value: formValues.tokenOut,
-            })
-          }
-          formValuesRef.trigger.updateTokenOut({ value: token })
-          break
-        default:
-          throw new Error("Invalid field name")
-      }
-    }
-  }, [payload, formValuesRef, formValues.tokenIn, formValues.tokenOut])
 
   const publicKeyVerifierRef = useSelector(
     useSelector(


### PR DESCRIPTION
With the new approach using the token select modal, we're not clearing the modalType after selecting a token. This causes issues when switching tokens, as it triggers a useEffect with stale context, resulting in an unintended rollback effect.

Solution: Use a direct callback event from the modal instead. This avoids side effects and ensures the state is updated cleanly.