### PR TITLE
refactor: use toError and NEP-141 storage utils from internal-utils

### DIFF
--- a/src/features/gift/actors/giftMakerRootMachine.ts
+++ b/src/features/gift/actors/giftMakerRootMachine.ts
@@ -1,3 +1,4 @@
+import { errors } from "@defuse-protocol/internal-utils"
 import {
   type ActorRefFrom,
   type DoneActorEvent,
@@ -19,7 +20,6 @@ import type {
   WalletSignatureResult,
 } from "../../../types/walletMessage"
 import { assert } from "../../../utils/assert"
-import { toError } from "../../../utils/errors"
 import {
   type Events as DepositedBalanceEvents,
   depositedBalanceMachine,
@@ -218,7 +218,7 @@ export const giftMakerRootMachine = setup({
   },
   actions: {
     logError: (_, event: { error: unknown }) => {
-      const err = toError(event.error)
+      const err = errors.toError(event.error)
       logger.error(err)
     },
     setError: assign({

--- a/src/features/machines/depositMachine.ts
+++ b/src/features/machines/depositMachine.ts
@@ -1,3 +1,4 @@
+import { errors } from "@defuse-protocol/internal-utils"
 import { assign, fromPromise, setup } from "xstate"
 import { logger } from "../../logger"
 import { emitEvent } from "../../services/emitter"
@@ -210,7 +211,7 @@ export const depositMachine = setup({
               params: ({ event }) => {
                 return {
                   reason: "ERR_SUBMITTING_TRANSACTION",
-                  error: toError(event.error),
+                  error: errors.toError(event.error),
                 }
               },
             },
@@ -265,7 +266,3 @@ export const depositMachine = setup({
     },
   },
 })
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error("unknown error")
-}

--- a/src/features/machines/poaBridgeInfoActor.ts
+++ b/src/features/machines/poaBridgeInfoActor.ts
@@ -1,3 +1,4 @@
+import { errors } from "@defuse-protocol/internal-utils"
 import {
   type ActorRefFrom,
   type SnapshotFrom,
@@ -90,7 +91,7 @@ export const poaBridgeInfoActor = setup({
           target: "error",
           actions: {
             type: "logError",
-            params: ({ event }) => toError(event.error),
+            params: ({ event }) => errors.toError(event.error),
           },
         },
       },
@@ -136,8 +137,4 @@ export const getPOABridgeInfo = (
       withdrawalFee: 0,
     }
   )
-}
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error("unknown error")
 }

--- a/src/features/machines/signIntentMachine.ts
+++ b/src/features/machines/signIntentMachine.ts
@@ -1,3 +1,4 @@
+import { errors } from "@defuse-protocol/internal-utils"
 import { assertEvent, assign, fromPromise, setup } from "xstate"
 import { nearClient } from "../../constants/nearClient"
 import {
@@ -11,7 +12,6 @@ import type {
   WalletSignatureResult,
 } from "../../types/walletMessage"
 import { assert } from "../../utils/assert"
-import { toError } from "../../utils/errors"
 import { verifyWalletSignature } from "../../utils/verifyWalletSignature"
 import {
   type WalletErrorCode,
@@ -172,7 +172,7 @@ export const signIntentMachine = setup({
                     event.error,
                     "ERR_USER_DIDNT_SIGN"
                   ),
-                  error: toError(event.error),
+                  error: errors.toError(event.error),
                 }
               },
             },
@@ -225,7 +225,7 @@ export const signIntentMachine = setup({
               type: "setError",
               params: ({ event }) => ({
                 reason: "ERR_CANNOT_VERIFY_SIGNATURE",
-                error: toError(event.error),
+                error: errors.toError(event.error),
               }),
             },
           ],

--- a/src/features/machines/swapIntentMachine.ts
+++ b/src/features/machines/swapIntentMachine.ts
@@ -1,4 +1,5 @@
 import type { FeeEstimation } from "@defuse-protocol/bridge-sdk"
+import { errors } from "@defuse-protocol/internal-utils"
 import { secp256k1 } from "@noble/curves/secp256k1"
 import type { providers } from "near-api-js"
 import { assign, fromPromise, setup } from "xstate"
@@ -424,7 +425,7 @@ export const swapIntentMachine = setup({
                   event.error,
                   "ERR_USER_DIDNT_SIGN"
                 ),
-                error: toError(event.error),
+                error: errors.toError(event.error),
               }),
             },
           ],
@@ -475,7 +476,7 @@ export const swapIntentMachine = setup({
               type: "setError",
               params: ({ event }) => ({
                 reason: "ERR_CANNOT_VERIFY_SIGNATURE",
-                error: toError(event.error),
+                error: errors.toError(event.error),
               }),
             },
           ],
@@ -536,7 +537,7 @@ export const swapIntentMachine = setup({
               type: "setError",
               params: ({ event }) => ({
                 reason: "ERR_PUBKEY_EXCEPTION",
-                error: toError(event.error),
+                error: errors.toError(event.error),
               }),
             },
           ],
@@ -589,7 +590,7 @@ export const swapIntentMachine = setup({
               type: "setError",
               params: ({ event }) => ({
                 reason: "ERR_CANNOT_PUBLISH_INTENT",
-                error: toError(event.error),
+                error: errors.toError(event.error),
               }),
             },
           ],
@@ -661,10 +662,6 @@ export const swapIntentMachine = setup({
     },
   },
 })
-
-function toError(error: unknown): Error {
-  return error instanceof Error ? error : new Error("unknown error")
-}
 
 function enqueueBetterQuote(
   quotes: PriorityQueue<AggregatedQuote>,

--- a/src/features/otcDesk/actors/otcMakerRootMachine.ts
+++ b/src/features/otcDesk/actors/otcMakerRootMachine.ts
@@ -1,3 +1,4 @@
+import { errors } from "@defuse-protocol/internal-utils"
 import {
   type ActorRefFrom,
   type PromiseActorLogic,
@@ -16,7 +17,6 @@ import type {
   WalletSignatureResult,
 } from "../../../types/walletMessage"
 import { assert } from "../../../utils/assert"
-import { toError } from "../../../utils/errors"
 import {
   type Events as DepositedBalanceEvents,
   depositedBalanceMachine,
@@ -129,7 +129,7 @@ export const otcMakerRootMachine = setup({
   },
   actions: {
     logError: (_, event: { error: unknown }) => {
-      const err = toError(event.error)
+      const err = errors.toError(event.error)
       logger.error(err)
     },
     setError: assign({

--- a/src/services/blockchainBalanceService.ts
+++ b/src/services/blockchainBalanceService.ts
@@ -1,4 +1,3 @@
-import { base64 } from "@scure/base"
 import { AccountLayout } from "@solana/spl-token"
 import { Connection, PublicKey } from "@solana/web3.js"
 import { Address as TonAddress, beginCell } from "@ton/ton"
@@ -65,57 +64,6 @@ export const getNearNep141Balance = async ({
     )
     return null
   }
-}
-
-export const getNearNep141StorageBalance = async ({
-  contractId,
-  accountId,
-}: {
-  contractId: string
-  accountId: string
-}): Promise<bigint> => {
-  try {
-    const args = { account_id: accountId }
-    const argsBase64 = Buffer.from(JSON.stringify(args)).toString("base64")
-
-    const response = await nearClient.query({
-      request_type: "call_function",
-      method_name: "storage_balance_of",
-      account_id: contractId,
-      args_base64: argsBase64,
-      finality: "optimistic",
-    })
-
-    const parsed = decodeQueryResult(
-      response,
-      v.union([v.null(), v.object({ total: v.string() })])
-    )
-
-    return BigInt(parsed?.total || "0")
-  } catch (err: unknown) {
-    throw new Error("Error fetching balance", { cause: err })
-  }
-}
-
-export const getNearNep141MinStorageBalance = async ({
-  contractId,
-}: {
-  contractId: string
-}): Promise<bigint> => {
-  const response = await nearClient.query({
-    request_type: "call_function",
-    method_name: "storage_balance_bounds",
-    account_id: contractId,
-    args_base64: base64.encode(new TextEncoder().encode(JSON.stringify({}))),
-    finality: "optimistic",
-  })
-
-  const parsed = decodeQueryResult(
-    response,
-    v.object({ min: v.string(), max: v.string() })
-  )
-
-  return BigInt(parsed.min)
 }
 
 export const getEvmNativeBalance = async ({

--- a/src/services/nep141StorageService.ts
+++ b/src/services/nep141StorageService.ts
@@ -1,10 +1,11 @@
-import { logger } from "../logger"
-import type { BaseTokenInfo } from "../types/base"
-import { isFungibleToken } from "../utils/token"
 import {
   getNearNep141MinStorageBalance,
   getNearNep141StorageBalance,
-} from "./blockchainBalanceService"
+} from "@defuse-protocol/internal-utils"
+import { nearClient } from "../constants/nearClient"
+import { logger } from "../logger"
+import type { BaseTokenInfo } from "../types/base"
+import { isFungibleToken } from "../utils/token"
 
 export type Output =
   | {
@@ -42,10 +43,12 @@ export async function getNEP141StorageRequired({
     await Promise.allSettled([
       getNearNep141MinStorageBalance({
         contractId: token.address,
+        nearProvider: nearClient,
       }),
       getNearNep141StorageBalance({
         contractId: token.address,
         accountId: userAccountId,
+        nearProvider: nearClient,
       }),
     ])
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,9 +1,4 @@
-export function toError(error: unknown): Error {
-  if (error instanceof Error) return error
-  return new Error(
-    typeof error === "string" ? error : "An unexpected error occurred"
-  )
-}
+import { errors } from "@defuse-protocol/internal-utils"
 
 export function hasMessage(
   err: unknown,
@@ -14,7 +9,7 @@ export function hasMessage(
 ): boolean {
   if (!searchText) return false
 
-  const error = toError(err)
+  const error = errors.toError(err)
   const search = options.ignoreCase ? searchText.toLowerCase() : searchText
 
   const matches = (text: string) =>
@@ -37,7 +32,7 @@ export function findError<T extends Error>(
   // biome-ignore lint/suspicious/noExplicitAny: any is required for the constructor type
   errorType: new (...args: any[]) => T
 ): T | null {
-  const error = toError(err)
+  const error = errors.toError(err)
 
   if (error instanceof errorType) return error
 


### PR DESCRIPTION
Depends on https://github.com/defuse-protocol/sdk-monorepo/pull/41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified error handling by replacing local error conversion utilities with a standardized external package across multiple features and services.
  * Updated imports and internal usage to reflect this change for improved consistency.

* **Chores**
  * Removed unused code related to NEAR NEP-141 token storage balance queries.
  * Cleaned up and reorganized imports in affected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->