### PR TITLE
feat: add presets from query params to the withdraw widget

### DIFF
--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -39,7 +39,10 @@ import type {
   TokenValue,
   UnifiedTokenInfo,
 } from "../../../../types/base"
-import type { WithdrawWidgetProps } from "../../../../types/withdraw"
+import {
+  type WithdrawWidgetProps,
+  isSupportedChainName,
+} from "../../../../types/withdraw"
 import { parseUnits } from "../../../../utils/parse"
 import { validateAddress } from "../../../../utils/validateAddress"
 import {
@@ -89,6 +92,9 @@ export const WithdrawForm = ({
   userAddress,
   chainType,
   tokenList,
+  presetAmount,
+  presetNetwork,
+  presetRecipient,
   sendNearTransaction,
   renderHostAppLink,
 }: WithdrawFormProps) => {
@@ -255,7 +261,6 @@ export const WithdrawForm = ({
       try {
         parsedAmount.amount = parseUnits(amountIn, parsedAmount.decimals)
       } catch {}
-
       actorRef.send({
         type: "WITHDRAW_FORM.UPDATE_TOKEN",
         params: {
@@ -326,6 +331,18 @@ export const WithdrawForm = ({
       sub.unsubscribe()
     }
   }, [watch, actorRef, token])
+
+  useEffect(() => {
+    if (presetAmount != null) {
+      setValue("amountIn", presetAmount)
+    }
+    if (presetNetwork != null && isSupportedChainName(presetNetwork)) {
+      setValue("blockchain", presetNetwork)
+    }
+    if (presetRecipient != null) {
+      setValue("recipient", presetRecipient)
+    }
+  }, [presetAmount, presetNetwork, presetRecipient, setValue])
 
   useEffect(() => {
     const sub = actorRef.on("INTENT_PUBLISHED", () => {
@@ -542,8 +559,12 @@ export const WithdrawForm = ({
                       }}
                       variant="outline"
                       size="3"
-                      title={`Autofill with your address ${truncateUserAddress(userAddress)}`}
-                      aria-label={`Autofill with your address ${truncateUserAddress(userAddress)}`}
+                      title={`Autofill with your address ${truncateUserAddress(
+                        userAddress
+                      )}`}
+                      aria-label={`Autofill with your address ${truncateUserAddress(
+                        userAddress
+                      )}`}
                     >
                       <MagicWandIcon />
                     </IconButton>

--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -127,7 +127,6 @@ export const WithdrawForm = ({
       totalAmountReceived: totalAmountReceivedSelector(state),
     }
   })
-
   const publicKeyVerifierRef = useSelector(swapRef, (state) => {
     if (state) {
       return state.children.publicKeyVerifierRef
@@ -275,7 +274,6 @@ export const WithdrawForm = ({
     const sub = watch(async (value, { name }) => {
       if (name === "amountIn") {
         const amount = value[name] ?? ""
-
         let parsedAmount: TokenValue | null = null
         try {
           const decimals = getTokenMaxDecimals(token)

--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -20,6 +20,7 @@ import { useTokensStore } from "src/providers/TokensStoreProvider"
 import type { BlockchainEnum } from "src/sdk/poaBridge/constants/blockchains"
 import { ModalType } from "src/stores/modalStore"
 import { reverseAssetNetworkAdapter } from "src/utils/adapters"
+import { isSupportedChainName } from "src/utils/blockchain"
 import { formatTokenValue, formatUsdAmount } from "src/utils/format"
 import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
 import { getTokenMaxDecimals } from "src/utils/tokenUtils"
@@ -39,10 +40,7 @@ import type {
   TokenValue,
   UnifiedTokenInfo,
 } from "../../../../types/base"
-import {
-  type WithdrawWidgetProps,
-  isSupportedChainName,
-} from "../../../../types/withdraw"
+import type { WithdrawWidgetProps } from "../../../../types/withdraw"
 import { parseUnits } from "../../../../utils/parse"
 import { validateAddress } from "../../../../utils/validateAddress"
 import {

--- a/src/features/withdraw/components/WithdrawWidget.tsx
+++ b/src/features/withdraw/components/WithdrawWidget.tsx
@@ -20,7 +20,15 @@ import { WithdrawUIMachineContext } from "../WithdrawUIMachineContext"
 import { WithdrawForm } from "./WithdrawForm"
 
 export const WithdrawWidget = (props: WithdrawWidgetProps) => {
-  const [initialTokenIn] = props.tokenList
+  const initialTokenIn =
+    props.presetTokenSymbol !== undefined
+      ? (props.tokenList.find(
+          (el) =>
+            el.symbol.toLowerCase().normalize() ===
+            props.presetTokenSymbol?.toLowerCase().normalize()
+        ) ?? props.tokenList[0])
+      : props.tokenList[0]
+
   assert(initialTokenIn, "Token list must have at least 1 token")
 
   const initialTokenOut = isBaseToken(initialTokenIn)

--- a/src/types/withdraw.ts
+++ b/src/types/withdraw.ts
@@ -1,12 +1,20 @@
 import type { SendNearTransaction } from "../features/machines/publicKeyVerifierMachine"
 import type { AuthHandle } from "./authHandle"
-import type { BaseTokenInfo, UnifiedTokenInfo } from "./base"
+import type {
+  BaseTokenInfo,
+  SupportedChainName,
+  UnifiedTokenInfo,
+} from "./base"
 import type { RenderHostAppLink } from "./hostAppLink"
 import type { WalletMessage, WalletSignatureResult } from "./walletMessage"
 
 export type WithdrawWidgetProps = {
   userAddress: AuthHandle["identifier"] | undefined
   chainType: AuthHandle["method"] | undefined
+  presetTokenSymbol: string | undefined
+  presetAmount: string | undefined
+  presetRecipient: string | undefined
+  presetNetwork: string | undefined
   renderHostAppLink: RenderHostAppLink
   tokenList: (BaseTokenInfo | UnifiedTokenInfo)[]
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
@@ -16,4 +24,28 @@ export type WithdrawWidgetProps = {
    * Prop is not reactive, set it once when the component is created.
    */
   referral?: string
+}
+
+export function isSupportedChainName(
+  chainName: string
+): chainName is SupportedChainName {
+  return [
+    "near",
+    "base",
+    "arbitrum",
+    "bitcoin",
+    "solana",
+    "dogecoin",
+    "turbochain",
+    "tuxappchain",
+    "vertex",
+    "optima",
+    "coineasy",
+    "aurora",
+    "xrpledger",
+    "zcash",
+    "gnosis",
+    "berachain",
+    "tron",
+  ].includes(chainName)
 }

--- a/src/types/withdraw.ts
+++ b/src/types/withdraw.ts
@@ -1,11 +1,6 @@
-import { CHAIN_IDS } from "src/constants/evm"
 import type { SendNearTransaction } from "../features/machines/publicKeyVerifierMachine"
 import type { AuthHandle } from "./authHandle"
-import type {
-  BaseTokenInfo,
-  SupportedChainName,
-  UnifiedTokenInfo,
-} from "./base"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "./base"
 import type { RenderHostAppLink } from "./hostAppLink"
 import type { WalletMessage, WalletSignatureResult } from "./walletMessage"
 export type WithdrawWidgetProps = {
@@ -24,11 +19,4 @@ export type WithdrawWidgetProps = {
    * Prop is not reactive, set it once when the component is created.
    */
   referral?: string
-}
-
-export function isSupportedChainName(
-  chainName: string
-): chainName is SupportedChainName {
-  const supportedChainNames = Object.keys(CHAIN_IDS)
-  return supportedChainNames.includes(chainName)
 }

--- a/src/types/withdraw.ts
+++ b/src/types/withdraw.ts
@@ -1,3 +1,4 @@
+import { CHAIN_IDS } from "src/constants/evm"
 import type { SendNearTransaction } from "../features/machines/publicKeyVerifierMachine"
 import type { AuthHandle } from "./authHandle"
 import type {
@@ -7,7 +8,6 @@ import type {
 } from "./base"
 import type { RenderHostAppLink } from "./hostAppLink"
 import type { WalletMessage, WalletSignatureResult } from "./walletMessage"
-
 export type WithdrawWidgetProps = {
   userAddress: AuthHandle["identifier"] | undefined
   chainType: AuthHandle["method"] | undefined
@@ -29,23 +29,6 @@ export type WithdrawWidgetProps = {
 export function isSupportedChainName(
   chainName: string
 ): chainName is SupportedChainName {
-  return [
-    "near",
-    "base",
-    "arbitrum",
-    "bitcoin",
-    "solana",
-    "dogecoin",
-    "turbochain",
-    "tuxappchain",
-    "vertex",
-    "optima",
-    "coineasy",
-    "aurora",
-    "xrpledger",
-    "zcash",
-    "gnosis",
-    "berachain",
-    "tron",
-  ].includes(chainName)
+  const supportedChainNames = Object.keys(CHAIN_IDS)
+  return supportedChainNames.includes(chainName)
 }

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { CHAIN_IDS } from "src/constants/evm"
 import type { BlockchainEnum } from "src/sdk/poaBridge/constants/blockchains"
 import type {
   BaseTokenInfo,
@@ -12,7 +13,6 @@ import {
 } from "src/utils/adapters"
 import { isBaseToken, isUnifiedToken } from "src/utils/token"
 import { getBlockchainsOptions } from "./blockchainOptions"
-
 export function isAuroraVirtualChain(network: SupportedChainName): boolean {
   const virtualChains = [
     "turbochain",
@@ -70,4 +70,11 @@ export function getDefaultBlockchainOptionValue(
       : null
   }
   return null
+}
+
+export function isSupportedChainName(
+  chainName: string
+): chainName is SupportedChainName {
+  const supportedChainNames = Object.keys(CHAIN_IDS)
+  return supportedChainNames.includes(chainName)
 }


### PR DESCRIPTION
Accept query parameters for withdraw preset configs on redirect from Aurora Cloud Console gas abstraction transactions top-up