### PR TITLE
fix: hidden reveal address button if user is not logged in

### DIFF
--- a/src/features/account/components/SummaryIsland.tsx
+++ b/src/features/account/components/SummaryIsland.tsx
@@ -29,16 +29,18 @@ export function SummaryIsland({
       <IslandHeader
         heading="Account"
         rightSlot={
-          <Button
-            variant="soft"
-            color="gray"
-            radius="full"
-            className="font-bold text-gray-12"
-            onClick={() => setIsRevealed(true)}
-          >
-            <IntentsIcon className="rounded-full" />
-            Reveal address <Eye weight="bold" />
-          </Button>
+          isLoggedIn ? (
+            <Button
+              variant="soft"
+              color="gray"
+              radius="full"
+              className="font-bold text-gray-12"
+              onClick={() => setIsRevealed(true)}
+            >
+              <IntentsIcon className="rounded-full" />
+              Reveal address <Eye weight="bold" />
+            </Button>
+          ) : null
         }
       />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Reveal address" button is now only visible to logged-in users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->