### PR TITLE
feat: support callback on swap token changes

### DIFF
--- a/src/features/swap/components/SwapUIMachineProvider.tsx
+++ b/src/features/swap/components/SwapUIMachineProvider.tsx
@@ -1,5 +1,6 @@
 import { createActorContext } from "@xstate/react"
 import type { PropsWithChildren, ReactElement, ReactNode } from "react"
+import { useRef } from "react"
 import { useFormContext } from "react-hook-form"
 import { assert } from "src/utils/assert"
 import { formatUnits } from "viem"
@@ -17,6 +18,7 @@ import type {
 import { computeTotalDeltaDifferentDecimals } from "../../../utils/tokenUtils"
 import { swapIntentMachine } from "../../machines/swapIntentMachine"
 import { swapUIMachine } from "../../machines/swapUIMachine"
+import { useTokenChangeNotifier } from "../hooks/useTokenChangeNotifier"
 import type { SwapFormValues } from "./SwapForm"
 
 /**
@@ -55,6 +57,10 @@ interface SwapUIMachineProviderProps extends PropsWithChildren {
   tokenList: SwappableToken[]
   signMessage: (params: WalletMessage) => Promise<WalletSignatureResult | null>
   referral?: string
+  onTokenChange?: (params: {
+    tokenIn: SwappableToken | null
+    tokenOut: SwappableToken | null
+  }) => void
 }
 
 export function SwapUIMachineProvider({
@@ -64,6 +70,7 @@ export function SwapUIMachineProvider({
   tokenList,
   signMessage,
   referral,
+  onTokenChange,
 }: SwapUIMachineProviderProps) {
   const { setValue, resetField } = useFormContext<SwapFormValues>()
   const tokenIn = initialTokenIn || tokenList[0]
@@ -114,7 +121,31 @@ export function SwapUIMachineProvider({
         },
       })}
     >
+      <TokenChangeNotifier
+        onTokenChange={onTokenChange}
+        tokenIn={tokenIn}
+        tokenOut={tokenOut}
+      />
       {children}
     </SwapUIMachineContext.Provider>
   )
+}
+
+function TokenChangeNotifier({
+  onTokenChange,
+  tokenIn,
+  tokenOut,
+}: {
+  onTokenChange?: (params: {
+    tokenIn: SwappableToken | null
+    tokenOut: SwappableToken | null
+  }) => void
+  tokenIn: SwappableToken
+  tokenOut: SwappableToken
+}) {
+  useTokenChangeNotifier({
+    onTokenChange,
+    prevTokensRef: useRef({ tokenIn, tokenOut }),
+  })
+  return null
 }

--- a/src/features/swap/components/SwapWidget.tsx
+++ b/src/features/swap/components/SwapWidget.tsx
@@ -19,6 +19,7 @@ export const SwapWidget = ({
   renderHostAppLink,
   initialTokenIn,
   initialTokenOut,
+  onTokenChange,
   referral,
 }: SwapWidgetProps) => {
   return (
@@ -38,6 +39,7 @@ export const SwapWidget = ({
             tokenList={tokenList}
             signMessage={signMessage}
             referral={referral}
+            onTokenChange={onTokenChange}
           >
             <SwapUIMachineFormSyncProvider
               userAddress={userAddress}

--- a/src/features/swap/hooks/useTokenChangeNotifier.ts
+++ b/src/features/swap/hooks/useTokenChangeNotifier.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react"
+import type { SwappableToken } from "../../../types/swap"
+import { SwapUIMachineContext } from "../components/SwapUIMachineProvider"
+
+export function useTokenChangeNotifier({
+  onTokenChange,
+  prevTokensRef,
+}: {
+  onTokenChange?: (params: {
+    tokenIn: SwappableToken | null
+    tokenOut: SwappableToken | null
+  }) => void
+  prevTokensRef: React.MutableRefObject<{
+    tokenIn: SwappableToken
+    tokenOut: SwappableToken
+  }>
+}) {
+  const { tokenIn, tokenOut } = SwapUIMachineContext.useSelector(
+    (snapshot) => ({
+      tokenIn: snapshot.context.formValues.tokenIn,
+      tokenOut: snapshot.context.formValues.tokenOut,
+    })
+  )
+
+  useEffect(() => {
+    if (
+      onTokenChange &&
+      (tokenIn !== prevTokensRef.current.tokenIn ||
+        tokenOut !== prevTokensRef.current.tokenOut)
+    ) {
+      onTokenChange({
+        tokenIn,
+        tokenOut,
+      })
+      prevTokensRef.current = { tokenIn, tokenOut }
+    }
+  }, [tokenIn, tokenOut, onTokenChange, prevTokensRef])
+}

--- a/src/features/swap/hooks/useTokenChangeNotifier.ts
+++ b/src/features/swap/hooks/useTokenChangeNotifier.ts
@@ -11,8 +11,8 @@ export function useTokenChangeNotifier({
     tokenOut: SwappableToken | null
   }) => void
   prevTokensRef: React.MutableRefObject<{
-    tokenIn: SwappableToken
-    tokenOut: SwappableToken
+    tokenIn: SwappableToken | null
+    tokenOut: SwappableToken | null
   }>
 }) {
   const { tokenIn, tokenOut } = SwapUIMachineContext.useSelector(
@@ -23,15 +23,11 @@ export function useTokenChangeNotifier({
   )
 
   useEffect(() => {
-    if (
-      onTokenChange &&
-      (tokenIn !== prevTokensRef.current.tokenIn ||
-        tokenOut !== prevTokensRef.current.tokenOut)
-    ) {
-      onTokenChange({
-        tokenIn,
-        tokenOut,
-      })
+    if (!onTokenChange) return
+
+    const prev = prevTokensRef.current
+    if (tokenIn !== prev.tokenIn || tokenOut !== prev.tokenOut) {
+      onTokenChange({ tokenIn, tokenOut })
       prevTokensRef.current = { tokenIn, tokenOut }
     }
   }, [tokenIn, tokenOut, onTokenChange, prevTokensRef])

--- a/src/types/swap.ts
+++ b/src/types/swap.ts
@@ -45,4 +45,12 @@ export type SwapWidgetProps = {
    * Prop is not reactive, set it once when the component is created.
    */
   referral?: string
+
+  /**
+   * Callback function called when tokens change (tokenIn or tokenOut)
+   */
+  onTokenChange?: (params: {
+    tokenIn: SwappableToken | null
+    tokenOut: SwappableToken | null
+  }) => void
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional callback to notify external components when the input or output token changes in the Swap Widget.
  * The Swap Widget and its provider now accept an onTokenChange prop for real-time token change notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->