### PR TITLE
feat: add internal intents network option

### DIFF
--- a/src/components/Network/ModalSelectNetwork.tsx
+++ b/src/components/Network/ModalSelectNetwork.tsx
@@ -19,6 +19,7 @@ interface ModalSelectNetworkProps {
   renderValueDetails?: (address: string) => ReactNode
   availableNetworks: NetworkOptions
   disabledNetworks: NetworkOptions
+  onIntentsSelect?: () => void
 }
 
 export const ModalSelectNetwork = ({
@@ -29,6 +30,7 @@ export const ModalSelectNetwork = ({
   renderValueDetails,
   availableNetworks,
   disabledNetworks,
+  onIntentsSelect,
 }: ModalSelectNetworkProps) => {
   const [searchValue, setSearchValue] = useState("")
 
@@ -85,6 +87,7 @@ export const ModalSelectNetwork = ({
                     selectedNetwork={selectedNetwork}
                     onChangeNetwork={onChangeNetwork}
                     renderValueDetails={renderValueDetails}
+                    onIntentsSelect={onIntentsSelect}
                   />
                 </div>
               )}
@@ -112,6 +115,7 @@ export const ModalSelectNetwork = ({
                     networkOptions={filteredDisabledNetworks}
                     selectedNetwork={selectedNetwork}
                     onChangeNetwork={onChangeNetwork}
+                    onIntentsSelect={onIntentsSelect}
                   />
                 </div>
               )}

--- a/src/components/Network/ModalSelectNetwork.tsx
+++ b/src/components/Network/ModalSelectNetwork.tsx
@@ -3,7 +3,6 @@ import { InfoCircledIcon } from "@radix-ui/react-icons"
 import { Text } from "@radix-ui/themes"
 import { type ReactNode, useMemo, useState } from "react"
 import type { NetworkOptions } from "../../hooks/useNetworkLists"
-import type { BlockchainEnum } from "../../sdk/poaBridge/constants/blockchains"
 import type { SupportedChainName } from "../../types/base"
 import { filterChains } from "../../utils/blockchain"
 import { BaseModalDialog } from "../Modal/ModalDialog"
@@ -34,19 +33,20 @@ export const ModalSelectNetwork = ({
   const [searchValue, setSearchValue] = useState("")
 
   const filteredAvailableNetworks = useMemo(() => {
-    const filtered = filterChains(availableNetworks, searchValue)
-    return Object.keys(filtered).map((key) => key as BlockchainEnum)
+    return filterChains(availableNetworks, searchValue)
   }, [availableNetworks, searchValue])
 
   const filteredDisabledNetworks = useMemo(() => {
-    const filtered = filterChains(disabledNetworks, searchValue)
-    return Object.keys(filtered).map((key) => key as BlockchainEnum)
+    return filterChains(disabledNetworks, searchValue)
   }, [disabledNetworks, searchValue])
 
   const onChangeNetwork = (network: SupportedChainName) => {
     selectNetwork(network)
     onClose()
   }
+
+  const availableNetworksValues = Object.keys(filteredAvailableNetworks)
+  const disabledNetworksValues = Object.keys(filteredDisabledNetworks)
 
   return (
     <BaseModalDialog open={!!isOpen} onClose={onClose} isDismissable>
@@ -70,25 +70,25 @@ export const ModalSelectNetwork = ({
         </div>
 
         <div className="z-10 flex-1 overflow-y-auto  -mr-[var(--inset-padding-right)] pr-[var(--inset-padding-right)]">
-          {[...filteredAvailableNetworks, ...filteredDisabledNetworks]
-            .length === 0 ? (
+          {[...availableNetworksValues, ...disabledNetworksValues].length ===
+          0 ? (
             <ModalNoResults
               text="No networks found"
               handleSearchClear={() => setSearchValue("")}
             />
           ) : (
             <div className="flex flex-col gap-2 divide-y divide-gray-300">
-              {filteredAvailableNetworks.length > 0 && (
+              {availableNetworksValues.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <NetworkList
-                    networks={filteredAvailableNetworks}
+                    networkOptions={filteredAvailableNetworks}
                     selectedNetwork={selectedNetwork}
                     onChangeNetwork={onChangeNetwork}
                     renderValueDetails={renderValueDetails}
                   />
                 </div>
               )}
-              {filteredDisabledNetworks.length > 0 && (
+              {disabledNetworksValues.length > 0 && (
                 <div className="flex flex-col gap-2 pt-4">
                   <div className="flex flex-row justify-start items-center gap-2">
                     <Text size="1" weight="bold" className="text-gray-500">
@@ -109,7 +109,7 @@ export const ModalSelectNetwork = ({
                   </div>
                   <NetworkList
                     disabled
-                    networks={filteredDisabledNetworks}
+                    networkOptions={filteredDisabledNetworks}
                     selectedNetwork={selectedNetwork}
                     onChangeNetwork={onChangeNetwork}
                   />

--- a/src/components/Network/ModalSelectNetwork.tsx
+++ b/src/components/Network/ModalSelectNetwork.tsx
@@ -2,18 +2,10 @@ import { X as CrossIcon } from "@phosphor-icons/react"
 import { InfoCircledIcon } from "@radix-ui/react-icons"
 import { Text } from "@radix-ui/themes"
 import { type ReactNode, useMemo, useState } from "react"
-import type {
-  BaseTokenInfo,
-  SupportedChainName,
-  UnifiedTokenInfo,
-} from "src/types/base"
-import { getBlockchainsOptions } from "../../constants/blockchains"
+import type { NetworkOptions } from "../../hooks/useNetworkLists"
 import type { BlockchainEnum } from "../../sdk/poaBridge/constants/blockchains"
-import {
-  availableChainsForToken,
-  availableDisabledChainsForToken,
-  filterChains,
-} from "../../utils/blockchain"
+import type { SupportedChainName } from "../../types/base"
+import { filterChains } from "../../utils/blockchain"
 import { BaseModalDialog } from "../Modal/ModalDialog"
 import { ModalNoResults } from "../Modal/ModalNoResults"
 import { SearchBar } from "../SearchBar"
@@ -21,44 +13,40 @@ import { TooltipInfo } from "../TooltipInfo"
 import { NetworkList } from "./NetworksList"
 
 interface ModalSelectNetworkProps {
-  token: BaseTokenInfo | UnifiedTokenInfo
   selectNetwork: (network: SupportedChainName) => void
   selectedNetwork: SupportedChainName | null
   isOpen?: boolean
   onClose: () => void
   renderValueDetails?: (address: string) => ReactNode
+  availableNetworks: NetworkOptions
+  disabledNetworks: NetworkOptions
 }
 
 export const ModalSelectNetwork = ({
-  token,
   selectNetwork,
   selectedNetwork,
   isOpen,
   onClose,
   renderValueDetails,
+  availableNetworks,
+  disabledNetworks,
 }: ModalSelectNetworkProps) => {
   const [searchValue, setSearchValue] = useState("")
-  const chains = getBlockchainsOptions()
 
-  const availableChains = useMemo(() => availableChainsForToken(token), [token])
-  const filteredChains = filterChains(availableChains, searchValue)
+  const filteredAvailableNetworks = useMemo(() => {
+    const filtered = filterChains(availableNetworks, searchValue)
+    return Object.keys(filtered).map((key) => key as BlockchainEnum)
+  }, [availableNetworks, searchValue])
 
-  const disabledChains = useMemo(
-    () => availableDisabledChainsForToken(chains, filteredChains),
-    [chains, filteredChains]
-  )
+  const filteredDisabledNetworks = useMemo(() => {
+    const filtered = filterChains(disabledNetworks, searchValue)
+    return Object.keys(filtered).map((key) => key as BlockchainEnum)
+  }, [disabledNetworks, searchValue])
 
   const onChangeNetwork = (network: SupportedChainName) => {
     selectNetwork(network)
     onClose()
   }
-
-  const availableNetworks = Object.keys(filteredChains).map(
-    (key) => key as BlockchainEnum
-  )
-  const disabledNetworks = Object.keys(disabledChains).map(
-    (key) => key as BlockchainEnum
-  )
 
   return (
     <BaseModalDialog open={!!isOpen} onClose={onClose} isDismissable>
@@ -82,24 +70,25 @@ export const ModalSelectNetwork = ({
         </div>
 
         <div className="z-10 flex-1 overflow-y-auto  -mr-[var(--inset-padding-right)] pr-[var(--inset-padding-right)]">
-          {[...availableNetworks, ...disabledNetworks].length === 0 ? (
+          {[...filteredAvailableNetworks, ...filteredDisabledNetworks]
+            .length === 0 ? (
             <ModalNoResults
               text="No networks found"
               handleSearchClear={() => setSearchValue("")}
             />
           ) : (
             <div className="flex flex-col gap-2 divide-y divide-gray-300">
-              {availableNetworks.length > 0 && (
+              {filteredAvailableNetworks.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <NetworkList
-                    networks={availableNetworks}
+                    networks={filteredAvailableNetworks}
                     selectedNetwork={selectedNetwork}
                     onChangeNetwork={onChangeNetwork}
                     renderValueDetails={renderValueDetails}
                   />
                 </div>
               )}
-              {disabledNetworks.length > 0 && (
+              {filteredDisabledNetworks.length > 0 && (
                 <div className="flex flex-col gap-2 pt-4">
                   <div className="flex flex-row justify-start items-center gap-2">
                     <Text size="1" weight="bold" className="text-gray-500">
@@ -120,7 +109,7 @@ export const ModalSelectNetwork = ({
                   </div>
                   <NetworkList
                     disabled
-                    networks={disabledNetworks}
+                    networks={filteredDisabledNetworks}
                     selectedNetwork={selectedNetwork}
                     onChangeNetwork={onChangeNetwork}
                   />

--- a/src/components/Network/NetworksList.tsx
+++ b/src/components/Network/NetworksList.tsx
@@ -1,15 +1,15 @@
 import { Text } from "@radix-ui/themes"
 import clsx from "clsx"
 import type { ReactNode } from "react"
-import { getBlockchainsOptions } from "../../constants/blockchains"
-import type { BlockchainEnum } from "../../sdk/poaBridge/constants/blockchains"
+import type { NetworkOptions } from "src/hooks/useNetworkLists"
+import { config } from "../../config"
 import type { SupportedChainName } from "../../types/base"
 import { reverseAssetNetworkAdapter } from "../../utils/adapters"
 import { isAuroraVirtualChain } from "../../utils/blockchain"
 import { PoweredByAuroraLabel } from "../PoweredByAuroraLabel"
 
 interface NetworkListProps {
-  networks: BlockchainEnum[]
+  networkOptions: NetworkOptions
   selectedNetwork: SupportedChainName | null
   onChangeNetwork: (network: SupportedChainName) => void
   disabled?: boolean
@@ -17,47 +17,92 @@ interface NetworkListProps {
 }
 
 export const NetworkList = ({
-  networks,
+  networkOptions,
   selectedNetwork,
   onChangeNetwork,
   disabled = false,
   renderValueDetails,
 }: NetworkListProps) => {
-  const chains = getBlockchainsOptions()
-
   return (
     <div
       className={clsx("flex flex-col gap-2", {
         "opacity-50 pointer-events-none": disabled,
       })}
     >
-      {networks.map((chain) => (
-        <button
-          key={chains[chain].value}
-          type="button"
-          className={clsx(
-            "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-3",
-            {
-              "bg-gray-3":
-                selectedNetwork === reverseAssetNetworkAdapter[chain],
-            }
-          )}
-          onClick={() => onChangeNetwork(reverseAssetNetworkAdapter[chain])}
-        >
-          <div className="flex items-center gap-2">
-            {chains[chain].icon}
-            <Text as="span" size="3" weight="bold">
-              {chains[chain].label}
-            </Text>
-            {isAuroraVirtualChain(reverseAssetNetworkAdapter[chain]) && (
-              <PoweredByAuroraLabel />
+      {Object.keys(networkOptions).map((network) => {
+        const networkInfo = networkOptions[network]
+        if (!networkInfo) return null
+
+        // Special case: Handle Intents internal transfers which exist outside the standard blockchain options.
+        if ((network as string) === "intents" && config.features.intents) {
+          // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+          const intents = networkOptions.intents as any
+          return (
+            <button
+              key={intents.value}
+              type="button"
+              className={clsx(
+                "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-3",
+                {
+                  "bg-gray-3": selectedNetwork === intents.value,
+                }
+              )}
+              onClick={() => onChangeNetwork(intents.value)}
+            >
+              <div className="flex items-center gap-2">
+                {intents.icon}
+                <Text as="span" size="3" weight="bold">
+                  {intents.label}
+                </Text>
+              </div>
+              <div className="flex items-center py-1 px-2 rounded-full bg-[#E1F9EA] text-[#17A615]">
+                <span className="text-xs">internal</span>
+              </div>
+            </button>
+          )
+        }
+
+        // Validate that the network key is a valid BlockchainEnum key
+        if (!isValidBlockchainEnumKey(network)) {
+          return null // Skip invalid network keys
+        }
+
+        const supportedChainName = reverseAssetNetworkAdapter[network]
+
+        // Normal case: Render standard blockchain options.
+        return (
+          <button
+            key={networkInfo.value}
+            type="button"
+            className={clsx(
+              "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-3",
+              {
+                "bg-gray-3": selectedNetwork === supportedChainName,
+              }
             )}
-          </div>
-          <div className="flex items-center gap-2">
-            {renderValueDetails?.(chains[chain].value)}
-          </div>
-        </button>
-      ))}
+            onClick={() => onChangeNetwork(supportedChainName)}
+          >
+            <div className="flex items-center gap-2">
+              {networkInfo.icon}
+              <Text as="span" size="3" weight="bold">
+                {networkInfo.label}
+              </Text>
+              {isAuroraVirtualChain(supportedChainName) && (
+                <PoweredByAuroraLabel />
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {renderValueDetails?.(networkInfo.value)}
+            </div>
+          </button>
+        )
+      })}
     </div>
   )
+}
+
+function isValidBlockchainEnumKey(
+  key: string
+): key is keyof typeof reverseAssetNetworkAdapter {
+  return key in reverseAssetNetworkAdapter
 }

--- a/src/components/Network/NetworksList.tsx
+++ b/src/components/Network/NetworksList.tsx
@@ -2,18 +2,22 @@ import { Text } from "@radix-ui/themes"
 import clsx from "clsx"
 import type { ReactNode } from "react"
 import type { NetworkOptions } from "src/hooks/useNetworkLists"
-import { config } from "../../config"
+import { isIntentsOption } from "../../constants/blockchains"
 import type { SupportedChainName } from "../../types/base"
-import { reverseAssetNetworkAdapter } from "../../utils/adapters"
+import {
+  isValidBlockchainEnumKey,
+  reverseAssetNetworkAdapter,
+} from "../../utils/adapters"
 import { isAuroraVirtualChain } from "../../utils/blockchain"
 import { PoweredByAuroraLabel } from "../PoweredByAuroraLabel"
 
 interface NetworkListProps {
   networkOptions: NetworkOptions
-  selectedNetwork: SupportedChainName | null
+  selectedNetwork: SupportedChainName | "intents" | null
   onChangeNetwork: (network: SupportedChainName) => void
   disabled?: boolean
   renderValueDetails?: (address: string) => ReactNode
+  onIntentsSelect?: () => void
 }
 
 export const NetworkList = ({
@@ -22,6 +26,7 @@ export const NetworkList = ({
   onChangeNetwork,
   disabled = false,
   renderValueDetails,
+  onIntentsSelect,
 }: NetworkListProps) => {
   return (
     <div
@@ -34,25 +39,23 @@ export const NetworkList = ({
         if (!networkInfo) return null
 
         // Special case: Handle Intents internal transfers which exist outside the standard blockchain options.
-        if ((network as string) === "intents" && config.features.intents) {
-          // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-          const intents = networkOptions.intents as any
+        if (isIntentsOption(networkInfo)) {
           return (
             <button
-              key={intents.value}
+              key={networkInfo.value}
               type="button"
               className={clsx(
                 "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-3",
                 {
-                  "bg-gray-3": selectedNetwork === intents.value,
+                  "bg-gray-3": selectedNetwork === "intents",
                 }
               )}
-              onClick={() => onChangeNetwork(intents.value)}
+              onClick={onIntentsSelect}
             >
               <div className="flex items-center gap-2">
-                {intents.icon}
+                {networkInfo.icon}
                 <Text as="span" size="3" weight="bold">
-                  {intents.label}
+                  {networkInfo.label}
                 </Text>
               </div>
               <div className="flex items-center py-1 px-2 rounded-full bg-[#E1F9EA] text-[#17A615]">
@@ -62,12 +65,10 @@ export const NetworkList = ({
           )
         }
 
-        // Validate that the network key is a valid BlockchainEnum key
         if (!isValidBlockchainEnumKey(network)) {
-          return null // Skip invalid network keys
+          return null
         }
-
-        const supportedChainName = reverseAssetNetworkAdapter[network]
+        const networkName = reverseAssetNetworkAdapter[network]
 
         // Normal case: Render standard blockchain options.
         return (
@@ -77,19 +78,17 @@ export const NetworkList = ({
             className={clsx(
               "flex justify-between items-center gap-3 p-2.5 rounded-md hover:bg-gray-3",
               {
-                "bg-gray-3": selectedNetwork === supportedChainName,
+                "bg-gray-3": selectedNetwork === networkName,
               }
             )}
-            onClick={() => onChangeNetwork(supportedChainName)}
+            onClick={() => onChangeNetwork(networkName)}
           >
             <div className="flex items-center gap-2">
               {networkInfo.icon}
               <Text as="span" size="3" weight="bold">
                 {networkInfo.label}
               </Text>
-              {isAuroraVirtualChain(supportedChainName) && (
-                <PoweredByAuroraLabel />
-              )}
+              {isAuroraVirtualChain(networkName) && <PoweredByAuroraLabel />}
             </div>
             <div className="flex items-center gap-2">
               {renderValueDetails?.(networkInfo.value)}
@@ -99,10 +98,4 @@ export const NetworkList = ({
       })}
     </div>
   )
-}
-
-function isValidBlockchainEnumKey(
-  key: string
-): key is keyof typeof reverseAssetNetworkAdapter {
-  return key in reverseAssetNetworkAdapter
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ interface SDKConfig {
     optimism: boolean
     avalanche: boolean
     sui: boolean
+    intents: boolean
   }
 }
 
@@ -47,6 +48,7 @@ export let config: SDKConfig = {
     optimism: false,
     avalanche: false,
     sui: false,
+    intents: false,
   },
 }
 

--- a/src/constants/blockchains.tsx
+++ b/src/constants/blockchains.tsx
@@ -9,6 +9,27 @@ type BlockchainOption = {
   tags?: string[]
 }
 
+type IntentsOption = {
+  label: string
+  icon: ReactNode
+  value: "intents"
+  tags?: string[]
+}
+
+export type NetworkOption = BlockchainOption | IntentsOption
+
+export function isIntentsOption(
+  option: NetworkOption
+): option is IntentsOption {
+  return option.value === "intents"
+}
+
+export function isBlockchainOption(
+  option: NetworkOption
+): option is BlockchainOption {
+  return option.value !== "intents"
+}
+
 export function getBlockchainsOptions(): Record<
   BlockchainEnum,
   BlockchainOption
@@ -311,4 +332,20 @@ function sortBlockchainOptionsByVolume(
     BlockchainEnum,
     BlockchainOption
   >
+}
+
+export function getIntentsOption(): Record<"intents", IntentsOption> {
+  return {
+    intents: {
+      label: "Intents",
+      icon: (
+        <NetworkIcon
+          chainIcon="/static/icons/network/intents.svg"
+          chainName="Intents"
+        />
+      ),
+      value: "intents",
+      tags: [],
+    },
+  }
 }

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -20,6 +20,7 @@ import type { ModalSelectAssetsPayload } from "../../../../components/Modal/Moda
 import { Select } from "../../../../components/Select/Select"
 import { SelectTriggerLike } from "../../../../components/Select/SelectTriggerLike"
 import { Separator } from "../../../../components/Separator"
+import { getBlockchainsOptions } from "../../../../constants/blockchains"
 import { getPOABridgeInfo } from "../../../../features/machines/poaBridgeInfoActor"
 import { useModalStore } from "../../../../providers/ModalStoreProvider"
 import type { BlockchainEnum } from "../../../../sdk/poaBridge/constants/blockchains"
@@ -176,9 +177,10 @@ export const DepositForm = ({
 
   const chainOptions = token != null ? availableChainsForToken(token) : {}
   const { availableNetworks, disabledNetworks } = usePreparedNetworkLists(
-    chainOptions,
+    getBlockchainsOptions(),
     token
   )
+
   const networkEnum = assetNetworkAdapter[network as SupportedChainName]
   const singleNetwork = Object.keys(chainOptions).length === 1
   return (

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "@xstate/react"
 import { useEffect, useState } from "react"
 import { Controller, useFormContext } from "react-hook-form"
 import { ModalSelectNetwork } from "src/components/Network/ModalSelectNetwork"
+import { usePreparedNetworkLists } from "src/hooks/useNetworkLists"
 import { assetNetworkAdapter } from "src/utils/adapters"
 import {
   availableChainsForToken,
@@ -174,6 +175,10 @@ export const DepositForm = ({
           : null
 
   const chainOptions = token != null ? availableChainsForToken(token) : {}
+  const { availableNetworks, disabledNetworks } = usePreparedNetworkLists(
+    chainOptions,
+    token
+  )
   const networkEnum = assetNetworkAdapter[network as SupportedChainName]
   const singleNetwork = Object.keys(chainOptions).length === 1
   return (
@@ -227,11 +232,12 @@ export const DepositForm = ({
                   />
 
                   <ModalSelectNetwork
-                    token={token}
                     selectNetwork={onChangeNetwork}
                     selectedNetwork={network}
                     isOpen={isNetworkModalOpen}
                     onClose={onCloseNetworkModal}
+                    availableNetworks={availableNetworks}
+                    disabledNetworks={disabledNetworks}
                   />
                 </>
               )}

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -176,10 +176,10 @@ export const DepositForm = ({
           : null
 
   const chainOptions = token != null ? availableChainsForToken(token) : {}
-  const { availableNetworks, disabledNetworks } = usePreparedNetworkLists(
-    getBlockchainsOptions(),
-    token
-  )
+  const { availableNetworks, disabledNetworks } = usePreparedNetworkLists({
+    networks: getBlockchainsOptions(),
+    token,
+  })
 
   const networkEnum = assetNetworkAdapter[network as SupportedChainName]
   const singleNetwork = Object.keys(chainOptions).length === 1

--- a/src/features/withdraw/components/WithdrawForm/components/RecipientSubForm/RecipientSubForm.tsx
+++ b/src/features/withdraw/components/WithdrawForm/components/RecipientSubForm/RecipientSubForm.tsx
@@ -4,7 +4,9 @@ import { useSelector } from "@xstate/react"
 import { useEffect, useState } from "react"
 import type { UseFormReturn } from "react-hook-form"
 import { Controller } from "react-hook-form"
+import { getBlockchainsOptions } from "src/constants/blockchains"
 import { getMinWithdrawalHiperliquidAmount } from "src/features/withdraw/utils/hyperliquid"
+import { usePreparedNetworkLists } from "src/hooks/useNetworkLists"
 import { EmptyIcon } from "../../../../../../components/EmptyIcon"
 import { ModalSelectNetwork } from "../../../../../../components/Network/ModalSelectNetwork"
 import { Select } from "../../../../../../components/Select/Select"
@@ -93,6 +95,10 @@ export const RecipientSubForm = ({
     : {}
 
   const blockchainSelectItems = getBlockchainSelectItems(token, maxWithdrawals)
+  const { availableNetworks, disabledNetworks } = usePreparedNetworkLists(
+    getBlockchainsOptions(),
+    token
+  )
   const showHotBalances = Object.keys(maxWithdrawals).length > 0
 
   const onCloseNetworkModal = () => setIsNetworkModalOpen(false)
@@ -182,11 +188,12 @@ export const RecipientSubForm = ({
             />
 
             <ModalSelectNetwork
-              token={token}
               selectNetwork={onChangeNetwork}
               selectedNetwork={getValues("blockchain")}
               isOpen={isNetworkModalOpen}
               onClose={() => setIsNetworkModalOpen(false)}
+              availableNetworks={availableNetworks}
+              disabledNetworks={disabledNetworks}
               renderValueDetails={
                 showHotBalances
                   ? (address: string) => (

--- a/src/features/withdraw/components/WithdrawForm/components/RecipientSubForm/RecipientSubForm.tsx
+++ b/src/features/withdraw/components/WithdrawForm/components/RecipientSubForm/RecipientSubForm.tsx
@@ -4,13 +4,14 @@ import { useSelector } from "@xstate/react"
 import { useEffect, useState } from "react"
 import type { UseFormReturn } from "react-hook-form"
 import { Controller } from "react-hook-form"
-import { getBlockchainsOptions } from "src/constants/blockchains"
 import { getMinWithdrawalHiperliquidAmount } from "src/features/withdraw/utils/hyperliquid"
 import { usePreparedNetworkLists } from "src/hooks/useNetworkLists"
 import { EmptyIcon } from "../../../../../../components/EmptyIcon"
 import { ModalSelectNetwork } from "../../../../../../components/Network/ModalSelectNetwork"
 import { Select } from "../../../../../../components/Select/Select"
 import { SelectTriggerLike } from "../../../../../../components/Select/SelectTriggerLike"
+import { config } from "../../../../../../config"
+import { getBlockchainsOptions } from "../../../../../../constants/blockchains"
 import { parseDestinationMemo } from "../../../../../../features/machines/withdrawFormReducer"
 import { WithdrawUIMachineContext } from "../../../../../../features/withdraw/WithdrawUIMachineContext"
 import { useSolverLiquidityQuery } from "../../../../../../queries/solverLiquidityQuerires"
@@ -95,10 +96,12 @@ export const RecipientSubForm = ({
     : {}
 
   const blockchainSelectItems = getBlockchainSelectItems(token, maxWithdrawals)
-  const { availableNetworks, disabledNetworks } = usePreparedNetworkLists(
-    getBlockchainsOptions(),
-    token
-  )
+  const { availableNetworks, disabledNetworks } = usePreparedNetworkLists({
+    networks: getBlockchainsOptions(),
+    token,
+    intents: config.features.intents,
+  })
+
   const showHotBalances = Object.keys(maxWithdrawals).length > 0
 
   const onCloseNetworkModal = () => setIsNetworkModalOpen(false)
@@ -109,6 +112,19 @@ export const RecipientSubForm = ({
       type: "WITHDRAW_FORM.UPDATE_MIN_RECEIVED_AMOUNT",
       params: {
         minReceivedAmount: getMinWithdrawalHiperliquidAmount(network, tokenOut),
+      },
+    })
+    onCloseNetworkModal()
+  }
+
+  const onIntentsSelect = () => {
+    // TODO: this will be checked and refactored later
+    // Intents are internal transfers on NEAR, so we set the blockchain to "near"
+    setValue("blockchain", "near")
+    actorRef.send({
+      type: "WITHDRAW_FORM.UPDATE_BLOCKCHAIN",
+      params: {
+        blockchain: "near",
       },
     })
     onCloseNetworkModal()
@@ -194,6 +210,7 @@ export const RecipientSubForm = ({
               onClose={() => setIsNetworkModalOpen(false)}
               availableNetworks={availableNetworks}
               disabledNetworks={disabledNetworks}
+              onIntentsSelect={onIntentsSelect}
               renderValueDetails={
                 showHotBalances
                   ? (address: string) => (

--- a/src/hooks/useNetworkLists.ts
+++ b/src/hooks/useNetworkLists.ts
@@ -1,0 +1,44 @@
+import { type ReactNode, useMemo } from "react"
+import type { BaseTokenInfo, UnifiedTokenInfo } from "src/types/base"
+import {
+  availableChainsForToken,
+  availableDisabledChainsForToken,
+} from "src/utils/blockchain"
+
+export type NetworkOptions = Record<
+  string,
+  {
+    label: string
+    icon: ReactNode
+    value: string
+  }
+>
+
+type UsePreparedNetworkLists = (
+  networks: NetworkOptions,
+  token: BaseTokenInfo | UnifiedTokenInfo | null
+) => {
+  availableNetworks: NetworkOptions
+  disabledNetworks: NetworkOptions
+}
+
+export const usePreparedNetworkLists: UsePreparedNetworkLists = (
+  networks,
+  token
+) => {
+  const availableNetworks = useMemo(
+    () => (token == null ? {} : availableChainsForToken(token)),
+    [token]
+  )
+  const disabledNetworks = useMemo(
+    () =>
+      token == null
+        ? {}
+        : availableDisabledChainsForToken(networks, availableNetworks),
+    [networks, availableNetworks, token]
+  )
+  return {
+    availableNetworks,
+    disabledNetworks,
+  }
+}

--- a/src/hooks/useNetworkLists.ts
+++ b/src/hooks/useNetworkLists.ts
@@ -1,34 +1,36 @@
-import { type ReactNode, useMemo } from "react"
+import { useMemo } from "react"
 import type { BaseTokenInfo, UnifiedTokenInfo } from "src/types/base"
 import {
   availableChainsForToken,
   availableDisabledChainsForToken,
 } from "src/utils/blockchain"
+import { type NetworkOption, getIntentsOption } from "../constants/blockchains"
 
-export type NetworkOptions = Record<
-  string,
-  {
-    label: string
-    icon: ReactNode
-    value: string
-  }
->
+export type NetworkOptions = Record<string, NetworkOption>
 
-type UsePreparedNetworkLists = (
-  networks: NetworkOptions,
+type UsePreparedNetworkLists = (params: {
+  networks: NetworkOptions
   token: BaseTokenInfo | UnifiedTokenInfo | null
-) => {
+  intents?: boolean
+}) => {
   availableNetworks: NetworkOptions
   disabledNetworks: NetworkOptions
 }
 
-export const usePreparedNetworkLists: UsePreparedNetworkLists = (
+export const usePreparedNetworkLists: UsePreparedNetworkLists = ({
   networks,
-  token
-) => {
+  token,
+  intents = false,
+}) => {
   const availableNetworks = useMemo(
-    () => (token == null ? {} : availableChainsForToken(token)),
-    [token]
+    () =>
+      token == null
+        ? {}
+        : {
+            ...(intents ? getIntentsOption() : {}),
+            ...availableChainsForToken(token),
+          },
+    [token, intents]
   )
   const disabledNetworks = useMemo(
     () =>

--- a/src/utils/adapters.ts
+++ b/src/utils/adapters.ts
@@ -59,3 +59,9 @@ export const reverseAssetNetworkAdapter: Record<
   [BlockchainEnum.AVALANCHE]: "avalanche",
   [BlockchainEnum.SUI]: "sui",
 }
+
+export function isValidBlockchainEnumKey(
+  key: string
+): key is keyof typeof reverseAssetNetworkAdapter {
+  return key in reverseAssetNetworkAdapter
+}

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -1,6 +1,6 @@
-import type { ReactNode } from "react"
 import { config } from "../config"
 import { getBlockchainsOptions } from "../constants/blockchains"
+import type { NetworkOption } from "../constants/blockchains"
 import { CHAIN_IDS } from "../constants/evm"
 import type { BlockchainEnum } from "../sdk/poaBridge/constants/blockchains"
 import type {
@@ -26,8 +26,9 @@ export function isAuroraVirtualChain(network: SupportedChainName): boolean {
   ]
   return virtualChains.includes(network)
 }
+
 export const filterChains = (
-  candidates: Record<string, { label: string; icon: ReactNode; value: string }>,
+  candidates: Record<string, NetworkOption>,
   searchValue: string
 ) => {
   if (searchValue === "") {
@@ -38,9 +39,9 @@ export const filterChains = (
 
   return Object.fromEntries(
     Object.entries(candidates).filter(
-      ([key, chain]) =>
-        chain.label.toLowerCase().includes(lowerCaseSearchValue) ||
-        chain.value.toLowerCase().includes(lowerCaseSearchValue) ||
+      ([key, option]) =>
+        option.label.toLowerCase().includes(lowerCaseSearchValue) ||
+        option.value.toLowerCase().includes(lowerCaseSearchValue) ||
         key.toLowerCase().includes(lowerCaseSearchValue)
     )
   )
@@ -68,7 +69,7 @@ function filterChainsByFeatureFlags<T extends string>(chains: T[]): T[] {
 
 export function availableChainsForToken(
   token: BaseTokenInfo | UnifiedTokenInfo
-): Record<string, { label: string; icon: ReactNode; value: string }> {
+): Record<string, NetworkOption> {
   const tokens = isUnifiedToken(token) ? token.groupedTokens : [token]
   let chains = tokens.map((token) => token.chainName)
 
@@ -84,12 +85,9 @@ export function availableChainsForToken(
 }
 
 export function availableDisabledChainsForToken(
-  chains: Record<string, { label: string; icon: ReactNode; value: string }>,
-  filteredChains: Record<
-    string,
-    { label: string; icon: ReactNode; value: string }
-  >
-): Record<string, { label: string; icon: ReactNode; value: string }> {
+  chains: Record<string, NetworkOption>,
+  filteredChains: Record<string, NetworkOption>
+): Record<string, NetworkOption> {
   return Object.values(chains).reduce(
     (acc, chain) => {
       const notDisabledChain = filterChainsByFeatureFlags([
@@ -100,7 +98,7 @@ export function availableDisabledChainsForToken(
       }
       return acc
     },
-    {} as Record<string, { label: string; icon: ReactNode; value: string }>
+    {} as Record<string, NetworkOption>
   )
 }
 


### PR DESCRIPTION
<details>
<summary>Example:</summary>
<img width="542" alt="Screenshot 2025-07-04 at 17 19 10" src="https://github.com/user-attachments/assets/4a45511c-7aa2-4da7-9785-366527db239a" />

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for an "intents" network option in network selection components.
  * Added a new feature flag to enable or disable "intents" functionality.

* **Enhancements**
  * Network selection modals now display available and disabled networks based on the selected token and feature flags.
  * Improved flexibility in how networks are filtered and displayed during token operations.

* **Bug Fixes**
  * Ensured network lists are accurately filtered and displayed according to user input and token compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->