### PR TITLE
fix: cex flag is not required for near_intents

### DIFF
--- a/src/features/machines/withdrawFormReducer.ts
+++ b/src/features/machines/withdrawFormReducer.ts
@@ -149,6 +149,10 @@ export const withdrawFormReducer = fromTransition(
           ? getAnyBaseTokenInfo(state.tokenIn)
           : getWithdrawTokenWithFallback(state.tokenIn, determinedBlockchain)
 
+        const cexFundsLooseConfirmation = isNearIntentsNetwork(blockchain)
+          ? "not_required"
+          : cexFundsLooseConfirmationStatusDefault(tokenOut)
+
         newState = {
           ...state,
           tokenOut,
@@ -156,8 +160,7 @@ export const withdrawFormReducer = fromTransition(
           parsedRecipient: null,
           destinationMemo: "",
           parsedDestinationMemo: null,
-          cexFundsLooseConfirmation:
-            cexFundsLooseConfirmationStatusDefault(tokenOut),
+          cexFundsLooseConfirmation,
           minReceivedAmount: null,
           blockchain,
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawal form behavior by updating confirmation status handling for Near Intents networks, ensuring accurate status display based on the selected blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->