### PR TITLE
feat: add memo to address generation

### DIFF
--- a/src/features/deposit/components/DepositForm/PassiveDeposit.tsx
+++ b/src/features/deposit/components/DepositForm/PassiveDeposit.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, CopyIcon } from "@radix-ui/react-icons"
 import { Button, Spinner } from "@radix-ui/themes"
 import { QRCodeSVG } from "qrcode.react"
 import { Copy } from "../../../../components/IntentCard/CopyButton"
+import { Separator } from "../../../../components/Separator"
 import type { BlockchainEnum } from "../../../../sdk/poaBridge/constants/blockchains"
 import type { BaseTokenInfo } from "../../../../types/base"
 import {
@@ -14,6 +15,7 @@ export type PassiveDepositProps = {
   depositAddress: string | null
   minDepositAmount: bigint | null
   token: BaseTokenInfo
+  memo: string | null
 }
 
 export function PassiveDeposit({
@@ -21,11 +23,44 @@ export function PassiveDeposit({
   depositAddress,
   minDepositAmount,
   token,
+  memo,
 }: PassiveDepositProps) {
   const truncatedAddress = truncateAddress(depositAddress ?? "")
 
   return (
     <div className="flex flex-col items-stretch">
+      {memo != null && (
+        <>
+          <div className="mb-6 flex flex-col items-center justify-center">
+            <div className="w-full max-w-xs rounded-lg border border-red-500 bg-red-50 p-4 flex flex-col items-center">
+              <div className="flex items-center w-full justify-between bg-red-100 rounded px-3 py-2 mb-2">
+                <span className="font-bold text-2xl text-black tracking-wider">
+                  {memo}
+                </span>
+                <Copy text={memo}>
+                  {(copied) => (
+                    <Button
+                      type="button"
+                      size="3"
+                      variant="solid"
+                      className="ml-2 box-border size-8 p-0 bg-red-200 hover:bg-red-300 text-red-600"
+                    >
+                      {copied ? <CheckIcon /> : <CopyIcon />}
+                    </Button>
+                  )}
+                </Copy>
+              </div>
+              <div className="text-red-500 text-sm text-center font-medium">
+                Include this MEMO to receive your funds!
+              </div>
+            </div>
+          </div>
+          <div className="-mx-5 mb-6">
+            <Separator />
+          </div>
+        </>
+      )}
+
       <div className="font-bold text-label text-sm">
         Use this deposit address
       </div>

--- a/src/features/deposit/components/DepositForm/index.tsx
+++ b/src/features/deposit/components/DepositForm/index.tsx
@@ -87,6 +87,11 @@ export const DepositForm = ({
   const depositAddress = isOutputOk
     ? preparationOutput.value.generateDepositAddress
     : null
+  const memo = isOutputOk
+    ? "memo" in preparationOutput.value
+      ? preparationOutput.value.memo
+      : null
+    : null
 
   const { setModalType, payload, onCloseModal } = useModalStore(
     (state) => state
@@ -284,6 +289,7 @@ export const DepositForm = ({
                   depositAddress={depositAddress}
                   minDepositAmount={minDepositAmount}
                   token={derivedToken}
+                  memo={memo}
                 />
               )}
           </>

--- a/src/features/deposit/components/DepositUIMachineProvider.tsx
+++ b/src/features/deposit/components/DepositUIMachineProvider.tsx
@@ -93,12 +93,16 @@ export function DepositUIMachineProvider({
               generateDepositAddress: fromPromise(async ({ input }) => {
                 const { userAddress, blockchain, userChainType } = input
 
-                const address = await generateDepositAddress(
+                const generatedResult = await generateDepositAddress(
                   authHandleToIntentsUserId(userAddress, userChainType),
                   assetNetworkAdapter[blockchain]
                 )
 
-                return address
+                return {
+                  generateDepositAddress:
+                    generatedResult.generatedDepositAddress,
+                  memo: generatedResult.memo,
+                }
               }),
             },
           }),

--- a/src/features/machines/depositGenerateAddressMachine.ts
+++ b/src/features/machines/depositGenerateAddressMachine.ts
@@ -12,6 +12,7 @@ export type Context = {
         tag: "ok"
         value: {
           generateDepositAddress: string | null
+          memo: string | null
         }
       }
     | {
@@ -45,7 +46,10 @@ export const depositGenerateAddressMachine = setup({
           userChainType: AuthMethod
           blockchain: SupportedChainName
         }
-      }): Promise<string> => {
+      }): Promise<{
+        generateDepositAddress: string | null
+        memo: string | null
+      }> => {
         throw new Error("not implemented")
       }
     ),
@@ -131,9 +135,7 @@ export const depositGenerateAddressMachine = setup({
           actions: assign({
             preparationOutput: ({ event }) => ({
               tag: "ok",
-              value: {
-                generateDepositAddress: event.output,
-              },
+              value: event.output,
             }),
           }),
 

--- a/src/sdk/poaBridge/poaBridgeHttpClient/types.ts
+++ b/src/sdk/poaBridge/poaBridgeHttpClient/types.ts
@@ -1,3 +1,4 @@
+import type { DepositNetworkMemo } from "src/services/depositService"
 import type { RpcRequestError } from "../../../errors/request"
 import type { BaseTokenInfo } from "../../../types/base"
 import type { RequestErrorType } from "../../../utils/request"
@@ -49,7 +50,8 @@ export type GetDepositAddressRequest = JSONRPCRequest<
     account_id: string
     /** Chain is joined blockchain and network (e.g. eth:8453) */
     chain: string
-  }
+    /** Special parameter for dedicated networks like Stellar */
+  } & Partial<DepositNetworkMemo>
 >
 
 export type GetDepositAddressResponse = JSONRPCResponse<{

--- a/src/sdk/poaBridge/poaBridgeHttpClient/types.ts
+++ b/src/sdk/poaBridge/poaBridgeHttpClient/types.ts
@@ -54,10 +54,17 @@ export type GetDepositAddressRequest = JSONRPCRequest<
   } & Partial<DepositNetworkMemo>
 >
 
-export type GetDepositAddressResponse = JSONRPCResponse<{
-  address: string
-  chain: string
-}>
+export type GetDepositAddressResponse = JSONRPCResponse<
+  | {
+      address: string
+      chain: string
+    }
+  | {
+      address: string
+      chain: string
+      memo: string
+    }
+>
 
 export type DepositStatus = {
   tx_hash: string

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -68,6 +68,7 @@ export type PreparationOutput =
         maxDepositValue: bigint | null
         solanaATACreationRequired: boolean
         tonJettonWalletCreationRequired: boolean
+        memo: string | null
       }
     }
   | {
@@ -198,6 +199,7 @@ export async function prepareDeposit(
       maxDepositValue: estimation.value.maxDepositValue,
       solanaATACreationRequired,
       tonJettonWalletCreationRequired,
+      memo: generateDepositAddress.value.memo,
     },
   }
 }
@@ -280,7 +282,10 @@ async function getGeneratedDepositAddress(
   },
   { signal }: { signal: AbortSignal }
 ): Promise<
-  | { tag: "ok"; value: { generateDepositAddress: string | null } }
+  | {
+      tag: "ok"
+      value: { generateDepositAddress: string | null; memo: string | null }
+    }
   | { tag: "err"; value: { reason: "ERR_GENERATING_ADDRESS" } }
 > {
   const depositGenerateAddressState = await waitFor(
@@ -297,7 +302,10 @@ async function getGeneratedDepositAddress(
     generateDepositAddressOutput?.value.generateDepositAddress ?? null
   return {
     tag: "ok",
-    value: { generateDepositAddress },
+    value: {
+      generateDepositAddress,
+      memo: generateDepositAddressOutput?.value.memo ?? null,
+    },
   }
 }
 
@@ -665,7 +673,10 @@ function createSPLTransferSolanaTransaction(
 export async function generateDepositAddress(
   userAddress: IntentsUserId,
   chain: BlockchainEnum
-): Promise<string> {
+): Promise<{
+  generatedDepositAddress: string
+  memo: string | null
+}> {
   try {
     const supportedTokens = await getSupportedTokens({
       chains: [chain],
@@ -675,14 +686,18 @@ export async function generateDepositAddress(
       throw new Error("No supported tokens found")
     }
 
-    const memo = getDepositNetworkMemo(chain)
+    const depositNetworkMemo = getDepositNetworkMemo(chain)
     const generatedDepositAddress = await getDepositAddress({
       account_id: userAddress,
       chain,
-      ...(memo && memo),
+      ...(depositNetworkMemo && depositNetworkMemo),
     })
 
-    return generatedDepositAddress.address
+    return {
+      generatedDepositAddress: generatedDepositAddress.address,
+      memo:
+        "memo" in generatedDepositAddress ? generatedDepositAddress.memo : null,
+    }
   } catch (error) {
     logger.error(
       new Error("Error generating deposit address", { cause: error })

--- a/src/services/depositService.ts
+++ b/src/services/depositService.ts
@@ -675,9 +675,11 @@ export async function generateDepositAddress(
       throw new Error("No supported tokens found")
     }
 
+    const memo = getDepositNetworkMemo(chain)
     const generatedDepositAddress = await getDepositAddress({
       account_id: userAddress,
       chain,
+      ...(memo && memo),
     })
 
     return generatedDepositAddress.address
@@ -1089,6 +1091,26 @@ export function getWalletRpcUrl(network: BlockchainEnum): string {
     default:
       network satisfies never
       throw new Error("exhaustive check failed")
+  }
+}
+
+export type DepositNetworkMemo = {
+  deposit_mode: "MEMO"
+} | null
+
+/**
+ * @notes - Stellar is the only blockchain that requires a memo at that moment.
+ */
+export function getDepositNetworkMemo(
+  network: BlockchainEnum
+): DepositNetworkMemo {
+  switch (network) {
+    case BlockchainEnum.STELLAR:
+      return {
+        deposit_mode: "MEMO",
+      }
+    default:
+      return null
   }
 }
 


### PR DESCRIPTION
<details>

<summary>Example</summary>

<img width="560" alt="Screenshot 2025-07-09 at 14 39 58" src="https://github.com/user-attachments/assets/7dc185fd-2b50-476a-a3f2-de2d84702e74" />


</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deposit addresses for supported networks can now display an additional memo field when required. The memo is shown prominently above the deposit address, includes a copy button, and provides a clear warning to include the memo when depositing funds.

* **Bug Fixes**
  * None.

* **Other**
  * Improved handling and display of deposit memos for blockchains that require them, ensuring users receive all necessary information for successful deposits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->