### PR TITLE
fix: handle balance check when user wallet contract is not deployed

### DIFF
--- a/src/features/machines/depositTokenBalanceMachine.ts
+++ b/src/features/machines/depositTokenBalanceMachine.ts
@@ -1,3 +1,8 @@
+import { settings } from "src/constants/settings"
+import {
+  checkTonJettonWalletRequired,
+  createTonClient,
+} from "src/services/tonJettonService"
 import type { Address } from "viem"
 import { assign, fromPromise, setup } from "xstate"
 import { logger } from "../../logger"
@@ -153,6 +158,17 @@ export const backgroundBalanceActor = fromPromise(
             throw new Error("Failed to fetch TON balances")
           }
           result.balance = balance
+          break
+        }
+
+        const isJettonWalletCreationRequired =
+          await checkTonJettonWalletRequired(
+            createTonClient(settings.rpcUrls.ton),
+            derivedToken,
+            userWalletAddress
+          )
+        if (isJettonWalletCreationRequired) {
+          result.balance = 0n
           break
         }
 

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -184,7 +184,7 @@ export async function prepareDeposit(
   const tonJettonWalletCreationRequired = await checkTonJettonWalletRequired(
     createTonClient(settings.rpcUrls.ton),
     formValues.derivedToken,
-    generateDepositAddress.value.generateDepositAddress
+    userAddress
   )
 
   return {

--- a/src/services/tonJettonService.ts
+++ b/src/services/tonJettonService.ts
@@ -106,12 +106,12 @@ export async function checkJettonWalletExists(
 export async function checkTonJettonWalletRequired(
   client: TonClient,
   token: BaseTokenInfo,
-  depositAddress: string | null
+  userWalletAddress: string | null
 ): Promise<boolean> {
   if (
     token.chainName !== "ton" ||
     isNativeToken(token) ||
-    depositAddress === null
+    userWalletAddress === null
   ) {
     return false
   }
@@ -119,7 +119,7 @@ export async function checkTonJettonWalletRequired(
   try {
     const jettonWalletAddress = await getUserJettonWalletAddress(
       client,
-      depositAddress,
+      userWalletAddress,
       token.address
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling for TON blockchain tokens by correctly checking if a TON Jetton wallet needs to be created, ensuring accurate balance display and preventing unnecessary balance fetch attempts.

- **Refactor**
  - Updated parameter naming for clarity in wallet-related checks, enhancing code readability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->