### PR TITLE
fix: set `add_public_key` gas to 5 TGas

### DIFF
--- a/src/features/machines/publicKeyVerifierMachine.ts
+++ b/src/features/machines/publicKeyVerifierMachine.ts
@@ -219,7 +219,7 @@ async function addPublicKeyToContract({
         params: {
           methodName: "add_public_key",
           args: { public_key: pubKey },
-          gas: "300000000000000",
+          gas: "5000000000000",
           deposit: "1",
         },
       },


### PR DESCRIPTION
It absolutely doesn't need 300, all 300 does is require users to have 0.2 NEAR, which [not everyone has](https://t.me/intearchat/56827).