### PR TITLE
feat: enable dialog revealing internal address

### DIFF
--- a/src/features/account/components/AccountWidget.tsx
+++ b/src/features/account/components/AccountWidget.tsx
@@ -31,6 +31,11 @@ export function AccountWidget({
   const holdings = useWatchHoldings({ userId, tokenList })
   const totalValueUsd = holdings ? computeTotalUsdValue(holdings) : undefined
 
+  const internalUserAddress =
+    userAddress != null && userChainType != null
+      ? authHandleToIntentsUserId(userAddress, userChainType)
+      : null
+
   return (
     <WidgetRoot>
       <div className="widget-container flex flex-col gap-5">
@@ -38,6 +43,7 @@ export function AccountWidget({
           isLoggedIn={userAddress != null}
           valueUsd={totalValueUsd}
           renderHostAppLink={renderHostAppLink}
+          internalUserAddress={internalUserAddress}
         />
 
         <HoldingsIsland isLoggedIn={userId != null} holdings={holdings} />

--- a/src/features/account/components/RevealAddressDialog.tsx
+++ b/src/features/account/components/RevealAddressDialog.tsx
@@ -1,0 +1,106 @@
+import { CheckIcon, CopyIcon } from "@radix-ui/react-icons"
+import { Dialog } from "@radix-ui/themes"
+import { Button } from "@radix-ui/themes"
+import { Callout } from "@radix-ui/themes"
+import { QRCodeSVG } from "qrcode.react"
+import { Copy } from "../../../components/IntentCard/CopyButton"
+import { BaseModalDialog } from "../../../components/Modal/ModalDialog"
+import { IntentsIcon } from "./shared/IntentsIcon"
+
+type RevealAddressDialogProps = {
+  internalUserAddress: string
+  onClose: () => void
+}
+
+export function RevealAddressDialog({
+  internalUserAddress,
+  onClose,
+}: RevealAddressDialogProps) {
+  const truncatedAddress = truncateAddress(internalUserAddress)
+
+  return (
+    <BaseModalDialog open onClose={onClose} isDismissable>
+      <Dialog.Title className="text-2xl font-black text-gray-12 mb-2.5">
+        <div className="min-h-11 flex items-center gap-4">
+          <IntentsIcon className="rounded-full" />
+          Your internal address
+        </div>
+      </Dialog.Title>
+      <Dialog.Description className="text-sm font-medium text-gray-11 mb-6">
+        Share this address with other Near Intents users for easy, fee-free
+        internal transfers of any asset.
+      </Dialog.Description>
+
+      {/* QR Code Section */}
+      <div className="flex flex-col items-center gap-4 z-10 mb-6">
+        {internalUserAddress && (
+          <div className="flex items-center justify-center bg-white w-[152px] h-[152px] p-2 rounded-md border border-gray-4">
+            <QRCodeSVG value={internalUserAddress} />
+          </div>
+        )}
+      </div>
+
+      {/* Visible Address Section */}
+      <div className="mb-4 flex items-center rounded-lg bg-gray-3 px-4 py-2">
+        <div className="flex flex-1 justify-center">
+          <span className="relative">
+            {/* Visible truncated address */}
+            <span className="pointer-events-none font-medium font-mono text-label text-sm">
+              {truncatedAddress}
+            </span>
+
+            {/* Hidden full address for copy functionality */}
+            <input
+              type="text"
+              value={internalUserAddress}
+              readOnly
+              style={{
+                // It's easier to make the input transparent using CSS instead of Tailwind
+                all: "unset",
+                position: "absolute",
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0,
+                color: "transparent",
+                outline: "none",
+              }}
+            />
+          </span>
+        </div>
+        <div className="shrink-0">
+          <Copy text={internalUserAddress}>
+            {(copied) => (
+              <Button
+                type="button"
+                size="4"
+                variant="solid"
+                className="box-border size-8 p-0"
+              >
+                {copied ? <CheckIcon /> : <CopyIcon />}
+              </Button>
+            )}
+          </Copy>
+        </div>
+      </div>
+
+      {/* Warning Section */}
+      <Callout.Root className="bg-warning px-3 py-2 text-warning-foreground">
+        <Callout.Text className="text-xs">
+          <span className="font-bold">
+            This is your internal Near Intents address.
+            {/* biome-ignore lint/nursery/useConsistentCurlyBraces: <explanation> */}
+          </span>{" "}
+          <span>
+            Funds will be deposited into your account, not your connected
+            wallet.
+          </span>
+        </Callout.Text>
+      </Callout.Root>
+    </BaseModalDialog>
+  )
+}
+
+function truncateAddress(address: string) {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`
+}

--- a/src/features/account/components/SummaryIsland.tsx
+++ b/src/features/account/components/SummaryIsland.tsx
@@ -1,41 +1,53 @@
-import { Gift, PaperPlaneRight, Plus } from "@phosphor-icons/react"
-import { Skeleton } from "@radix-ui/themes"
+import { Eye, Gift, PaperPlaneRight, Plus } from "@phosphor-icons/react"
+import { Button, Skeleton } from "@radix-ui/themes"
+import { useState } from "react"
 import { AuthGate } from "../../../components/AuthGate"
 import { Island } from "../../../components/Island"
 import { IslandHeader } from "../../../components/IslandHeader"
 import type { RenderHostAppLink } from "../../../types/hostAppLink"
+import { RevealAddressDialog } from "./RevealAddressDialog"
 import { FormattedCurrency } from "./shared/FormattedCurrency"
+import { IntentsIcon } from "./shared/IntentsIcon"
 import { NavButton } from "./shared/NavButton"
 
 export function SummaryIsland({
   isLoggedIn,
   valueUsd,
   renderHostAppLink,
+  internalUserAddress,
 }: {
   isLoggedIn: boolean
   valueUsd: number | undefined
   renderHostAppLink: RenderHostAppLink
+  internalUserAddress: string | null
 }) {
   valueUsd = isLoggedIn ? valueUsd : 0
+  const [isRevealed, setIsRevealed] = useState(false)
 
   return (
     <Island className="flex flex-col gap-8">
       <IslandHeader
         heading="Account"
         rightSlot={
-          null
-          // It will be added in the future
-          // <Button
-          //   variant="soft"
-          //   color="gray"
-          //   radius="full"
-          //   className="font-bold text-gray-12"
-          // >
-          //   <IntentsIcon className="rounded-full" />
-          //   Reveal address <Eye weight="bold" />
-          // </Button>
+          <Button
+            variant="soft"
+            color="gray"
+            radius="full"
+            className="font-bold text-gray-12"
+            onClick={() => setIsRevealed(true)}
+          >
+            <IntentsIcon className="rounded-full" />
+            Reveal address <Eye weight="bold" />
+          </Button>
         }
       />
+
+      {isRevealed && internalUserAddress != null && (
+        <RevealAddressDialog
+          internalUserAddress={internalUserAddress}
+          onClose={() => setIsRevealed(false)}
+        />
+      )}
 
       <div className="flex flex-col gap-2">
         {valueUsd != null ? (


### PR DESCRIPTION
<details>

<summary>Example</summary>
<img width="571" alt="Screenshot 2025-07-09 at 21 19 34" src="https://github.com/user-attachments/assets/ca68b3d8-e1d5-4003-b8ad-e082410b5977" />


</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Reveal address" button to the account summary section, allowing users to view their internal Near Intents address.
  * Introduced a dialog that displays the internal address, provides a QR code, and includes an easy copy-to-clipboard feature with feedback.
  * Enhanced user guidance with a warning about the internal address usage and improved address visibility with truncation for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->