### PR TITLE
build: include generated types into build

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "vitest --passWithNoTests",
     "coverage": "vitest run --coverage",
     "build": "rollup -c && tsc && copy:types",
-    "build:watch": "concurrently \"rollup -c -w\" \"tsc -w\" \"yarn copy:types\"",
+    "build:watch": "concurrently 'rollup -c -w' 'tsc -w' 'yarn copy:types'",
     "copy:types": "mkdir -p dist && rsync -avm --include='*/' --include='*.d.ts' --exclude='*' src/ dist/",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "check": "biome check",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
   "scripts": {
     "test": "vitest --passWithNoTests",
     "coverage": "vitest run --coverage",
-    "build": "rollup -c && tsc",
-    "build:watch": "concurrently \"rollup -c -w\" \"tsc -w\"",
+    "build": "rollup -c && tsc && copy:types",
+    "build:watch": "concurrently \"rollup -c -w\" \"tsc -w\" \"yarn copy:types\"",
+    "copy:types": "mkdir -p dist && rsync -avm --include='*/' --include='*.d.ts' --exclude='*' src/ dist/",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "check": "biome check",
     "format": "biome format --write src/",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,6 +67,7 @@ const config = [
       "@noble/hashes/sha3",
       "@noble/hashes/sha256",
       "near-api-js/lib/providers",
+      "@hot-labs/omni-sdk/build/utils",
     ],
   },
 ]


### PR DESCRIPTION
Now *.d.ts files are not included into the build ("./dist" folder), which break typing of the package.