### PR TITLE
fix: update bridge-sdk with ton token fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "husky && ./scripts/gen-defuse-types.sh"
   },
   "dependencies": {
-    "@defuse-protocol/bridge-sdk": "^0.1.8",
+    "@defuse-protocol/bridge-sdk": "^0.1.9",
     "@lifeomic/attempt": "^3.1.0",
     "@noble/curves": "1.4.0",
     "@noble/hashes": "^1.7.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the "@defuse-protocol/bridge-sdk" dependency to version ^0.1.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->