### PR TITLE
feat: use prebuilt withdraw intents for all types of withdrawals

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "husky && ./scripts/gen-defuse-types.sh"
   },
   "dependencies": {
-    "@defuse-protocol/bridge-sdk": "^0.1.10",
+    "@defuse-protocol/bridge-sdk": "^0.2.0",
     "@lifeomic/attempt": "^3.1.0",
     "@noble/curves": "1.4.0",
     "@noble/hashes": "^1.7.1",

--- a/src/features/withdraw/components/WithdrawWidget.tsx
+++ b/src/features/withdraw/components/WithdrawWidget.tsx
@@ -1,22 +1,15 @@
-import type { Quote } from "src/sdk/solverRelay/solverRelayHttpClient/types"
 import { assign, fromPromise } from "xstate"
 import { WidgetRoot } from "../../../components/WidgetRoot"
-import { auroraEngineContractId } from "../../../constants/aurora"
 import { settings } from "../../../constants/settings"
 import { WithdrawWidgetProvider } from "../../../providers/WithdrawWidgetProvider"
 import type { WithdrawWidgetProps } from "../../../types/withdraw"
 import { assert } from "../../../utils/assert"
 import {
-  makeInnerSwapAndWithdrawMessage,
   makeInnerSwapMessage,
   makeSwapMessage,
 } from "../../../utils/messageFactory"
 import { isBaseToken } from "../../../utils/token"
-import { adjustDecimals } from "../../../utils/tokenUtils"
-import {
-  calcOperationAmountOut,
-  swapIntentMachine,
-} from "../../machines/swapIntentMachine"
+import { swapIntentMachine } from "../../machines/swapIntentMachine"
 import { withdrawUIMachine } from "../../machines/withdrawUIMachine"
 import { WithdrawUIMachineContext } from "../WithdrawUIMachineContext"
 import { WithdrawForm } from "./WithdrawForm"
@@ -70,132 +63,21 @@ export const WithdrawWidget = (props: WithdrawWidgetProps) => {
                         "Type must be withdraw"
                       )
 
-                      const {
-                        tokenOut,
-                        feeEstimation,
-                        recipient,
-                        destinationMemo,
-                        quote,
-                      } = context.intentOperationParams
+                      const { quote } = context.intentOperationParams
 
-                      const totalAmountWithdrawn = calcOperationAmountOut(
-                        context.intentOperationParams,
-                        quote
-                      )
-
-                      const tokenOutAccountId =
-                        tokenOut.defuseAssetId.split(":")[1]
-                      assert(
-                        tokenOutAccountId != null,
-                        "Token out account id must be defined"
-                      )
-
-                      assert(
-                        tokenOut.chainName !== "xrpledger"
-                          ? destinationMemo === null
-                          : true,
-                        "Destination memo may exist only for XRP Ledger"
-                      )
-
-                      const innerMessage = makeInnerSwapAndWithdrawMessage({
-                        tokenDeltas: quote?.tokenDeltas ?? [],
-                        storageTokenDeltas:
-                          feeEstimation.quote == null
-                            ? []
-                            : quoteToDelta(feeEstimation.quote),
-                        withdrawParams: (() => {
-                          const bridge = tokenOut.bridge
-                          switch (bridge) {
-                            case "direct":
-                              return {
-                                type: "to_near",
-                                amount: adjustDecimals(
-                                  totalAmountWithdrawn.amount,
-                                  totalAmountWithdrawn.decimals,
-                                  tokenOut.decimals
-                                ),
-                                receiverId: recipient,
-                                tokenAccountId: tokenOutAccountId,
-                                storageDeposit:
-                                  feeEstimation.quote == null
-                                    ? feeEstimation.amount
-                                    : BigInt(feeEstimation.quote.amount_out),
-                              }
-
-                            case "aurora_engine": {
-                              const contractId = (
-                                auroraEngineContractId as Record<string, string>
-                              )[tokenOut.chainName]
-
-                              assert(
-                                contractId != null,
-                                `AuroraEngine contract id is not specified for "${tokenOut.chainName}"`
-                              )
-
-                              return {
-                                type: "to_aurora_engine",
-                                amount: adjustDecimals(
-                                  totalAmountWithdrawn.amount,
-                                  totalAmountWithdrawn.decimals,
-                                  tokenOut.decimals
-                                ),
-                                tokenAccountId: tokenOutAccountId,
-                                auroraEngineContractId: contractId,
-                                destinationAddress: recipient,
-                              }
-                            }
-
-                            case "poa":
-                              return {
-                                type: "via_poa_bridge",
-                                amount: adjustDecimals(
-                                  totalAmountWithdrawn.amount,
-                                  totalAmountWithdrawn.decimals,
-                                  tokenOut.decimals
-                                ),
-                                tokenAccountId: tokenOutAccountId,
-                                destinationAddress: recipient,
-                                destinationMemo,
-                              }
-
-                            case "hot_omni":
-                              return {
-                                type: "hot_omni",
-                                chainName: tokenOut.chainName,
-                                defuseAssetId: tokenOut.defuseAssetId,
-                                amount: adjustDecimals(
-                                  totalAmountWithdrawn.amount,
-                                  totalAmountWithdrawn.decimals,
-                                  tokenOut.decimals
-                                ),
-                                destinationAddress: recipient,
-                              }
-
-                            default:
-                              bridge satisfies never
-                              throw new Error(`Unsupported bridge "${bridge}"`)
-                          }
-                        })(),
-                        signerId: context.defuseUserId,
+                      const innerMessage = makeInnerSwapMessage({
                         deadlineTimestamp:
                           Date.now() + settings.swapExpirySec * 1000,
                         referral: context.referral,
+                        signerId: context.defuseUserId,
+                        tokenDeltas: quote?.tokenDeltas ?? [],
                       })
 
-                      // override the old hot_omni withdrawal approach
-                      if (tokenOut.bridge === "hot_omni") {
-                        innerMessage.intents = [
-                          ...(makeInnerSwapMessage({
-                            deadlineTimestamp:
-                              Date.now() + settings.swapExpirySec * 1000,
-                            referral: context.referral,
-                            signerId: context.defuseUserId,
-                            tokenDeltas: quote?.tokenDeltas ?? [],
-                          }).intents ?? []),
-                          ...context.intentOperationParams
-                            .prebuiltWithdrawalIntents,
-                        ]
-                      }
+                      innerMessage.intents ??= []
+                      innerMessage.intents.push(
+                        ...context.intentOperationParams
+                          .prebuiltWithdrawalIntents
+                      )
 
                       return {
                         innerMessage,
@@ -213,11 +95,4 @@ export const WithdrawWidget = (props: WithdrawWidgetProps) => {
       </WithdrawWidgetProvider>
     </WidgetRoot>
   )
-}
-
-function quoteToDelta(quote: Quote): [string, bigint][] {
-  return [
-    [quote.defuse_asset_identifier_in, -BigInt(quote.amount_in)],
-    [quote.defuse_asset_identifier_out, BigInt(quote.amount_out)],
-  ]
 }

--- a/src/services/withdrawService.ts
+++ b/src/services/withdrawService.ts
@@ -5,6 +5,7 @@ import {
 import { Err, Ok, type Result } from "@thames/monads"
 import { findError } from "src/utils/errors"
 import { type ActorRefFrom, waitFor } from "xstate"
+import { auroraEngineContractId } from "../constants/aurora"
 import { bridgeSDK } from "../constants/bridgeSdk"
 import type {
   QuoteInput,
@@ -209,20 +210,23 @@ export async function prepareWithdraw(
     }
   }
 
-  // BridgeSDK doesn't support virtual chains yet, and currently prebuilt
-  // withdrawal intents will be used only for `hot_omni`, so we can skip generating
-  const withdrawalIntents = isAuroraVirtualChain(formValues.tokenOut.chainName)
-    ? []
-    : await bridgeSDK.createWithdrawalIntents({
-        withdrawalParams: {
-          assetId: formValues.tokenOut.defuseAssetId,
-          amount: receivedAmount.amount,
-          destinationAddress: formValues.parsedRecipient,
-          destinationMemo: formValues.parsedDestinationMemo ?? undefined,
-          feeInclusive: false,
-        },
-        feeEstimation: feeEstimation.unwrap(),
-      })
+  const withdrawalIntents = await bridgeSDK.createWithdrawalIntents({
+    withdrawalParams: {
+      assetId: formValues.tokenOut.defuseAssetId,
+      amount: receivedAmount.amount,
+      destinationAddress: formValues.parsedRecipient,
+      destinationMemo: formValues.parsedDestinationMemo ?? undefined,
+      feeInclusive: false,
+      bridgeConfig: !isAuroraVirtualChain(formValues.tokenOut.chainName)
+        ? undefined
+        : {
+            bridge: "aurora_engine",
+            auroraEngineContractId:
+              auroraEngineContractId[formValues.tokenOut.chainName],
+          },
+    },
+    feeEstimation: feeEstimation.unwrap(),
+  })
 
   return {
     tag: "ok",
@@ -351,14 +355,6 @@ async function estimateFee({
   amount: bigint
   recipient: string
 }): Promise<Result<FeeEstimation, { reason: "ERR_WITHDRAWAL_FEE_FETCH" }>> {
-  // BridgeSDK doesn't support virtual chains yet, so it can't estimate
-  if (isAuroraVirtualChain(chainName)) {
-    return Ok({
-      amount: 0n,
-      quote: null,
-    })
-  }
-
   return bridgeSDK
     .estimateWithdrawalFee({
       withdrawalParams: {
@@ -367,6 +363,12 @@ async function estimateFee({
         destinationAddress: recipient,
         destinationMemo: undefined,
         feeInclusive: true,
+        bridgeConfig: !isAuroraVirtualChain(chainName)
+          ? undefined
+          : {
+              bridge: "aurora_engine",
+              auroraEngineContractId: auroraEngineContractId[chainName],
+            },
       },
     })
     .then(Ok, (err) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,10 +367,10 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
-"@defuse-protocol/bridge-sdk@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@defuse-protocol/bridge-sdk/-/bridge-sdk-0.1.10.tgz#7a5fba6263851c00202534bac307dbf5c13e15ab"
-  integrity sha512-5wFZMS6vUzrP8bpJvN3jqmrMRZtm9a0a+yi2prySZfMT5a90z3Dm129mDRPfiA2Apfkk2BlvTZ7yhiOsG7BX2A==
+"@defuse-protocol/bridge-sdk@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@defuse-protocol/bridge-sdk/-/bridge-sdk-0.2.0.tgz#b556130619c40a6bd4a28d3b76d4a21146304b1a"
+  integrity sha512-dclCmR2aGkcQ5NEAaEh1UC9xpHMMwPiM/hRsotn8T5r744SyI/xN3EpSJI0ffyMoRCBpt9CUV6cTum76MghViQ==
   dependencies:
     "@defuse-protocol/contract-types" "0.0.2"
     "@defuse-protocol/internal-utils" "0.0.6"


### PR DESCRIPTION
I added Aurora Engine chains support to Bridge SDK, so we don't need to dance around it and just use the SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Aurora virtual chains in withdrawal processing and fee estimation.

- **Refactor**
  - Simplified the withdrawal message assembly, removing bridge-specific parameter handling for a more streamlined process.

- **Chores**
  - Updated the "@defuse-protocol/bridge-sdk" dependency to version ^0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->