### PR TITLE
fix: handle unfillable withdrawals when dust is involved

### DIFF
--- a/src/features/machines/backgroundQuoterMachine.ts
+++ b/src/features/machines/backgroundQuoterMachine.ts
@@ -131,7 +131,7 @@ function pollQuote(
         // strictly less is used deliberately, because we ignore only all quotes except MPC quotes
         requestId < INITIAL_QUOTE_WAIT_MS.length &&
         result.tag === "err" &&
-        result.value.type === "NO_QUOTES"
+        result.value.reason === "ERR_NO_QUOTES"
       ) {
         return
       }

--- a/src/features/swap/components/SwapForm.tsx
+++ b/src/features/swap/components/SwapForm.tsx
@@ -70,11 +70,11 @@ export const SwapForm = ({ isLoggedIn, renderHostAppLink }: SwapFormProps) => {
       const noLiquidity =
         snapshot.context.quote &&
         snapshot.context.quote.tag === "err" &&
-        snapshot.context.quote.value.type === "NO_QUOTES"
+        snapshot.context.quote.value.reason === "ERR_NO_QUOTES"
       const insufficientTokenInAmount =
         snapshot.context.quote &&
         snapshot.context.quote.tag === "err" &&
-        snapshot.context.quote.value.type === "INSUFFICIENT_AMOUNT"
+        snapshot.context.quote.value.reason === "ERR_INSUFFICIENT_AMOUNT"
 
       return {
         tokenIn,

--- a/src/features/withdraw/components/WithdrawForm/components/PreparationResult/PreparationResult.tsx
+++ b/src/features/withdraw/components/WithdrawForm/components/PreparationResult/PreparationResult.tsx
@@ -26,8 +26,8 @@ export const PreparationResult = ({
     case "ERR_AMOUNT_TOO_LOW":
       content = `Need ${formatTokenValue(err.minWithdrawalAmount - err.receivedAmount, err.token.decimals)} ${err.token.symbol} more to withdraw (considering fee)`
       break
-    case "NO_QUOTES":
-    case "INSUFFICIENT_AMOUNT":
+    case "ERR_NO_QUOTES":
+    case "ERR_INSUFFICIENT_AMOUNT":
       // Don't duplicate error messages, message should be displayed in the submit button
       break
     case "ERR_CANNOT_FETCH_QUOTE":

--- a/src/features/withdraw/components/WithdrawForm/components/PreparationResult/PreparationResult.tsx
+++ b/src/features/withdraw/components/WithdrawForm/components/PreparationResult/PreparationResult.tsx
@@ -1,12 +1,19 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
-import { Callout } from "@radix-ui/themes"
+import { Button, Callout } from "@radix-ui/themes"
 import type { ReactNode } from "react"
+import type { TokenValue } from "src/types/base"
 import type { PreparationOutput } from "../../../../../../services/withdrawService"
 import { formatTokenValue } from "../../../../../../utils/format"
 
 export const PreparationResult = ({
   preparationOutput,
-}: { preparationOutput: PreparationOutput | null }) => {
+  increaseAmount,
+  decreaseAmount,
+}: {
+  preparationOutput: PreparationOutput | null
+  increaseAmount: (v: TokenValue) => void
+  decreaseAmount: (v: TokenValue) => void
+}) => {
   if (preparationOutput?.tag !== "err") return null
 
   let content: ReactNode = null
@@ -36,6 +43,38 @@ export const PreparationResult = ({
     case "ERR_BALANCE_FETCH":
     case "ERR_BALANCE_MISSING":
       content = "Cannot fetch balance"
+      break
+    case "ERR_UNFULFILLABLE_AMOUNT":
+      content = (
+        <>
+          {/* biome-ignore lint/nursery/useConsistentCurlyBraces: <explanation> */}
+          Specified amount cannot be withdrawn. Please,{" "}
+          <Button
+            onClick={() => {
+              decreaseAmount(err.shortfall)
+            }}
+            variant="ghost"
+            className="underline"
+          >
+            decrease
+          </Button>
+          {/* biome-ignore lint/nursery/useConsistentCurlyBraces: <explanation> */}
+          {" or "}
+          <Button
+            onClick={() => {
+              if (err.overage != null) {
+                increaseAmount(err.overage)
+              }
+            }}
+            variant="ghost"
+            className="underline"
+          >
+            increase
+          </Button>
+          {/* biome-ignore lint/nursery/useConsistentCurlyBraces: <explanation> */}
+          {" for slight amount."}
+        </>
+      )
       break
     default:
       val satisfies never

--- a/src/features/withdraw/components/WithdrawForm/index.tsx
+++ b/src/features/withdraw/components/WithdrawForm/index.tsx
@@ -22,7 +22,11 @@ import { reverseAssetNetworkAdapter } from "src/utils/adapters"
 import { isSupportedChainName } from "src/utils/blockchain"
 import { formatTokenValue, formatUsdAmount } from "src/utils/format"
 import getTokenUsdPrice from "src/utils/getTokenUsdPrice"
-import { getTokenMaxDecimals } from "src/utils/tokenUtils"
+import {
+  addAmounts,
+  getTokenMaxDecimals,
+  subtractAmounts,
+} from "src/utils/tokenUtils"
 import { AuthGate } from "../../../../components/AuthGate"
 import { ButtonCustom } from "../../../../components/Button/ButtonCustom"
 import { EmptyIcon } from "../../../../components/EmptyIcon"
@@ -382,6 +386,38 @@ export const WithdrawForm = ({
   const balances = mergeBridgeBalances(poaBridgeBalances, nonPoaBridgeBalances)
   const showHotBalances = shouldShowHotBalance(balances, tokenInBalance)
 
+  const increaseAmount = (tokenValue: TokenValue) => {
+    if (parsedAmountIn == null) return
+
+    const newValue = addAmounts(parsedAmountIn, tokenValue)
+
+    const newFormattedValue = formatTokenValue(
+      newValue.amount,
+      newValue.decimals
+    )
+
+    actorRef.send({
+      type: "WITHDRAW_FORM.UPDATE_AMOUNT",
+      params: { amount: newFormattedValue, parsedAmount: newValue },
+    })
+  }
+
+  const decreaseAmount = (tokenValue: TokenValue) => {
+    if (parsedAmountIn == null) return
+
+    const newValue = subtractAmounts(parsedAmountIn, tokenValue)
+
+    const newFormattedValue = formatTokenValue(
+      newValue.amount,
+      newValue.decimals
+    )
+
+    actorRef.send({
+      type: "WITHDRAW_FORM.UPDATE_AMOUNT",
+      params: { amount: newFormattedValue, parsedAmount: newValue },
+    })
+  }
+
   return (
     <Island className="widget-container flex flex-col gap-4">
       <IslandHeader heading="Withdraw" condensed />
@@ -675,7 +711,11 @@ export const WithdrawForm = ({
         </Flex>
       </Form>
 
-      <PreparationResult preparationOutput={state.context.preparationOutput} />
+      <PreparationResult
+        preparationOutput={state.context.preparationOutput}
+        increaseAmount={increaseAmount}
+        decreaseAmount={decreaseAmount}
+      />
       {renderIntentCreationResult(intentCreationResult)}
 
       {intentRefs.length !== 0 && <Intents intentRefs={intentRefs} />}

--- a/src/features/withdraw/components/WithdrawForm/selectors.ts
+++ b/src/features/withdraw/components/WithdrawForm/selectors.ts
@@ -8,7 +8,7 @@ export function isLiquidityUnavailableSelector(
 ): boolean {
   return (
     state.context.preparationOutput?.tag === "err" &&
-    state.context.preparationOutput.value.reason === "NO_QUOTES"
+    state.context.preparationOutput.value.reason === "ERR_NO_QUOTES"
   )
 }
 export function isUnsufficientTokenInAmount(
@@ -16,7 +16,7 @@ export function isUnsufficientTokenInAmount(
 ): boolean {
   return (
     state.context.preparationOutput?.tag === "err" &&
-    state.context.preparationOutput.value.reason === "INSUFFICIENT_AMOUNT"
+    state.context.preparationOutput.value.reason === "ERR_INSUFFICIENT_AMOUNT"
   )
 }
 

--- a/src/sdk/aggregatedQuote/calculateSplitAmounts.test.ts
+++ b/src/sdk/aggregatedQuote/calculateSplitAmounts.test.ts
@@ -312,9 +312,22 @@ describe("calculateSplitAmounts", () => {
       token2: adjustDecimals(50n, 0, token2.decimals),
     }
 
-    expect(() => calculateSplitAmounts(tokensIn, amountIn, balances)).toThrow(
-      AmountMismatchError
-    )
+    try {
+      calculateSplitAmounts(tokensIn, amountIn, balances)
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(AmountMismatchError)
+      expect(err).toEqual(
+        expect.objectContaining({
+          requested: { amount: 200000000n, decimals: 6 },
+          fulfilled: { amount: 150000000n, decimals: 6 },
+          shortfall: { amount: 50000000n, decimals: 6 },
+          nextFulfillable: null,
+          overage: null,
+        })
+      )
+    }
+
+    expect.assertions(2)
   })
 
   it("throws AmountMismatchError when balances are zero", () => {
@@ -325,9 +338,22 @@ describe("calculateSplitAmounts", () => {
       token2: 0n,
     }
 
-    expect(() => calculateSplitAmounts(tokensIn, amountIn, balances)).toThrow(
-      AmountMismatchError
-    )
+    try {
+      calculateSplitAmounts(tokensIn, amountIn, balances)
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(AmountMismatchError)
+      expect(err).toEqual(
+        expect.objectContaining({
+          requested: { amount: 100n, decimals: 6 },
+          fulfilled: { amount: 0n, decimals: 6 },
+          shortfall: { amount: 100n, decimals: 6 },
+          nextFulfillable: null,
+          overage: null,
+        })
+      )
+    }
+
+    expect.assertions(2)
   })
 
   it("throws AmountMismatchError when no balances available", () => {
@@ -335,9 +361,20 @@ describe("calculateSplitAmounts", () => {
     const amountIn = { amount: 100n, decimals: 6 }
     const balances = {}
 
-    expect(() => calculateSplitAmounts(tokensIn, amountIn, balances)).toThrow(
-      AmountMismatchError
-    )
+    try {
+      calculateSplitAmounts(tokensIn, amountIn, balances)
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(AmountMismatchError)
+      expect(err).toEqual(
+        expect.objectContaining({
+          requested: { amount: 100n, decimals: 6 },
+          fulfilled: { amount: 0n, decimals: 6 },
+          shortfall: { amount: 100n, decimals: 6 },
+          nextFulfillable: null,
+          overage: null,
+        })
+      )
+    }
   })
 
   it("throws AmountMismatchError when tokens array is empty", () => {
@@ -345,9 +382,49 @@ describe("calculateSplitAmounts", () => {
     const amountIn = { amount: 100n, decimals: 6 }
     const balances = {}
 
-    expect(() => calculateSplitAmounts(tokensIn, amountIn, balances)).toThrow(
-      AmountMismatchError
-    )
+    try {
+      calculateSplitAmounts(tokensIn, amountIn, balances)
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(AmountMismatchError)
+      expect(err).toEqual(
+        expect.objectContaining({
+          requested: { amount: 100n, decimals: 6 },
+          fulfilled: { amount: 0n, decimals: 6 },
+          shortfall: { amount: 100n, decimals: 6 },
+          nextFulfillable: null,
+          overage: null,
+        })
+      )
+    }
+  })
+
+  it("throws AmountMismatchError when dust is requested", () => {
+    const tokensIn = [
+      { ...token1, decimals: 6 },
+      { ...token2, decimals: 8 },
+      { ...token3, decimals: 24 },
+    ]
+    const amountIn = { amount: 100n, decimals: 24 }
+    const balances = {
+      token1: adjustDecimals(1n, 0, 6),
+      token2: adjustDecimals(1n, 0, 8),
+      token3: 95n,
+    }
+
+    try {
+      calculateSplitAmounts(tokensIn, amountIn, balances)
+    } catch (err: unknown) {
+      expect(err).toBeInstanceOf(AmountMismatchError)
+      expect(err).toEqual(
+        expect.objectContaining({
+          requested: { amount: 100n, decimals: 24 },
+          fulfilled: { amount: 95n, decimals: 24 },
+          shortfall: { amount: 5n, decimals: 24 },
+          nextFulfillable: { amount: 10n ** 24n, decimals: 24 },
+          overage: { amount: 10n ** 24n - 100n, decimals: 24 },
+        })
+      )
+    }
   })
 
   function sumTotal(

--- a/src/sdk/aggregatedQuote/calculateSplitAmounts.ts
+++ b/src/sdk/aggregatedQuote/calculateSplitAmounts.ts
@@ -55,58 +55,68 @@ export function sortForOptimalAmountSplitting(
  * Function to calculate how to split the input amounts based on available balances.
  * Duplicate tokens are processed only once and their balances are considered only once.
  */
+
 export function calculateSplitAmounts(
   tokensIn: TokenSlice[],
   amountIn: TokenValue,
-  balances: Balances
+  balances: Record<string, bigint>
 ): Record<string, bigint> {
-  const amountsToQuote: Record<string, bigint> = {}
-
-  const uniqueTokensIn_ = deduplicateTokens(tokensIn)
-  const uniqueTokensIn = sortForOptimalAmountSplitting(
-    uniqueTokensIn_,
+  const unique = sortForOptimalAmountSplitting(
+    deduplicateTokens(tokensIn),
     balances
   )
 
-  let remainingAmount = amountIn.amount
-  const remainingDecimals = amountIn.decimals
+  // 1) no tokens → immediate error
+  if (unique.length === 0) {
+    throw new AmountMismatchError({
+      requested: amountIn,
+      fulfilled: { amount: 0n, decimals: amountIn.decimals },
+      nextFulfillable: null,
+    })
+  }
 
-  for (const tokenIn of uniqueTokensIn) {
-    const availableIn = balances[tokenIn.defuseAssetId] ?? 0n
+  // 2) greedy fill in each token's own decimals
+  let remaining = amountIn.amount
+  const dec = amountIn.decimals
+  const out: Record<string, bigint> = {}
 
-    // Convert remaining amount to token's decimals
-    const normalizedRemainingAmount = adjustDecimals(
-      remainingAmount,
-      remainingDecimals,
-      tokenIn.decimals
-    )
-
-    const amountToQuote = min(availableIn, normalizedRemainingAmount)
-
-    if (amountToQuote > 0n) {
-      amountsToQuote[tokenIn.defuseAssetId] = amountToQuote
-
-      // Convert back to original decimals to subtract from remaining
-      remainingAmount -= adjustDecimals(
-        amountToQuote,
-        tokenIn.decimals,
-        remainingDecimals
-      )
+  for (const t of unique) {
+    const avail = balances[t.defuseAssetId] ?? 0n
+    const need = adjustDecimals(remaining, dec, t.decimals)
+    const take = avail < need ? avail : need
+    if (take > 0n) {
+      out[t.defuseAssetId] = take
+      remaining -= adjustDecimals(take, t.decimals, dec)
     }
-
-    if (remainingAmount === 0n) break
+    if (remaining === 0n) break
   }
 
-  if (remainingAmount !== 0n) {
-    throw new AmountMismatchError(
-      { amount: amountIn.amount, decimals: amountIn.decimals },
-      { amount: remainingAmount, decimals: remainingDecimals }
-    )
+  // 3) if still short, build the error
+  if (remaining !== 0n) {
+    // what we did fill vs what's left
+    const fulfilledAmt = amountIn.amount - remaining
+
+    // total available in the input's decimals
+    const totalAvail = unique
+      .map((t) =>
+        adjustDecimals(balances[t.defuseAssetId] ?? 0n, t.decimals, dec)
+      )
+      .reduce((sum, v) => sum + v, 0n)
+
+    const oneUnit = 10n ** BigInt(dec)
+    const nextAmt = ceilDiv(amountIn.amount, oneUnit) * oneUnit
+
+    const nextFulfillable =
+      totalAvail >= nextAmt ? { amount: nextAmt, decimals: dec } : null
+
+    throw new AmountMismatchError({
+      requested: amountIn,
+      fulfilled: { amount: fulfilledAmt, decimals: dec },
+      nextFulfillable: nextFulfillable,
+    })
   }
 
-  return amountsToQuote
+  return out
 }
 
-function min(a: bigint, b: bigint): bigint {
-  return a < b ? a : b
-}
+const ceilDiv = (a: bigint, b: bigint) => (a + b - 1n) / b

--- a/src/sdk/aggregatedQuote/calculateSplitAmounts.ts
+++ b/src/sdk/aggregatedQuote/calculateSplitAmounts.ts
@@ -55,7 +55,6 @@ export function sortForOptimalAmountSplitting(
  * Function to calculate how to split the input amounts based on available balances.
  * Duplicate tokens are processed only once and their balances are considered only once.
  */
-
 export function calculateSplitAmounts(
   tokensIn: TokenSlice[],
   amountIn: TokenValue,

--- a/src/sdk/aggregatedQuote/errors/amountMismatchError.ts
+++ b/src/sdk/aggregatedQuote/errors/amountMismatchError.ts
@@ -1,11 +1,47 @@
 import { BaseError } from "../../../errors/base"
 import type { TokenValue } from "../../../types/base"
+import { subtractAmounts } from "../../../utils/tokenUtils"
 
 export class AmountMismatchError extends BaseError {
-  constructor(requested: TokenValue, remaining: TokenValue) {
+  public readonly requested: TokenValue
+  public readonly fulfilled: TokenValue
+  public readonly shortfall: TokenValue
+  public readonly nextFulfillable: TokenValue | null
+  public readonly overage: TokenValue | null
+
+  /**
+   * @param requested
+   * @param fulfilled
+   * @param nextFulfillable - smallest higher (or null)
+   */
+  constructor({
+    requested,
+    fulfilled,
+    nextFulfillable,
+  }: {
+    requested: TokenValue
+    fulfilled: TokenValue
+    nextFulfillable: TokenValue | null
+  }) {
+    const parts = [
+      `Requested: ${requested.amount.toString()} (decimals ${requested.decimals})`,
+      `Fulfilled: ${fulfilled.amount.toString()}`,
+      nextFulfillable
+        ? `Next possible: ${nextFulfillable.amount.toString()}`
+        : undefined,
+    ].filter(Boolean) as string[]
+
     super("Unable to fulfill requested amount", {
-      details: `Unable to fulfill requested amount ${requested.amount} (decimals: ${requested.decimals}) with remaining amount ${remaining.amount} (decimals: ${remaining.decimals})`,
+      metaMessages: parts,
     })
     this.name = "AmountMismatchError"
+
+    this.requested = requested
+    this.fulfilled = fulfilled
+    this.shortfall = subtractAmounts(requested, fulfilled)
+    this.nextFulfillable = nextFulfillable
+    this.overage = nextFulfillable
+      ? subtractAmounts(nextFulfillable, requested)
+      : null
   }
 }

--- a/src/sdk/aggregatedQuote/getAggregatedQuoteExactIn.ts
+++ b/src/sdk/aggregatedQuote/getAggregatedQuoteExactIn.ts
@@ -1,4 +1,5 @@
 import { settings } from "../../constants/settings"
+import type { AssertionError } from "../../errors/assert"
 import type { BaseTokenInfo, TokenValue } from "../../types/base"
 import { assert } from "../../utils/assert"
 import {
@@ -33,6 +34,7 @@ export type GetAggregatedQuoteExactInErrorType =
   | JSONRPCErrorType
   | AggregatedQuoteError
   | AmountMismatchError
+  | AssertionError
 
 export async function getAggregatedQuoteExactIn({
   aggregatedQuoteParams,

--- a/src/services/quoteService.test.ts
+++ b/src/services/quoteService.test.ts
@@ -228,14 +228,14 @@ describe("queryQuote()", () => {
     await expect(queryQuote(input)).resolves.toEqual({
       tag: "err",
       value: {
-        type: "NO_QUOTES",
+        reason: "ERR_NO_QUOTES",
       },
     })
 
     await expect(queryQuote(input)).resolves.toEqual({
       tag: "err",
       value: {
-        type: "NO_QUOTES",
+        reason: "ERR_NO_QUOTES",
       },
     })
   })

--- a/src/services/quoteService.ts
+++ b/src/services/quoteService.ts
@@ -1,5 +1,6 @@
 import { settings } from "../constants/settings"
 import { AggregatedQuoteError } from "../sdk/aggregatedQuote/errors/aggregatedQuoteError"
+import { AmountMismatchError } from "../sdk/aggregatedQuote/errors/amountMismatchError"
 import { getAggregatedQuoteExactIn } from "../sdk/aggregatedQuote/getAggregatedQuoteExactIn"
 import type {
   FailedQuote,
@@ -42,9 +43,13 @@ export type QuoteResult =
   | {
       tag: "err"
       value:
-        | FailedQuote
         | {
-            type: "NO_QUOTES"
+            reason: "ERR_INSUFFICIENT_AMOUNT" | "ERR_NO_QUOTES"
+          }
+        | {
+            reason: "ERR_UNFULFILLABLE_AMOUNT"
+            shortfall: TokenValue
+            overage: TokenValue | null
           }
     }
 export async function queryQuote(
@@ -83,13 +88,26 @@ export async function queryQuote(
       if (quoteError?.quote) {
         return {
           tag: "err",
-          value: quoteError.quote,
+          value: {
+            reason: `ERR_${quoteError.quote.type}`,
+          },
         }
       }
       return {
         tag: "err",
         value: {
-          type: "NO_QUOTES",
+          reason: "ERR_NO_QUOTES",
+        },
+      }
+    }
+
+    if (err instanceof AmountMismatchError) {
+      return {
+        tag: "err",
+        value: {
+          reason: "ERR_UNFULFILLABLE_AMOUNT",
+          shortfall: err.shortfall,
+          overage: err.overage,
         },
       }
     }
@@ -131,7 +149,7 @@ export async function queryQuoteExactOut(
     return {
       tag: "err",
       value: {
-        type: "NO_QUOTES",
+        reason: "ERR_NO_QUOTES",
       },
     }
   }
@@ -172,14 +190,16 @@ export async function queryQuoteExactOut(
   if (failedQuotes[0]) {
     return {
       tag: "err",
-      value: failedQuotes[0],
+      value: {
+        reason: `ERR_${failedQuotes[0].type}`,
+      },
     }
   }
 
   return {
     tag: "err",
     value: {
-      type: "NO_QUOTES",
+      reason: "ERR_NO_QUOTES",
     },
   }
 }

--- a/src/services/withdrawService.ts
+++ b/src/services/withdrawService.ts
@@ -18,7 +18,6 @@ import {
 import type { State as WithdrawFormContext } from "../features/machines/withdrawFormReducer"
 import { logger } from "../logger"
 import { getWithdrawalEstimate } from "../sdk/poaBridge/poaBridgeHttpClient"
-import type { FailedQuote } from "../sdk/solverRelay/solverRelayHttpClient/types"
 import type { BaseTokenInfo, TokenValue, UnifiedTokenInfo } from "../types/base"
 import { assetNetworkAdapter } from "../utils/adapters"
 import { assert } from "../utils/assert"
@@ -66,6 +65,7 @@ export type PreparationOutput =
   | {
       tag: "err"
       value:
+        | Extract<QuoteResult, { tag: "err" }>["value"]
         | {
             reason:
               | "ERR_BALANCE_FETCH"
@@ -74,8 +74,6 @@ export type PreparationOutput =
               | "ERR_NEP141_STORAGE"
               | "ERR_CANNOT_FETCH_POA_BRIDGE_INFO"
               | "ERR_CANNOT_FETCH_QUOTE"
-              | "NO_QUOTES"
-              | "INSUFFICIENT_AMOUNT"
           }
         | {
             reason: "ERR_AMOUNT_TOO_LOW"
@@ -188,10 +186,7 @@ export async function prepareWithdraw(
   }
 
   if (swapRequirement && swapRequirement.swapQuote.tag === "err") {
-    return {
-      tag: "err",
-      value: { reason: swapRequirement.swapQuote.value.type },
-    }
+    return { tag: "err", value: swapRequirement.swapQuote.value }
   }
 
   const nep141Storage = await determineNEP141StorageRequirement(
@@ -284,13 +279,9 @@ async function determineNEP141StorageRequirement(
   | { tag: "ok"; value: NEP141StorageRequirement | null }
   | {
       tag: "err"
-      value: {
-        reason:
-          | "ERR_NEP141_STORAGE"
-          | FailedQuote["type"]
-          | "NO_QUOTES"
-          | "ERR_CANNOT_FETCH_QUOTE"
-      }
+      value:
+        | Extract<QuoteResult, { tag: "err" }>["value"]
+        | { reason: "ERR_NEP141_STORAGE" | "ERR_CANNOT_FETCH_QUOTE" }
     }
 > {
   // We withdraw unwrapped near so no storage deposit is required for withdrawal of NEAR
@@ -338,7 +329,7 @@ async function determineNEP141StorageRequirement(
       { logBalanceSufficient: true, signal }
     )
     if (nep141StorageQuote.tag === "err") {
-      return { tag: "err", value: { reason: nep141StorageQuote.value.type } }
+      return { tag: "err", value: nep141StorageQuote.value }
     }
     return {
       tag: "ok",


### PR DESCRIPTION
## When such bug happen
1. User has 0.000000000000012345 USDT_BSC (as USDT on BSC has 18 decimals)
2. User has 0.1 USDT_ETH (6 decimals)
3. User wants to withdraw 0.1 USDT_BSC

## Why this bug happen
We take 0.000000000000012345 (A) for direct withdrawal. 0.1 - A = 0.09999999999998765 (B) is needed to swap to.
We can't swap for B because it includes 18 decimals, but USDT_ETH only 6 decimals. 

## Solution
We suggest user either to increase (to X) or decrease (to Y) the input amount. Where 
X = 0.000001 (smallest unit of USDT_ETH) + A = 0.000001000000012345
Y = A = 0.000000000000012345

<details><summary>Screenshot</summary>
<p>

<img width="519" alt="Screenshot 2025-05-29 at 18 26 04" src="https://github.com/user-attachments/assets/c798cddb-1af5-486b-9de0-ef499e33eacb" />


</p>
</details> 