### PR TITLE
chore: include src directory in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "src",
+    "rollup.config.js",
+    "tailwind.config.js"
   ],
   "scripts": {
     "test": "vitest --passWithNoTests",


### PR DESCRIPTION
Including source code to the package might be counter intuitive. But it helpful if one tries to use the package which has poor documentation, they can simply open raw source code and see what is going on. 

Another use case: monkey-patch the package. It might be useful if a package has a bug, or you want to change behavior, but you don't want to fork it. Basically you make local changes and store it along with your code. In such case the patching flow is pretty simple you change "src" files and then build the package.

I faced ^ this issue during prototyping Bridge SDK, where i want to re-use existing code from SDK, but it's not exported. I monkey-patched the same way the HOT Bridge SDK btw.


upd: after careful review, i realized that just src folder is not enough, it also needs rollup and tailwind config.